### PR TITLE
fix(pet-22): redact secrets from verbose audit payloads

### DIFF
--- a/docs/specs/TODO/PET-22.test-output.txt
+++ b/docs/specs/TODO/PET-22.test-output.txt
@@ -57,6 +57,7 @@ tests/test_audit.py::TestEdgeCases::test_stale_session_pruning PASSED    [100%]
 ============================= 46 passed in 0.18s ==============================
 
 Additional checks:
+- ruff format --check . : 49 files already formatted
 - ruff check . : All checks passed!
-- mypy --strict petasos/ : Success: no issues found in 19 source files
+- mypy --strict . : Success: no issues found in 49 source files
 - Full suite: 542 passed, 28 skipped, 2 errors (pre-existing benchmark test errors)

--- a/docs/specs/TODO/PET-22.test-output.txt
+++ b/docs/specs/TODO/PET-22.test-output.txt
@@ -1,0 +1,62 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-22-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 46 items
+
+tests/test_config.py::TestConfigDefaults::test_default_construction PASSED [  2%]
+tests/test_config.py::TestConfigDefaults::test_premium_stubs_default_disabled PASSED [  4%]
+tests/test_config.py::TestConfigDefaults::test_normalization_toggles_default_true PASSED [  6%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_direction PASSED [  8%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_fail_mode PASSED [ 10%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_redaction_mode PASSED [ 13%]
+tests/test_config.py::TestConfigValidation::test_requires_hash_key_for_hash_mode PASSED [ 15%]
+tests/test_config.py::TestConfigValidation::test_hash_mode_without_anonymize_ok PASSED [ 17%]
+tests/test_config.py::TestConfigValidation::test_rejects_empty_pii_entity PASSED [ 19%]
+tests/test_config.py::TestConfigSerialization::test_round_trip PASSED    [ 21%]
+tests/test_config.py::TestConfigSerialization::test_to_dict_converts_tuples_to_lists PASSED [ 23%]
+tests/test_config.py::TestConfigSerialization::test_from_dict_partial_fills_defaults PASSED [ 26%]
+tests/test_config.py::TestConfigSerialization::test_from_dict_ignores_extra_keys PASSED [ 28%]
+tests/test_config.py::TestConfigSerialization::test_empty_pii_entities_valid PASSED [ 30%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_redact_secrets_masks_hash_key PASSED [ 32%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_redact_secrets_none_stays_none PASSED [ 34%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_default_preserves_hash_key PASSED [ 36%]
+tests/test_config.py::TestSecretRedaction::test_secret_fields_subset_of_config_fields PASSED [ 39%]
+tests/test_config.py::TestConfigFrozen::test_frozen_prevents_mutation PASSED [ 41%]
+tests/test_audit.py::TestAuditEventConstruction::test_frozen_dataclass_raises_on_mutation PASSED [ 43%]
+tests/test_audit.py::TestAuditEventConstruction::test_all_fields_populated PASSED [ 45%]
+tests/test_audit.py::TestAuditEventConstruction::test_event_id_is_valid_uuid4_hex PASSED [ 47%]
+tests/test_audit.py::TestVerbosityLevels::test_minimal_payload_keys PASSED [ 50%]
+tests/test_audit.py::TestVerbosityLevels::test_standard_payload_keys PASSED [ 52%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_payload_keys PASSED [ 54%]
+tests/test_audit.py::TestVerbosityLevels::test_minimal_no_extra_keys PASSED [ 56%]
+tests/test_audit.py::TestVerbosityLevels::test_standard_findings_content PASSED [ 58%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_scanner_results_content PASSED [ 60%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_config_snapshot_is_dict PASSED [ 63%]
+tests/test_audit.py::TestSequenceNumbers::test_first_emit_sequence_zero PASSED [ 65%]
+tests/test_audit.py::TestSequenceNumbers::test_sequential_emits_monotonic PASSED [ 67%]
+tests/test_audit.py::TestSequenceNumbers::test_different_sessions_independent PASSED [ 69%]
+tests/test_audit.py::TestSequenceNumbers::test_none_session_uses_dedicated_counter PASSED [ 71%]
+tests/test_audit.py::TestSequenceNumbers::test_no_gaps_across_100_emits PASSED [ 73%]
+tests/test_audit.py::TestCallbackBehavior::test_no_callback_completes_without_error PASSED [ 76%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_receives_exact_event PASSED [ 78%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_raises_valueerror_wrapped_as_runtime PASSED [ 80%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_raises_generic_exception_wrapped PASSED [ 82%]
+tests/test_audit.py::TestEventTypes::test_event_type_is_scan_complete PASSED [ 84%]
+tests/test_audit.py::TestEdgeCases::test_empty_findings_zero_count PASSED [ 86%]
+tests/test_audit.py::TestEdgeCases::test_freq_result_none_standard_payload PASSED [ 89%]
+tests/test_audit.py::TestEdgeCases::test_multiple_sessions_interleaved PASSED [ 91%]
+tests/test_audit.py::TestEdgeCases::test_payload_is_immutable PASSED     [ 93%]
+tests/test_audit.py::TestEdgeCases::test_verbose_payload_redacts_hash_key PASSED [ 95%]
+tests/test_audit.py::TestEdgeCases::test_verbose_payload_no_raw_secret_in_str PASSED [ 97%]
+tests/test_audit.py::TestEdgeCases::test_stale_session_pruning PASSED    [100%]
+
+============================= 46 passed in 0.18s ==============================
+
+Additional checks:
+- ruff check . : All checks passed!
+- mypy --strict petasos/ : Success: no issues found in 19 source files
+- Full suite: 542 passed, 28 skipped, 2 errors (pre-existing benchmark test errors)

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -22,6 +22,9 @@ def _validate_tier_thresholds(tier1: float, tier2: float, tier3: float) -> None:
         raise ValueError(f"tier3 must be >= {TIER3_FLOOR}, got {tier3}")
 
 
+_SECRET_FIELDS: frozenset[str] = frozenset({"hash_key"})
+
+
 @dataclass(frozen=True)
 class PetasosConfig:
     # Normalization toggles
@@ -258,10 +261,13 @@ class PetasosConfig:
                 f"got {self.audit_verbosity!r}"
             )
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, *, redact_secrets: bool = False) -> dict[str, Any]:
         d: dict[str, Any] = {}
         for f in fields(self):
             val = getattr(self, f.name)
+            if redact_secrets and f.name in _SECRET_FIELDS:
+                d[f.name] = "[REDACTED]" if val is not None else None
+                continue
             if isinstance(val, tuple):
                 val = list(val)
             elif isinstance(val, MappingProxyType):

--- a/petasos/premium/audit.py
+++ b/petasos/premium/audit.py
@@ -96,7 +96,7 @@ class AuditEmitter:
                 }
                 for sr in result.scanner_results
             ]
-            data["config_snapshot"] = self._config.to_dict()
+            data["config_snapshot"] = self._config.to_dict(redact_secrets=True)
             data["timing"] = {
                 "timestamp": time.time(),
             }

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -287,6 +287,30 @@ class TestEdgeCases:
         with pytest.raises(TypeError):
             event.payload["injected"] = True  # type: ignore[index]
 
+    def test_verbose_payload_redacts_hash_key(self) -> None:
+        cfg = _cfg(
+            audit_verbosity="verbose",
+            anonymize=True,
+            redaction_mode="hash",
+            hash_key="super-secret-hmac-key-for-test",
+        )
+        emitter = AuditEmitter(cfg)
+        event = emitter.emit(_result(), "s1", _freq_result())
+        snapshot = event.payload["config_snapshot"]
+        assert snapshot["hash_key"] == "[REDACTED]"
+
+    def test_verbose_payload_no_raw_secret_in_str(self) -> None:
+        raw_key = "super-secret-hmac-key-for-test"
+        cfg = _cfg(
+            audit_verbosity="verbose",
+            anonymize=True,
+            redaction_mode="hash",
+            hash_key=raw_key,
+        )
+        emitter = AuditEmitter(cfg)
+        event = emitter.emit(_result(), "s1", _freq_result())
+        assert raw_key not in str(event.payload)
+
     def test_stale_session_pruning(self) -> None:
         cfg = _cfg(session_ttl_seconds=1.0)
         emitter = AuditEmitter(cfg)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import dataclasses
 
 import pytest
 
-from petasos.config import PetasosConfig
+from petasos.config import _SECRET_FIELDS, PetasosConfig
 
 
 class TestConfigDefaults:
@@ -90,6 +90,31 @@ class TestConfigSerialization:
     def test_empty_pii_entities_valid(self) -> None:
         cfg = PetasosConfig(pii_entities=())
         assert cfg.pii_entities == ()
+
+
+class TestSecretRedaction:
+    def test_to_dict_redact_secrets_masks_hash_key(self) -> None:
+        cfg = PetasosConfig(anonymize=True, redaction_mode="hash", hash_key="my-secret-key")
+        d = cfg.to_dict(redact_secrets=True)
+        assert d["hash_key"] == "[REDACTED]"
+
+    def test_to_dict_redact_secrets_none_stays_none(self) -> None:
+        cfg = PetasosConfig()
+        assert cfg.hash_key is None
+        d = cfg.to_dict(redact_secrets=True)
+        assert d["hash_key"] is None
+
+    def test_to_dict_default_preserves_hash_key(self) -> None:
+        cfg = PetasosConfig(anonymize=True, redaction_mode="hash", hash_key="my-secret-key")
+        d = cfg.to_dict()
+        assert d["hash_key"] == "my-secret-key"
+
+    def test_secret_fields_subset_of_config_fields(self) -> None:
+        config_field_names = {f.name for f in dataclasses.fields(PetasosConfig)}
+        for name in _SECRET_FIELDS:
+            assert name in config_field_names, (
+                f"_SECRET_FIELDS contains '{name}' which is not a PetasosConfig field"
+            )
 
 
 class TestConfigFrozen:


### PR DESCRIPTION
## Summary
- Prevent `AuditEmitter._build_payload` from leaking `hash_key` (HMAC secret for PII redaction) in verbose audit `config_snapshot` payloads
- Add `_SECRET_FIELDS` frozenset registry and `to_dict(redact_secrets=True)` opt-in redaction to `PetasosConfig`
- 6 new tests covering config redaction and audit payload assertions

## Layered defense
1. **Secret registry** (`petasos/config.py`): `_SECRET_FIELDS` frozenset centralizes which fields are secrets. Future secret fields require a one-line addition.
2. **Opt-in redaction** (`petasos/config.py`): `to_dict(redact_secrets=True)` replaces secret values with `[REDACTED]` sentinel. Default `False` preserves backward compat for `copy()` and serialization.
3. **Audit path** (`petasos/premium/audit.py`): `_build_payload` always uses the redacted variant. No secret reaches an `on_audit` callback consumer.

## Files changed

| File | Change |
|------|--------|
| `petasos/config.py` | Adds `_SECRET_FIELDS` frozenset; adds `redact_secrets` kwarg to `to_dict()` |
| `petasos/premium/audit.py` | Calls `to_dict(redact_secrets=True)` in `_build_payload` |
| `tests/test_config.py` | 4 new tests: redaction masking, None preservation, backward compat, field validation |
| `tests/test_audit.py` | 2 new tests: verbose payload redaction, raw secret absence check |
| `docs/specs/TODO/PET-22.test-output.txt` | Test output artifact |

## Test plan
- [x] `python -m pytest tests/test_config.py tests/test_audit.py -v` — 46/46 pass (full output: docs/specs/TODO/PET-22.test-output.txt)
- [x] `ruff check .` — clean
- [x] `mypy --strict petasos/` — clean
- [x] Full suite: 542 passed, 28 skipped (2 pre-existing benchmark errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration objects can optionally redact sensitive fields in serialized output; audit events now store redacted configuration snapshots by default when redaction is enabled.

* **Documentation**
  * Added a recorded test-suite transcript summarizing full-suite results and checks.

* **Tests**
  * Added tests verifying secret redaction behavior and that redacted values do not appear in audit payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->