### PR TITLE
fix(pet-51): severity-first finding merge in overlap resolution

### DIFF
--- a/docs/specs/TODO/PET-51.test-output.txt
+++ b/docs/specs/TODO/PET-51.test-output.txt
@@ -1,0 +1,22 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-51-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 11 items
+
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_degraded_partial_ml_failure_still_safe PASSED [  9%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_critical_survives_over_high_conf_info PASSED [ 18%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_same_severity_higher_conf_wins PASSED [ 27%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_same_severity_same_conf_keeps_both PASSED [ 36%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_non_overlapping_preserved PASSED [ 45%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_high_beats_medium_regardless_of_conf PASSED [ 54%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_unpositioned_always_kept PASSED [ 63%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_merge_critical_as_nxt_beats_earlier_info PASSED [ 72%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_pipeline_critical_low_conf_still_blocks PASSED [ 81%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_normalization_toggle_all_or_nothing PASSED [ 90%]
+tests/adversarial/pipeline/test_degraded_fail_open.py::test_from_dict_rejects_normalize_nfkc_falsy_zero PASSED [100%]
+
+============================= 11 passed in 0.03s ==============================

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -69,14 +69,14 @@ def merge_findings(results: Sequence[ScanResult]) -> tuple[ScanFinding, ...]:
         assert current.position is not None
         assert nxt.position is not None
         if nxt.position.start < current.position.end:
-            if nxt.confidence > current.confidence:
+            nxt_rank = _SEVERITY_RANK.get(nxt.severity, 999)
+            cur_rank = _SEVERITY_RANK.get(current.severity, 999)
+            if nxt_rank < cur_rank:
                 current = nxt
-            elif nxt.confidence == current.confidence:
-                nxt_rank = _SEVERITY_RANK.get(nxt.severity, 999)
-                cur_rank = _SEVERITY_RANK.get(current.severity, 999)
-                if nxt_rank < cur_rank:
+            elif nxt_rank == cur_rank:
+                if nxt.confidence > current.confidence:
                     current = nxt
-                elif nxt_rank == cur_rank:
+                elif nxt.confidence == current.confidence:
                     surviving.append(current)
                     current = nxt
         else:

--- a/tests/adversarial/pipeline/test_degraded_fail_open.py
+++ b/tests/adversarial/pipeline/test_degraded_fail_open.py
@@ -109,8 +109,8 @@ async def test_closed_partial_ml_failure_blocks() -> None:
     assert result.safe is False
 
 
-def test_merge_drops_lower_confidence_critical() -> None:
-    """PIPE-04: overlapping findings — higher confidence wins over CRITICAL severity."""
+def test_merge_critical_survives_over_high_conf_info() -> None:
+    """Regression for PET-51: CRITICAL at low confidence survives over INFO at high confidence."""
     low_crit = ScanFinding(
         rule_id="a",
         finding_type="t",
@@ -135,8 +135,216 @@ def test_merge_drops_lower_confidence_critical() -> None:
             ScanResult("y", (high_info,)),
         ]
     )
-    assert low_crit not in merged
-    assert high_info in merged
+    assert low_crit in merged
+    assert high_info not in merged
+
+
+def test_merge_same_severity_higher_conf_wins() -> None:
+    """Same severity: higher confidence wins the tiebreaker."""
+    low_conf = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.HIGH,
+        confidence=0.5,
+        message="",
+        scanner_name="x",
+        position=Position(0, 10),
+    )
+    high_conf = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.HIGH,
+        confidence=0.9,
+        message="",
+        scanner_name="x",
+        position=Position(5, 15),
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (low_conf,)),
+            ScanResult("y", (high_conf,)),
+        ]
+    )
+    assert high_conf in merged
+    assert low_conf not in merged
+
+
+def test_merge_same_severity_same_conf_keeps_both() -> None:
+    """Same severity, same confidence: both survive."""
+    a = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.HIGH,
+        confidence=0.8,
+        message="",
+        scanner_name="x",
+        position=Position(0, 10),
+    )
+    b = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.HIGH,
+        confidence=0.8,
+        message="",
+        scanner_name="y",
+        position=Position(5, 15),
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (a,)),
+            ScanResult("y", (b,)),
+        ]
+    )
+    assert a in merged
+    assert b in merged
+
+
+def test_merge_non_overlapping_preserved() -> None:
+    """Non-overlapping findings all survive regardless of severity."""
+    crit = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.CRITICAL,
+        confidence=0.3,
+        message="",
+        scanner_name="x",
+        position=Position(0, 5),
+    )
+    info = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.INFO,
+        confidence=0.99,
+        message="",
+        scanner_name="y",
+        position=Position(10, 20),
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (crit,)),
+            ScanResult("y", (info,)),
+        ]
+    )
+    assert crit in merged
+    assert info in merged
+
+
+def test_merge_high_beats_medium_regardless_of_conf() -> None:
+    """Higher severity wins even when lower severity has much higher confidence."""
+    high = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.HIGH,
+        confidence=0.3,
+        message="",
+        scanner_name="x",
+        position=Position(0, 10),
+    )
+    medium = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.MEDIUM,
+        confidence=0.99,
+        message="",
+        scanner_name="y",
+        position=Position(5, 15),
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (high,)),
+            ScanResult("y", (medium,)),
+        ]
+    )
+    assert high in merged
+    assert medium not in merged
+    assert len(merged) == 1
+
+
+def test_merge_unpositioned_always_kept() -> None:
+    """Unpositioned findings pass through regardless of overlap logic."""
+    positioned = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.CRITICAL,
+        confidence=0.9,
+        message="",
+        scanner_name="x",
+        position=Position(0, 10),
+    )
+    unpositioned = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.INFO,
+        confidence=0.1,
+        message="",
+        scanner_name="y",
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (positioned,)),
+            ScanResult("y", (unpositioned,)),
+        ]
+    )
+    assert positioned in merged
+    assert unpositioned in merged
+
+
+def test_merge_critical_as_nxt_beats_earlier_info() -> None:
+    """CRITICAL arriving as nxt (later start) still beats earlier INFO via nxt_rank < cur_rank."""
+    info_first = ScanFinding(
+        rule_id="a",
+        finding_type="t",
+        severity=Severity.INFO,
+        confidence=0.99,
+        message="",
+        scanner_name="x",
+        position=Position(0, 10),
+    )
+    crit_second = ScanFinding(
+        rule_id="b",
+        finding_type="t",
+        severity=Severity.CRITICAL,
+        confidence=0.5,
+        message="",
+        scanner_name="y",
+        position=Position(5, 15),
+    )
+    merged = merge_findings(
+        [
+            ScanResult("x", (info_first,)),
+            ScanResult("y", (crit_second,)),
+        ]
+    )
+    assert crit_second in merged
+    assert info_first not in merged
+
+
+@pytest.mark.asyncio
+async def test_pipeline_critical_low_conf_still_blocks() -> None:
+    """Full pipeline: CRITICAL at any confidence produces safe=False."""
+
+    class _CritScanner:
+        name = "crit_inject"
+
+        async def scan(self, text: str, **kwargs: object) -> ScanResult:
+            return ScanResult(
+                scanner_name=self.name,
+                findings=(
+                    ScanFinding(
+                        rule_id="synth",
+                        finding_type="test",
+                        severity=Severity.CRITICAL,
+                        confidence=0.1,
+                        message="synthetic critical",
+                        scanner_name=self.name,
+                        position=Position(0, 5),
+                    ),
+                ),
+            )
+
+    pipe = Pipeline([_CritScanner()], config=PetasosConfig())
+    result = await pipe.inspect("hello")
+    assert result.safe is False
 
 
 class _CapturingScanner:


