### PR TITLE
fix(pet-57): defensive copy before MappingProxyType in _parse_profile

### DIFF
--- a/docs/specs/TODO/PET-57.test-output.txt
+++ b/docs/specs/TODO/PET-57.test-output.txt
@@ -1,0 +1,55 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-57-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 41 items
+
+tests/test_profiles_retained_ref.py::test_severity_overrides_not_mutated_by_caller PASSED [  2%]
+tests/test_profiles_retained_ref.py::test_tool_alias_map_not_mutated_by_caller PASSED [  4%]
+tests/test_profiles_retained_ref.py::test_empty_overrides_not_shared PASSED [  7%]
+tests/test_profiles.py::TestTierThresholds::test_valid_ascending PASSED  [  9%]
+tests/test_profiles.py::TestTierThresholds::test_non_ascending_raises PASSED [ 12%]
+tests/test_profiles.py::TestTierThresholds::test_tier3_below_floor_raises PASSED [ 14%]
+tests/test_profiles.py::TestTierThresholds::test_non_finite_raises PASSED [ 17%]
+tests/test_profiles.py::TestTierThresholds::test_frozen PASSED           [ 19%]
+tests/test_profiles.py::TestProfileResolverLoading::test_all_builtins_load PASSED [ 21%]
+tests/test_profiles.py::TestProfileResolverLoading::test_general_profile_is_identity PASSED [ 24%]
+tests/test_profiles.py::TestProfileResolverLoading::test_resolve_unknown_raises_keyerror PASSED [ 26%]
+tests/test_profiles.py::TestProfileResolverLoading::test_admin_profile_values PASSED [ 29%]
+tests/test_profiles.py::TestProfileResolverLoading::test_research_profile_suppress_rules PASSED [ 31%]
+tests/test_profiles.py::TestProfileResolverLoading::test_code_generation_profile PASSED [ 34%]
+tests/test_profiles.py::TestProfileResolverLoading::test_customer_service_severity_overrides PASSED [ 36%]
+tests/test_profiles.py::TestProfileFrozenAndSerialization::test_profile_is_frozen PASSED [ 39%]
+tests/test_profiles.py::TestProfileFrozenAndSerialization::test_to_dict_roundtrip PASSED [ 41%]
+tests/test_profiles.py::TestProfileFrozenAndSerialization::test_general_to_dict_null_thresholds PASSED [ 43%]
+tests/test_profiles.py::TestProfileFrozenAndSerialization::test_empty_suppress_rules_roundtrip PASSED [ 46%]
+tests/test_profiles.py::TestProfileRegister::test_register_custom_profile PASSED [ 48%]
+tests/test_profiles.py::TestProfileRegister::test_register_overwrites_existing PASSED [ 51%]
+tests/test_profiles.py::TestDictMerge::test_dict_merge_inherits_from_general PASSED [ 53%]
+tests/test_profiles.py::TestDictMerge::test_suppress_rules_union PASSED  [ 56%]
+tests/test_profiles.py::TestDictMerge::test_severity_overrides_merge PASSED [ 58%]
+tests/test_profiles.py::TestDictMerge::test_tier_thresholds_override PASSED [ 60%]
+tests/test_profiles.py::TestDictMerge::test_tier_thresholds_partial_raises PASSED [ 63%]
+tests/test_profiles.py::TestDictMerge::test_tier_thresholds_none_override PASSED [ 65%]
+tests/test_profiles.py::TestDictMerge::test_pii_entities_union PASSED    [ 68%]
+tests/test_profiles.py::TestDictMerge::test_tool_exempt_list_replace PASSED [ 70%]
+tests/test_profiles.py::TestDictMerge::test_tool_alias_map_merge PASSED  [ 73%]
+tests/test_profiles.py::TestDictMerge::test_tool_alias_map_empty_value_raises PASSED [ 75%]
+tests/test_profiles.py::TestDictMerge::test_confidence_floor_type_error PASSED [ 78%]
+tests/test_profiles.py::TestDictMerge::test_suppress_rules_type_error PASSED [ 80%]
+tests/test_profiles.py::TestDictMerge::test_resolve_invalid_type_raises PASSED [ 82%]
+tests/test_profiles.py::TestDictMerge::test_alias_onto_exempt_raises_at_parse PASSED [ 85%]
+tests/test_profiles.py::TestDictMerge::test_alias_onto_exempt_raises_at_parse_whitespace PASSED [ 87%]
+tests/test_profiles.py::TestDictMerge::test_alias_onto_exempt_raises_at_merge PASSED [ 90%]
+tests/test_profiles.py::TestDictMerge::test_alias_onto_exempt_raises_at_merge_whitespace PASSED [ 92%]
+tests/test_profiles.py::TestStructuralOverrideProtection::test_structural_rule_override_rejected_at_parse PASSED [ 95%]
+tests/test_profiles.py::TestStructuralOverrideProtection::test_structural_rule_override_rejected_at_merge PASSED [ 97%]
+tests/test_profiles.py::TestStructuralOverrideProtection::test_structural_rule_ids_match_prefix PASSED [100%]
+
+============================= 41 passed in 0.12s ==============================
+All checks passed!
+60 files already formatted
+Success: no issues found in 1 source file

