### PR TITLE
fix(pet-49): partial ML failure blocks content in degraded mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ petasos/
 ## Key Design Invariants
 
 - **Pipeline never throws** — all errors caught and returned in `PipelineResult`.
-- **Fail-mode defaults to `degraded`** — partial scanner failure passes content; all ML scanners down blocks content; syntactic pre-filter (zero deps) always runs. Configurable to `open` or `closed`.
+- **Fail-mode defaults to `degraded`** — partial or total ML scanner failure blocks content; syntactic pre-filter (zero deps) always runs. Configurable to `open` or `closed`.
 - **Zero required ML deps at base install** — scanner backends are pip extras, not hard deps. `pip install petasos` is lightweight; `pip install petasos[all]` is ~300MB.
 - **Frozen exports** — built-in profiles, rules, and default configs must be immutable (defensive copies, frozen dataclasses).
 - **Tier 3 escalation cannot be disabled** — hardcoded floor, no config override.

--- a/docs/specs/TODO/PET-49.test-output.txt
+++ b/docs/specs/TODO/PET-49.test-output.txt
@@ -1,7 +1,7 @@
 ﻿============================= test session starts =============================
 platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
 cachedir: .pytest_cache
-rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-49-worktree
+rootdir: <workspace>
 configfile: pyproject.toml
 plugins: anyio-4.13.0, asyncio-1.3.0
 asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function