### PR DESCRIPTION
## Summary
- Inverts `merge_findings` overlap resolution: severity rank is now the primary key, confidence breaks ties within equal severity
- Fixes PIPE-04: a high-confidence INFO finding can no longer drop an overlapping CRITICAL, preventing `safe=True` on critical threats
- Aligns with Drawbridge's severity-first approach and OWASP ASI07 guidance

## Design
When two positioned findings overlap, the merge now:
1. Compares severity rank (`_SEVERITY_RANK`): higher severity (lower rank number) wins
2. Same severity: higher confidence wins
3. Same severity + same confidence: both survive

Previously confidence was checked first, allowing a 0.99-confidence INFO to drop a 0.5-confidence CRITICAL.

## Files changed

| File | Change |
|------|--------|
| `petasos/pipeline.py` | Rewrite overlap-resolution in `merge_findings` (severity-first, confidence-second) |
| `tests/adversarial/pipeline/test_degraded_fail_open.py` | Rename + invert regression test; add 7 new merge tests |

## Test plan
- [x] `python -m pytest tests/adversarial/pipeline/test_degraded_fail_open.py -v` — 11/11 pass (full output: docs/specs/TODO/PET-51.test-output.txt)
- [x] `python -m pytest` full suite — 653 passed, 0 failures (2 pre-existing benchmark errors)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finding merge behavior updated to prefer severity ranking before confidence when overlapping findings conflict, improving decision consistency.

* **Tests**
  * Added and updated unit and integration tests covering merge tie-breakers, edge cases, and pipeline behavior to validate the new merge rules.

* **Documentation**
  * Added test run output log demonstrating a passing CI test run.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->