--- a/petasos/premium/profiles/__init__.py
+++ b/petasos/premium/profiles/__init__.py
@@ -130,12 +130,12 @@ def _parse_profile(data: dict[str, Any]) -> ResolvedProfile:
     return ResolvedProfile(
         name=data["name"],
         suppress_rules=_validate_suppress_rules(frozenset(data.get("suppress_rules", []))),
-        severity_overrides=MappingProxyType(sev_overrides),
+        severity_overrides=MappingProxyType(dict(sev_overrides)),
         confidence_floor=float(data.get("confidence_floor", 0.0)),
         tier_thresholds=tier_thresholds,
         pii_entities_extra=tuple(data.get("pii_entities_extra", [])),
         tool_exempt_list=exempt_set,
-        tool_alias_map=MappingProxyType(alias_map),
+        tool_alias_map=MappingProxyType(dict(alias_map)),
     )
 
 

--- a/tests/test_profiles_retained_ref.py
+++ b/tests/test_profiles_retained_ref.py
@@ -1,0 +1,37 @@
+"""PROF-02 regression: retained dict ref must not mutate ResolvedProfile."""
+
+from __future__ import annotations
+
+from petasos.premium.profiles import _parse_profile
+
+
+def test_severity_overrides_not_mutated_by_caller() -> None:
+    data: dict = {
+        "name": "test",
+        "severity_overrides": {"SYN-001": "high"},
+    }
+    profile = _parse_profile(data)
+    data["severity_overrides"]["SYN-001"] = "info"
+    data["severity_overrides"]["SYN-002"] = "low"
+    assert profile.severity_overrides["SYN-001"] == "high"
+    assert "SYN-002" not in profile.severity_overrides
+
+
+def test_tool_alias_map_not_mutated_by_caller() -> None:
+    data: dict = {
+        "name": "test",
+        "tool_alias_map": {"read_file": "file_read"},
+    }
+    profile = _parse_profile(data)
+    data["tool_alias_map"]["read_file"] = "evil_read"
+    data["tool_alias_map"]["new_tool"] = "smuggled"
+    assert profile.tool_alias_map["read_file"] == "file_read"
+    assert "new_tool" not in profile.tool_alias_map
+
+
+def test_empty_overrides_not_shared() -> None:
+    data_a: dict = {"name": "a"}
+    data_b: dict = {"name": "b"}
+    prof_a = _parse_profile(data_a)
+    prof_b = _parse_profile(data_b)
+    assert prof_a.severity_overrides is not prof_b.severity_overrides

--- a/tests/test_profiles_retained_ref.py
+++ b/tests/test_profiles_retained_ref.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from petasos.premium.profiles import _parse_profile
 
 
 def test_severity_overrides_not_mutated_by_caller() -> None:
-    data: dict = {
+    data: dict[str, Any] = {
         "name": "test",
         "severity_overrides": {"SYN-001": "high"},
     }
@@ -18,7 +20,7 @@ def test_severity_overrides_not_mutated_by_caller() -> None:
 
 
 def test_tool_alias_map_not_mutated_by_caller() -> None:
-    data: dict = {
+    data: dict[str, Any] = {
         "name": "test",
         "tool_alias_map": {"read_file": "file_read"},
     }
@@ -30,8 +32,8 @@ def test_tool_alias_map_not_mutated_by_caller() -> None:
 
 
 def test_empty_overrides_not_shared() -> None:
-    data_a: dict = {"name": "a"}
-    data_b: dict = {"name": "b"}
+    data_a: dict[str, Any] = {"name": "a"}
+    data_b: dict[str, Any] = {"name": "b"}
     prof_a = _parse_profile(data_a)
     prof_b = _parse_profile(data_b)
     assert prof_a.severity_overrides is not prof_b.severity_overrides


### PR DESCRIPTION
## Summary
- Adds `dict()` defensive copies around `severity_overrides` and `tool_alias_map` in `_parse_profile` before wrapping with `MappingProxyType`, breaking the retained-reference link from caller-held dicts
- Prevents post-construction mutation of profile fields via retained dict references, enforcing the frozen-export invariant
- Adds 3 regression tests proving the fix

## Defense-in-depth context
The public API path (`ProfileResolver.resolve(dict)`) routes to `_merge_with_base`, which already constructs fresh dicts before proxy-wrapping. This fix hardens `_parse_profile` — a private function importable by test code and downstream integrators — against the same retained-reference vector.

## Files changed

| File | Change |
|------|--------|
| `petasos/premium/profiles/__init__.py` | Defensive `dict()` copy around `sev_overrides` and `alias_map` before `MappingProxyType` |
| `tests/test_profiles_retained_ref.py` | New — 3 regression tests (severity mutation, alias mutation, empty-dict isolation) |
| `docs/specs/TODO/PET-57.test-output.txt` | Test evidence |

## Test plan
- [x] `python -m pytest tests/test_profiles_retained_ref.py tests/test_profiles.py -v` — 41/41 pass (full output: docs/specs/TODO/PET-57.test-output.txt)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --strict petasos/premium/profiles/__init__.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile configuration handling to ensure overrides and aliases are isolated between profiles.

* **Tests**
  * Added regression tests verifying profile configuration isolation; test suite reports 41 passed.

* **Documentation**
  * Updated test output/verification log to reflect environment details, formatter/status checks, and overall success.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->