### PR TITLE
fix(pet-62): LlamaFirewall empty components returns error

### DIFF
--- a/docs/specs/TODO/PET-62.test-output.txt
+++ b/docs/specs/TODO/PET-62.test-output.txt
@@ -1,0 +1,48 @@
+[1m============================= test session starts =============================[0m
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-62-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+[1mcollecting ... [0mcollected 37 items
+
+tests/test_llama_firewall_scanner.py::TestUnit::test_name [32mPASSED[0m[32m         [  2%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_protocol_conformance [32mPASSED[0m[32m [  5%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_import_failure_returns_error [32mPASSED[0m[32m [  8%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_import_failure_message [32mPASSED[0m[32m [ 10%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_init_failure_returns_error [32mPASSED[0m[32m [ 13%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_no_components_enabled [32mPASSED[0m[32m [ 16%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_no_components_duration_tracked [32mPASSED[0m[32m [ 18%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_single_component_enabled_no_error [32mPASSED[0m[32m [ 21%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_all_disabled_warns_on_load [32mPASSED[0m[32m [ 24%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_default_constructor [32mPASSED[0m[32m [ 27%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_thread_safety [32mPASSED[0m[32m [ 29%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_duration_tracking [32mPASSED[0m[32m [ 32%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_exception_in_scan_returns_error [32mPASSED[0m[32m [ 35%][0m
+tests/test_llama_firewall_scanner.py::TestUnit::test_empty_string [32mPASSED[0m[32m [ 37%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_block_produces_finding [32mPASSED[0m[32m [ 40%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_allow_no_finding [32mPASSED[0m[32m [ 43%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_confidence_clamped_high [32mPASSED[0m[32m [ 45%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_confidence_clamped_low [32mPASSED[0m[32m [ 48%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_direction_inbound_uses_user_message [32mPASSED[0m[32m [ 51%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_direction_outbound_uses_assistant_message [32mPASSED[0m[32m [ 54%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_multiple_components [32mPASSED[0m[32m [ 56%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_partial_failure_preserves_findings [32mPASSED[0m[32m [ 59%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_non_allow_decision_produces_finding [32mPASSED[0m[32m [ 62%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_none_score_defaults_to_one [32mPASSED[0m[32m [ 64%][0m
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_fail_once_semantics [32mPASSED[0m[32m [ 67%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_prompt_guard_detects_jailbreak [33mSKIPPED[0m[32m [ 70%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_prompt_guard_clean_message [33mSKIPPED[0m[32m [ 72%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_code_shield_detects_unsafe [33mSKIPPED[0m[32m [ 75%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_alignment_check_cot [33mSKIPPED[0m[32m [ 78%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_direction_inbound [33mSKIPPED[0m[32m [ 81%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_direction_outbound [33mSKIPPED[0m[32m [ 83%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_multiple_components_enabled [33mSKIPPED[0m[32m [ 86%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_finding_field_completeness [33mSKIPPED[0m[32m [ 89%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_backend_exception_partial_findings [33mSKIPPED[0m[32m [ 91%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_confidence_range [33mSKIPPED[0m[32m [ 94%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_corpus [33mSKIPPED[0m[32m [ 97%][0m
+tests/test_llama_firewall_scanner.py::TestIntegration::test_async_correctness [33mSKIPPED[0m[32m [100%][0m
+
+[32m======================= [32m[1m25 passed[0m, [33m12 skipped[0m[32m in 0.12s[0m[32m ========================[0m

--- a/petasos/scanners/llama_firewall.py
+++ b/petasos/scanners/llama_firewall.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 from types import MappingProxyType
 from typing import Any
 
 from petasos._types import Direction, ScanFinding, ScanResult, Severity
+
+_logger = logging.getLogger(__name__)
 
 _COMPONENT_TAXONOMY: MappingProxyType[str, tuple[str, str, Severity]] = MappingProxyType(
     {
@@ -91,6 +94,11 @@ class LlamaFirewallScanner:
                                 Role.ASSISTANT: [scanner_type],
                             }
                         )
+                if not self._components:
+                    _logger.warning(
+                        "LlamaFirewallScanner: all components disabled — "
+                        "scan() will return error, not clean"
+                    )
                 return True
             except ImportError:
                 self._components.clear()
@@ -164,6 +172,7 @@ class LlamaFirewallScanner:
                     scanner_name=self.name,
                     findings=(),
                     duration_ms=elapsed,
+                    error="all components disabled — no ML inspection performed",
                 )
 
             findings, errors = await asyncio.to_thread(self._scan_sync, text, direction)

--- a/tests/test_llama_firewall_scanner.py
+++ b/tests/test_llama_firewall_scanner.py
@@ -216,7 +216,7 @@ class TestUnit:
     async def test_single_component_enabled_no_error(self) -> None:
         with _injected_mock():
             for flag in ("enable_prompt_guard", "enable_alignment_check", "enable_code_shield"):
-                scanner = LlamaFirewallScanner(**{flag: True})  # type: ignore[arg-type]
+                scanner = LlamaFirewallScanner(**{flag: True})
                 r = await scanner.scan("test")
                 assert r.error is None, f"unexpected error with {flag}=True: {r.error}"
 

--- a/tests/test_llama_firewall_scanner.py
+++ b/tests/test_llama_firewall_scanner.py
@@ -191,6 +191,7 @@ class TestUnit:
             assert "GPU not found" in r.error
 
     async def test_no_components_enabled(self) -> None:
+        # Regression for PET-62: empty-components must return error, not clean
         with _injected_mock():
             scanner = LlamaFirewallScanner(
                 enable_prompt_guard=False,
@@ -199,7 +200,36 @@ class TestUnit:
             )
             r = await scanner.scan("test")
             assert r.findings == ()
-            assert r.error is None
+            assert r.error is not None
+            assert "all components disabled" in r.error
+
+    async def test_no_components_duration_tracked(self) -> None:
+        with _injected_mock():
+            scanner = LlamaFirewallScanner(
+                enable_prompt_guard=False,
+                enable_alignment_check=False,
+                enable_code_shield=False,
+            )
+            r = await scanner.scan("test")
+            assert r.duration_ms > 0
+
+    async def test_single_component_enabled_no_error(self) -> None:
+        with _injected_mock():
+            for flag in ("enable_prompt_guard", "enable_alignment_check", "enable_code_shield"):
+                scanner = LlamaFirewallScanner(**{flag: True})  # type: ignore[arg-type]
+                r = await scanner.scan("test")
+                assert r.error is None, f"unexpected error with {flag}=True: {r.error}"
+
+    async def test_all_disabled_warns_on_load(self, caplog: pytest.LogCaptureFixture) -> None:
+        with _injected_mock():
+            scanner = LlamaFirewallScanner(
+                enable_prompt_guard=False,
+                enable_alignment_check=False,
+                enable_code_shield=False,
+            )
+            with caplog.at_level("WARNING", logger="petasos.scanners.llama_firewall"):
+                await scanner.scan("test")
+            assert any("all components disabled" in rec.message for rec in caplog.records)
 
     def test_default_constructor(self) -> None:
         scanner = LlamaFirewallScanner()


### PR DESCRIPTION
## Summary
- LlamaFirewallScanner with all components disabled now returns `ScanResult(error=...)` instead of a false-clean result
- Warning log emitted in `_ensure_loaded()` when load succeeds but zero components are enabled
- Existing `test_no_components_enabled` updated to assert error; 3 new tests added

## Layered defense
1. **Scan-time signal** (`llama_firewall.py` L167): empty-components path sets `error="all components disabled — no ML inspection performed"`. Pipeline's `_compute_safe` counts this as an errored ML scanner → `all_ml_failure` → `degraded` mode marks content unsafe.
2. **Load-time warning** (`llama_firewall.py` L97–101): `_ensure_loaded()` logs a WARNING when the package loads fine but `self._components` is empty. Deferred to load time (not constructor) to avoid misleading logs when `llamafirewall` isn't installed.

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/llama_firewall.py` | Adds error string to empty-components return; adds warning log in `_ensure_loaded` |
| `tests/test_llama_firewall_scanner.py` | Updates `test_no_components_enabled` assertion; adds 3 new tests |

## Test plan
- [x] `python -m pytest tests/test_llama_firewall_scanner.py -v` — 25/25 pass (full output: docs/specs/TODO/PET-62.test-output.txt)
- [x] `ruff check .` — clean
- [x] Full suite: 649 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling when all firewall components are disabled—the scanner now reports this as an error with a clear message instead of proceeding with an empty configuration.

* **Chores**
  * Enhanced logging and diagnostic warnings to help identify when firewall components are misconfigured.
  * Expanded test coverage to verify error reporting, duration tracking, and logging behavior across different component configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->