### PR TITLE
fix(pet-63): require non-empty hash_key for hash anonymization

### DIFF
--- a/docs/specs/TODO/PET-63.test-output.txt
+++ b/docs/specs/TODO/PET-63.test-output.txt
@@ -1,0 +1,168 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 92 items
+
+tests/test_presidio_scanner.py::TestSeverityMapping::test_critical_entities PASSED [  1%]
+tests/test_presidio_scanner.py::TestSeverityMapping::test_high_entities PASSED [  2%]
+tests/test_presidio_scanner.py::TestSeverityMapping::test_medium_entities PASSED [  3%]
+tests/test_presidio_scanner.py::TestSeverityMapping::test_unknown_defaults_to_low PASSED [  4%]
+tests/test_presidio_scanner.py::TestEntityTypeRecovery::test_presidio_prefix PASSED [  5%]
+tests/test_presidio_scanner.py::TestEntityTypeRecovery::test_presidio_prefix_with_hyphen PASSED [  6%]
+tests/test_presidio_scanner.py::TestEntityTypeRecovery::test_non_presidio_rule PASSED [  7%]
+tests/test_presidio_scanner.py::TestEntityTypeRecovery::test_simple_dotted PASSED [  8%]
+tests/test_presidio_scanner.py::TestScannerProtocol::test_satisfies_protocol PASSED [  9%]
+tests/test_presidio_scanner.py::TestScannerProtocol::test_name_property PASSED [ 10%]
+tests/test_presidio_scanner.py::TestLazyLoadFailure::test_import_error_returns_errored_result PASSED [ 11%]
+tests/test_presidio_scanner.py::TestLazyLoadFailure::test_spacy_model_missing PASSED [ 13%]
+tests/test_presidio_scanner.py::TestLazyLoadFailure::test_backend_exception_during_analyze PASSED [ 14%]
+tests/test_presidio_scanner.py::TestAnonymizeEmptyInputs::test_empty_findings_returns_original PASSED [ 15%]
+tests/test_presidio_scanner.py::TestAnonymizeEmptyInputs::test_empty_text_returns_empty PASSED [ 16%]
+tests/test_presidio_scanner.py::TestAnonymizeEmptyInputs::test_all_unpositioned_findings_returns_original PASSED [ 17%]
+tests/test_presidio_scanner.py::TestAnonymizeRedact::test_single_entity_redacted PASSED [ 18%]
+tests/test_presidio_scanner.py::TestAnonymizeRedact::test_multiple_entity_types PASSED [ 19%]
+tests/test_presidio_scanner.py::TestAnonymizeReplace::test_counter_based_labels PASSED [ 20%]
+tests/test_presidio_scanner.py::TestAnonymizeReplace::test_counter_resets_across_calls PASSED [ 21%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hmac_deterministic PASSED [ 22%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_different_keys_produce_different_hashes PASSED [ 23%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hash_without_key_raises PASSED [ 25%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hash_mode_rejects_empty_key PASSED [ 26%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hash_mode_with_valid_key_works PASSED [ 27%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hmac_operator_rejects_empty_key PASSED [ 28%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_hmac_operator_rejects_missing_key PASSED [ 29%]
+tests/test_presidio_scanner.py::TestAnonymizeHash::test_redact_mode_ignores_hash_key PASSED [ 30%]
+tests/test_presidio_scanner.py::TestAnonymizeMask::test_mask_hides_leading PASSED [ 31%]
+tests/test_presidio_scanner.py::TestAnonymizeMask::test_mask_short_value_fully_masked PASSED [ 32%]
+tests/test_presidio_scanner.py::TestAnonymizeMask::test_mask_matched_text_none_fallback PASSED [ 33%]
+tests/test_presidio_scanner.py::TestAnonymizeOverlap::test_overlapping_manual_path_deduplicates PASSED [ 34%]
+tests/test_presidio_scanner.py::TestAnonymizeOverlap::test_overlapping_higher_confidence_wins PASSED [ 35%]
+tests/test_presidio_scanner.py::TestAnonymizeUnsortedFindings::test_reverse_order_input_handled PASSED [ 36%]
+tests/test_presidio_scanner.py::TestAnonymizeMixedPositioned::test_unpositioned_findings_skipped PASSED [ 38%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_email PASSED [ 39%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_phone PASSED [ 40%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_person PASSED [ 41%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_credit_card PASSED [ 42%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_no_pii_clean PASSED [ 43%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_empty_text PASSED [ 44%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_position_accuracy PASSED [ 45%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_confidence_range PASSED [ 46%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_duration_tracked PASSED [ 47%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_score_threshold_filtering PASSED [ 48%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_custom_entities_filter PASSED [ 50%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_multi_finding_message PASSED [ 51%]
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_scanner_name_in_findings PASSED [ 52%]
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_redact_removes_pii PASSED [ 53%]
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_replace_with_counters PASSED [ 54%]
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_hash_with_key_deterministic PASSED [ 55%]
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_mask_shows_trailing PASSED [ 56%]
+tests/test_config.py::TestConfigDefaults::test_default_construction PASSED [ 57%]
+tests/test_config.py::TestConfigDefaults::test_premium_stubs_default_disabled PASSED [ 58%]
+tests/test_config.py::TestConfigDefaults::test_normalization_toggles_default_true PASSED [ 59%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_direction PASSED [ 60%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_fail_mode PASSED [ 61%]
+tests/test_config.py::TestConfigValidation::test_rejects_invalid_redaction_mode PASSED [ 63%]
+tests/test_config.py::TestConfigValidation::test_requires_hash_key_for_hash_mode PASSED [ 64%]
+tests/test_config.py::TestConfigValidation::test_rejects_empty_hash_key_for_hash_mode PASSED [ 65%]
+tests/test_config.py::TestConfigValidation::test_hash_mode_without_anonymize_ok PASSED [ 66%]
+tests/test_config.py::TestConfigValidation::test_rejects_empty_pii_entity PASSED [ 67%]
+tests/test_config.py::TestConfigValidation::test_rejects_critical_per_minute_cap_zero PASSED [ 68%]
+tests/test_config.py::TestConfigValidation::test_rejects_critical_per_minute_cap_bool PASSED [ 69%]
+tests/test_config.py::TestConfigValidation::test_rejects_critical_per_minute_cap_negative PASSED [ 70%]
+tests/test_config.py::TestConfigSerialization::test_round_trip PASSED    [ 71%]
+tests/test_config.py::TestConfigSerialization::test_to_dict_converts_tuples_to_lists PASSED [ 72%]
+tests/test_config.py::TestConfigSerialization::test_from_dict_partial_fills_defaults PASSED [ 73%]
+tests/test_config.py::TestConfigSerialization::test_from_dict_ignores_extra_keys PASSED [ 75%]
+tests/test_config.py::TestConfigSerialization::test_empty_pii_entities_valid PASSED [ 76%]
+tests/test_config.py::TestSessionSecret::test_from_dict_session_secret_base64 PASSED [ 77%]
+tests/test_config.py::TestSessionSecret::test_to_dict_excludes_session_secret PASSED [ 78%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_per_session_contribution_cap_rejects_zero PASSED [ 79%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_per_session_contribution_cap_rejects_negative PASSED [ 80%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_per_session_contribution_cap_rejects_bool PASSED [ 81%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_max_session_contribution_entries_rejects_zero PASSED [ 82%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_max_session_contribution_entries_rejects_negative PASSED [ 83%]
+tests/test_config.py::TestSessionContributionCapValidation::test_alert_max_session_contribution_entries_rejects_bool PASSED [ 84%]
+tests/test_config.py::TestSessionContributionCapValidation::test_cross_field_validation_cap_gt_per_minute PASSED [ 85%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_rejects_int_zero_for_bool PASSED [ 86%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_rejects_int_one_for_bool PASSED [ 88%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_rejects_string_for_bool PASSED [ 89%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_rejects_none_for_bool PASSED [ 90%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_accepts_true_bool PASSED [ 91%]
+tests/test_config.py::TestBoolCoercion::test_from_dict_accepts_false_bool PASSED [ 92%]
+tests/test_config.py::TestBoolCoercion::test_direct_constructor_rejects_int_for_bool PASSED [ 93%]
+tests/test_config.py::TestBoolFieldsCoverage::test_all_bool_fields_covered PASSED [ 94%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_redact_secrets_masks_hash_key PASSED [ 95%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_redact_secrets_none_stays_none PASSED [ 96%]
+tests/test_config.py::TestSecretRedaction::test_to_dict_default_preserves_hash_key PASSED [ 97%]
+tests/test_config.py::TestSecretRedaction::test_secret_fields_subset_of_config_fields PASSED [ 98%]
+tests/test_config.py::TestConfigFrozen::test_frozen_prevents_mutation PASSED [100%]
+
+============================== warnings summary ===============================
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_email
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:380: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_phone
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:392: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_person
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:400: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_detect_credit_card
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:408: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_no_pii_clean
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:417: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_empty_text
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:424: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan(""))
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_position_accuracy
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:430: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_confidence_range
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:436: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_duration_tracked
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:443: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan("john@example.com"))
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_score_threshold_filtering
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:448: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_custom_entities_filter
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:457: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_multi_finding_message
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:465: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/test_presidio_scanner.py::TestPresidioScannerIntegration::test_scanner_name_in_findings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:472: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan("john@example.com"))
+
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_redact_removes_pii
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_replace_with_counters
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_hash_with_key_deterministic
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_hash_with_key_deterministic
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:486: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+
+tests/test_presidio_scanner.py::TestAnonymizeIntegration::test_mask_shows_trailing
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-63-worktree\tests\test_presidio_scanner.py:515: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+====================== 92 passed, 18 warnings in 38.31s =======================

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -127,7 +127,10 @@ class PetasosConfig:
                 f"got {self.redaction_mode!r}"
             )
         if self.anonymize and self.redaction_mode == "hash" and not self.hash_key:
-            raise ValueError("hash_key is required and must be non-empty when redaction_mode='hash' and anonymize=True")
+            raise ValueError(
+                "hash_key is required and must be non-empty when "
+                "redaction_mode='hash' and anonymize=True"
+            )
         for entity in self.pii_entities:
             if not isinstance(entity, str) or not entity:
                 raise ValueError(f"pii_entities entries must be non-empty strings, got {entity!r}")

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -126,8 +126,8 @@ class PetasosConfig:
                 f"redaction_mode must be 'redact', 'replace', 'hash', or 'mask', "
                 f"got {self.redaction_mode!r}"
             )
-        if self.anonymize and self.redaction_mode == "hash" and self.hash_key is None:
-            raise ValueError("hash_key is required when redaction_mode='hash' and anonymize=True")
+        if self.anonymize and self.redaction_mode == "hash" and not self.hash_key:
+            raise ValueError("hash_key is required and must be non-empty when redaction_mode='hash' and anonymize=True")
         for entity in self.pii_entities:
             if not isinstance(entity, str) or not entity:
                 raise ValueError(f"pii_entities entries must be non-empty strings, got {entity!r}")

--- a/petasos/scanners/presidio.py
+++ b/petasos/scanners/presidio.py
@@ -68,6 +68,8 @@ def _make_hmac_operator_class() -> type:
         def validate(self, params: dict[str, Any] | None = None) -> None:
             if not params or not isinstance(params.get("hmac_key"), str):
                 raise ValueError("hmac_key (str) is required")
+            if not params["hmac_key"]:
+                raise ValueError("hmac_key must be non-empty")
 
         def operate(self, text: str, params: dict[str, Any] | None = None) -> str:
             if not params or "hmac_key" not in params:
@@ -220,6 +222,12 @@ def anonymize(
     mode: Literal["redact", "replace", "hash", "mask"] = "redact",
     hash_key: str | None = None,
 ) -> str:
+    if mode == "hash" and not hash_key:
+        raise ValueError(
+            "hash_key is required and must be non-empty for mode='hash'. "
+            "Unkeyed hashing is reversible on low-entropy PII."
+        )
+
     positioned = [(f, _recover_entity_type(f.rule_id)) for f in findings if f.position is not None]
     if not positioned:
         return text
@@ -261,12 +269,10 @@ def _anonymize_engine_path(
         for et in entity_types_seen:
             operators[et] = OperatorConfig("replace", {"new_value": f"<{et}>"})
     elif mode == "hash":
-        if hash_key is not None:
-            for et in entity_types_seen:
-                operators[et] = OperatorConfig("hmac_sha256", {"hmac_key": hash_key})
-        else:
-            for et in entity_types_seen:
-                operators[et] = OperatorConfig("hash", {"hash_type": "sha256"})
+        if not hash_key:
+            raise ValueError("hash_key must be non-empty (enforced by anonymize())")
+        for et in entity_types_seen:
+            operators[et] = OperatorConfig("hmac_sha256", {"hmac_key": hash_key})
 
     result = engine.anonymize(
         text=text,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,10 @@ class TestConfigValidation:
         with pytest.raises(ValueError, match="hash_key"):
             PetasosConfig(anonymize=True, redaction_mode="hash")
 
+    def test_rejects_empty_hash_key_for_hash_mode(self) -> None:
+        with pytest.raises(ValueError, match="hash_key"):
+            PetasosConfig(anonymize=True, redaction_mode="hash", hash_key="")
+
     def test_hash_mode_without_anonymize_ok(self) -> None:
         cfg = PetasosConfig(anonymize=False, redaction_mode="hash")
         assert cfg.redaction_mode == "hash"

--- a/tests/test_presidio_scanner.py
+++ b/tests/test_presidio_scanner.py
@@ -14,6 +14,7 @@ from petasos._types import (
 from petasos.scanners.presidio import (
     _SEVERITY_MAP,
     PresidioScanner,
+    _make_hmac_operator_class,
     _recover_entity_type,
     anonymize,
 )
@@ -248,11 +249,42 @@ class TestAnonymizeHash:
         r2 = anonymize(text, [finding], mode="hash", hash_key="key2")
         assert r1 != r2
 
-    def test_hash_without_key_uses_sha256(self) -> None:
+    def test_hash_without_key_raises(self) -> None:
         text = "John Smith lives here"
         finding = _make_finding("petasos.presidio.person", 0, 10, matched_text="John Smith")
-        result = anonymize(text, [finding], mode="hash")
+        with pytest.raises(ValueError, match="hash_key"):
+            anonymize(text, [finding], mode="hash")
+
+    def test_hash_mode_rejects_empty_key(self) -> None:
+        text = "John Smith lives here"
+        finding = _make_finding("petasos.presidio.person", 0, 10, matched_text="John Smith")
+        with pytest.raises(ValueError, match="hash_key"):
+            anonymize(text, [finding], mode="hash", hash_key="")
+
+    def test_hash_mode_with_valid_key_works(self) -> None:
+        text = "John Smith lives here"
+        finding = _make_finding("petasos.presidio.person", 0, 10, matched_text="John Smith")
+        result = anonymize(text, [finding], mode="hash", hash_key="secret")
         assert "John Smith" not in result
+
+    def test_hmac_operator_rejects_empty_key(self) -> None:
+        cls = _make_hmac_operator_class()
+        op = cls()
+        with pytest.raises(ValueError, match="non-empty"):
+            op.validate({"hmac_key": ""})
+
+    def test_hmac_operator_rejects_missing_key(self) -> None:
+        cls = _make_hmac_operator_class()
+        op = cls()
+        with pytest.raises(ValueError):
+            op.validate({})
+
+    def test_redact_mode_ignores_hash_key(self) -> None:
+        text = "John Smith lives here"
+        finding = _make_finding("petasos.presidio.person", 0, 10, matched_text="John Smith")
+        result = anonymize(text, [finding], mode="redact", hash_key=None)
+        assert "John Smith" not in result
+        assert "<PERSON>" in result
 
 
 class TestAnonymizeMask:


### PR DESCRIPTION
## Summary
- Eliminate insecure unkeyed SHA-256 fallback in PII anonymization — `mode="hash"` now requires a non-empty `hash_key`
- Reject empty `hash_key` strings at four defense-in-depth layers (config, anonymize(), operator, engine path)
- HMAC with empty key is cryptographically degenerate; unkeyed SHA-256 is trivially reversible on low-entropy PII

## Layered defense

1. **Config guard** (`config.py`): Tightens existing `hash_key is None` check to `not hash_key` — catches both `None` and `""` at construction time
2. **Entry guard** (`presidio.py` `anonymize()`): `ValueError` before any PII processing for direct callers bypassing config
3. **Operator guard** (`presidio.py` `_HmacSha256Operator.validate()`): Rejects empty `hmac_key` at the Presidio operator level
4. **Engine guard** (`presidio.py` `_anonymize_engine_path()`): Removes the unkeyed SHA-256 fallback entirely with explicit `ValueError`

## Files changed

| File | Change |
|------|--------|
| `petasos/config.py` | Tighten `hash_key` validation from `is None` to `not hash_key` |
| `petasos/scanners/presidio.py` | Add entry guard, operator empty-key check, remove unkeyed fallback |
| `tests/test_presidio_scanner.py` | 6 new tests + 1 updated (empty key, missing key, operator validation) |
| `tests/test_config.py` | 1 new test for empty-string config rejection |

## Test plan
- [x] `python -m pytest tests/test_presidio_scanner.py tests/test_config.py -v` — 92/92 pass (full output: docs/specs/TODO/PET-63.test-output.txt)
- [x] All 8 spec tests pass (6 new + 1 updated + 1 config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation so hash-based redaction requires a non-empty hash key, preventing invalid configurations.

* **Tests**
  * Expanded tests to assert the stricter hash-key/HMAC validation and anonymization behaviors; test suite passes (92 passed).

* **Documentation**
  * Added captured test run output to project docs for verification and auditing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->