--- a/docs/specs/TODO/PET-49.test-output.txt
+++ b/docs/specs/TODO/PET-49.test-output.txt
@@ -1,0 +1,37 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-49-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 14 items
+
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_degraded_partial_ml_failure_blocks PASSED [  7%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_degraded_all_ml_failure_blocks PASSED [ 14%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_degraded_no_ml_failure_passes PASSED [ 21%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_degraded_partial_ml_failure_with_findings_blocks PASSED [ 28%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_open_partial_ml_failure_passes PASSED [ 35%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_closed_partial_ml_failure_blocks PASSED [ 42%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_drops_lower_confidence_critical PASSED [ 50%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_normalization_toggle_all_or_nothing PASSED [ 57%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_from_dict_rejects_normalize_nfkc_falsy_zero PASSED [ 64%]
+tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_pre_fix_baseline XFAIL [ 71%]
+tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_norm01_breaks_link1 XFAIL [ 78%]
+tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_syn08_breaks_link2 XFAIL [ 85%]
+tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_pipe02_breaks_link3 PASSED [ 92%]
+tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_all_fixed XFAIL [100%]
+
+======================== 10 passed, 4 xfailed in 0.21s ========================
+
+--- ruff check . ---
+All checks passed!
+
+--- ruff format --check . ---
+55 files already formatted
+
+--- python -m mypy --strict . ---
+Success: no issues found in 55 source files
+
+--- Full suite regression (python -m pytest -x) ---
+155 passed, 4 xfailed, 1 error (pre-existing benchmark fixture)

--- a/docs/specs/TODO/PET-49.test-output.txt
+++ b/docs/specs/TODO/PET-49.test-output.txt
@@ -22,7 +22,7 @@ tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_syn08_breaks_li
 tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_pipe02_breaks_link3 PASSED [ 92%]
 tests/adversarial/pipeline/test_rt075_chain.py::test_rt075_chain_all_fixed XFAIL [100%]
 
-======================== 10 passed, 4 xfailed in 0.21s ========================
+======================== 10 passed, 4 xfailed in 0.11s ========================
 
 --- ruff check . ---
 All checks passed!
@@ -32,6 +32,3 @@ All checks passed!
 
 --- python -m mypy --strict . ---
 Success: no issues found in 55 source files
-
---- Full suite regression (python -m pytest -x) ---
-155 passed, 4 xfailed, 1 error (pre-existing benchmark fixture)

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -50,6 +50,9 @@ class PetasosConfig:
 
     # Scanning
     direction: Direction = "inbound"
+    # open: ML failures ignored (pass-through)
+    # degraded: partial or total ML failure → safe=False
+    # closed: same as degraded + early-exit on CRITICAL from syntactic pre-filter
     fail_mode: Literal["open", "closed", "degraded"] = "degraded"
 
     # Anonymization

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -114,7 +114,7 @@ def _compute_safe(
     all_ml_failure = ml_errored == ml_total
 
     if fail_mode == "degraded":
-        if all_ml_failure:
+        if partial_failure or all_ml_failure:
             safe = False
     elif fail_mode == "open":
         pass

--- a/tests/adversarial/pipeline/test_degraded_fail_open.py
+++ b/tests/adversarial/pipeline/test_degraded_fail_open.py
@@ -24,15 +24,89 @@ class _CleanScanner:
         return ScanResult(scanner_name=self.name, findings=())
 
 
+class _HighFindingScanner:
+    name = "mock_ml_high"
+
+    async def scan(self, text: str, **kwargs: object) -> ScanResult:
+        return ScanResult(
+            scanner_name=self.name,
+            findings=(
+                ScanFinding(
+                    rule_id="mock.high",
+                    finding_type="test",
+                    severity=Severity.HIGH,
+                    confidence=1.0,
+                    message="mock high finding",
+                    scanner_name=self.name,
+                ),
+            ),
+        )
+
+
 @pytest.mark.asyncio
-async def test_degraded_partial_ml_failure_still_safe() -> None:
-    """PIPE-02: partial ML failure in degraded mode still passes when minimal is clean."""
+async def test_degraded_partial_ml_failure_blocks() -> None:
+    """PIPE-02: partial ML failure in degraded mode blocks content."""
     pipe = Pipeline(
         [MinimalScanner(), _ErrorScanner(), _CleanScanner()],
         config=PetasosConfig(fail_mode="degraded"),
     )
     result = await pipe.inspect("hello world")
+    assert result.safe is False
+
+
+@pytest.mark.asyncio
+async def test_degraded_all_ml_failure_blocks() -> None:
+    """PIPE-02: total ML failure in degraded mode blocks content."""
+    pipe = Pipeline(
+        [MinimalScanner(), _ErrorScanner(), _ErrorScanner()],
+        config=PetasosConfig(fail_mode="degraded"),
+    )
+    result = await pipe.inspect("hello world")
+    assert result.safe is False
+
+
+@pytest.mark.asyncio
+async def test_degraded_no_ml_failure_passes() -> None:
+    """PIPE-02: all ML scanners healthy + clean in degraded mode passes content."""
+    pipe = Pipeline(
+        [MinimalScanner(), _CleanScanner(), _CleanScanner()],
+        config=PetasosConfig(fail_mode="degraded"),
+    )
+    result = await pipe.inspect("hello world")
     assert result.safe is True
+
+
+@pytest.mark.asyncio
+async def test_degraded_partial_ml_failure_with_findings_blocks() -> None:
+    """PIPE-02: partial ML failure + HIGH finding in degraded mode blocks content."""
+    pipe = Pipeline(
+        [MinimalScanner(), _ErrorScanner(), _HighFindingScanner()],
+        config=PetasosConfig(fail_mode="degraded"),
+    )
+    result = await pipe.inspect("hello world")
+    assert result.safe is False
+
+
+@pytest.mark.asyncio
+async def test_open_partial_ml_failure_passes() -> None:
+    """PIPE-02: partial ML failure in open mode passes content (risk accepted)."""
+    pipe = Pipeline(
+        [MinimalScanner(), _ErrorScanner(), _CleanScanner()],
+        config=PetasosConfig(fail_mode="open"),
+    )
+    result = await pipe.inspect("hello world")
+    assert result.safe is True
+
+
+@pytest.mark.asyncio
+async def test_closed_partial_ml_failure_blocks() -> None:
+    """PIPE-02: partial ML failure in closed mode blocks content."""
+    pipe = Pipeline(
+        [MinimalScanner(), _ErrorScanner(), _CleanScanner()],
+        config=PetasosConfig(fail_mode="closed"),
+    )
+    result = await pipe.inspect("hello world")
+    assert result.safe is False
 
 
 def test_merge_drops_lower_confidence_critical() -> None:

--- a/tests/adversarial/pipeline/test_rt075_chain.py
+++ b/tests/adversarial/pipeline/test_rt075_chain.py
@@ -92,7 +92,6 @@ async def test_rt075_chain_syn08_breaks_link2() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Requires PET-49 (PIPE-02) fix in pipeline.py")
 async def test_rt075_chain_pipe02_breaks_link3() -> None:
     pipe = Pipeline(
         [MinimalScanner(), _FlakyMLScanner(), _CleanMLScanner()],

--- a/tests/test_integration_e2e.py
+++ b/tests/test_integration_e2e.py
@@ -500,7 +500,7 @@ class TestDegradedModeVariants:
 
         assert result.safe is False
 
-    async def test_degraded_safe_when_partial_ml_error(self, valid_key: str) -> None:
+    async def test_degraded_blocks_when_partial_ml_error(self, valid_key: str) -> None:
         config = PetasosConfig(fail_mode="degraded")
         mock_ok = MockMLScanner(name="mock_ok")
         mock_err = MockMLScanner(name="mock_err", error=RuntimeError("down"))
@@ -514,4 +514,4 @@ class TestDegradedModeVariants:
             direction="inbound",
         )
 
-        assert result.safe is True
+        assert result.safe is False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -351,12 +351,12 @@ class TestFailModeDegraded:
         assert result.safe is True
 
     @pytest.mark.asyncio
-    async def test_partial_ml_failure_safe_unchanged(self) -> None:
+    async def test_partial_ml_failure_blocks(self) -> None:
         good = MockScanner("good", findings=())
         bad = MockScanner("bad", error=RuntimeError("down"))
         p = Pipeline(scanners=[good, bad], config=PetasosConfig(fail_mode="degraded"))
         result = await p.inspect("hello")
-        assert result.safe is True
+        assert result.safe is False
 
     @pytest.mark.asyncio
     async def test_all_ml_failure_blocks(self) -> None:


### PR DESCRIPTION
## Summary
- **PIPE-02 fix**: `_compute_safe` now treats partial ML scanner failure as `safe=False` in degraded mode, matching closed mode's scanner health treatment
- **RT-075 chain**: closes link 3 of the end-to-end bypass chain; `test_rt075_chain_pipe02_breaks_link3` xfail removed
- **Docs**: CLAUDE.md Key Design Invariants and config.py `fail_mode` field comment updated to reflect new semantics

## Tri-state fail-mode after fix

| Mode | Partial ML failure | Total ML failure | Early-exit on CRITICAL |
|------|-------------------|-----------------|----------------------|
| `open` | pass-through | pass-through | no |
| `degraded` | **blocks** (was: pass-through) | blocks | no |
| `closed` | blocks | blocks | yes |

## Files changed

| File | Change |
|------|--------|
| `petasos/pipeline.py` | Add `partial_failure` to degraded-mode condition in `_compute_safe` |
| `petasos/config.py` | Inline comment on `fail_mode` describing tri-state semantics |
| `CLAUDE.md` | Update Key Design Invariants fail-mode bullet |
| `tests/adversarial/pipeline/test_degraded_fail_open.py` | Rename bug-confirming test, add `_HighFindingScanner` mock + 5 new coverage tests |
| `tests/adversarial/pipeline/test_rt075_chain.py` | Remove xfail from `test_rt075_chain_pipe02_breaks_link3` |

## Test plan
- [x] `python -m pytest tests/adversarial/pipeline/test_degraded_fail_open.py tests/adversarial/pipeline/test_rt075_chain.py -v` — 10/10 pass, 4 xfail (full output: docs/specs/TODO/PET-49.test-output.txt)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 55 files formatted
- [x] `python -m mypy --strict .` — 0 issues in 55 files
- [x] Full suite regression: 155 passed, 4 xfailed (1 pre-existing benchmark fixture error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Degraded fail-mode now treats partial ML scanner failures as blocking (unsafe), not just complete ML failures.

* **Documentation**
  * Clarified fail-mode semantics and ML failure handling in docs and inline configuration comments; updated specification/test-output artifact.

* **Tests**
  * Updated and expanded tests to cover partial and total ML failure behavior across fail-modes, removed an xfail marker, and adjusted expectations to reflect the new behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->