### PR TITLE
fix(pet-48): harden inspect() against CancelledError and BaseException

### DIFF
--- a/docs/specs/TODO/PET-48.test-output.txt
+++ b/docs/specs/TODO/PET-48.test-output.txt
@@ -1,0 +1,17 @@
+﻿============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-48-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 6 items
+
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_inspect_catches_cancelled_error PASSED [ 16%]
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_scan_one_isolates_cancelled_scanner PASSED [ 33%]
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_gather_return_exceptions_isolates_failure PASSED [ 50%]
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_keyboard_interrupt_caught_at_boundary PASSED [ 66%]
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_cancelled_error_logged PASSED [ 83%]
+tests/adversarial/pipeline/test_cancel_mid_gather.py::test_mid_gather_cancel_full_pipeline PASSED [100%]
+
+============================== 6 passed in 0.05s ==============================

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 from dataclasses import replace
@@ -24,6 +25,8 @@ from petasos.premium.frequency import FrequencyTracker, FrequencyUpdateResult
 from petasos.premium.license import LicenseClaims, LicenseState, LicenseValidator
 from petasos.premium.profiles import ProfileResolver, ResolvedProfile
 from petasos.scanners.minimal import MinimalScanner
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -140,14 +143,28 @@ async def _scan_one(
             scanner.scan(normalized_text, direction=direction, session_id=session_id),
             timeout=_SCANNER_TIMEOUT,
         )
-    except Exception as exc:
+    except BaseException as exc:
         elapsed = (time.perf_counter() - t0) * 1000
         return ScanResult(
             scanner_name=sname,
             findings=(),
             duration_ms=elapsed,
-            error=str(exc),
+            error=f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__,
         )
+
+
+def _normalize_gather_result(
+    result: ScanResult | BaseException,
+    scanner_name: str,
+) -> ScanResult:
+    if isinstance(result, BaseException):
+        return ScanResult(
+            scanner_name=scanner_name,
+            findings=(),
+            duration_ms=0.0,
+            error=f"{type(result).__name__}: {result}" if str(result) else type(result).__name__,
+        )
+    return result
 
 
 class Pipeline:
@@ -324,11 +341,18 @@ class Pipeline:
                 session_id=session_id,
                 active_profile=active_profile,
             )
-        except Exception as exc:
+        except BaseException as exc:
+            if not isinstance(exc, Exception):
+                _logger.warning(
+                    "Non-Exception caught at inspect() boundary: %s: %s",
+                    type(exc).__name__,
+                    exc,
+                )
+            error_msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
             return PipelineResult(
                 safe=False,
                 findings=(),
-                errors=(str(exc),),
+                errors=(error_msg,),
             )
 
     async def _inspect_inner(
@@ -380,7 +404,11 @@ class Pipeline:
                 _scan_one(s, normalized_text, direction=direction, session_id=session_id)
                 for s in self._ml_scanners
             ]
-            ml_results = list(await asyncio.gather(*tasks))
+            raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+            ml_results = [
+                _normalize_gather_result(r, getattr(s, "name", "unknown"))
+                for r, s in zip(raw_results, self._ml_scanners, strict=True)
+            ]
         else:
             ml_results = []
 

--- a/tests/adversarial/pipeline/test_cancel_mid_gather.py
+++ b/tests/adversarial/pipeline/test_cancel_mid_gather.py
@@ -1,0 +1,210 @@
+"""Tests for PET-48: CancelledError / BaseException handling in Pipeline.inspect()."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from petasos._types import (
+    Direction,
+    PipelineResult,
+    ScanFinding,
+    ScanResult,
+    Severity,
+)
+from petasos.pipeline import Pipeline, _scan_one
+
+# ---------------------------------------------------------------------------
+# Stub scanners
+# ---------------------------------------------------------------------------
+
+
+class _CancellingScanner:
+    """Scanner whose scan() raises CancelledError."""
+
+    @property
+    def name(self) -> str:
+        return "cancelling"
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        raise asyncio.CancelledError()
+
+
+class _KeyboardInterruptScanner:
+    """Scanner whose scan() raises KeyboardInterrupt synchronously (before any await)."""
+
+    @property
+    def name(self) -> str:
+        return "ki_scanner"
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        raise KeyboardInterrupt("simulated")
+
+
+class _HealthyScanner:
+    """Scanner that returns a normal finding."""
+
+    @property
+    def name(self) -> str:
+        return "healthy"
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        return ScanResult(
+            scanner_name="healthy",
+            findings=(
+                ScanFinding(
+                    rule_id="healthy.rule",
+                    finding_type="test",
+                    severity=Severity.MEDIUM,
+                    confidence=0.9,
+                    message="test finding",
+                    scanner_name="healthy",
+                ),
+            ),
+            duration_ms=1.0,
+        )
+
+
+class _BlockingScanner:
+    """Scanner that blocks on an event — for deterministic cancellation tests."""
+
+    def __init__(self, started: asyncio.Event, proceed: asyncio.Event) -> None:
+        self._started = started
+        self._proceed = proceed
+
+    @property
+    def name(self) -> str:
+        return "blocking"
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        self._started.set()
+        await self._proceed.wait()
+        return ScanResult(
+            scanner_name="blocking",
+            findings=(),
+            duration_ms=0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inspect_catches_cancelled_error() -> None:
+    # Regression for PET-48: CancelledError must not escape inspect()
+    pipe = Pipeline(scanners=[_CancellingScanner()])
+    result = await pipe.inspect("test input")
+    assert isinstance(result, PipelineResult)
+    assert result.safe is False
+    errors_joined = " ".join(result.errors)
+    assert "CancelledError" in errors_joined or any(
+        sr.error is not None and "CancelledError" in sr.error
+        for sr in result.scanner_results
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_one_isolates_cancelled_scanner() -> None:
+    # Regression for PET-48: _scan_one must catch BaseException
+    scanner = _CancellingScanner()
+    result = await _scan_one(
+        scanner, "test", direction="inbound", session_id=None
+    )
+    assert isinstance(result, ScanResult)
+    assert result.error is not None
+    assert "CancelledError" in result.error
+
+
+@pytest.mark.asyncio
+async def test_gather_return_exceptions_isolates_failure() -> None:
+    # Regression for PET-48: one cancelled scanner must not abort others
+    pipe = Pipeline(scanners=[_CancellingScanner(), _HealthyScanner()])
+    result = await pipe.inspect("test input")
+    assert isinstance(result, PipelineResult)
+    # Healthy scanner's findings should be in the merged output
+    assert any(f.rule_id == "healthy.rule" for f in result.findings)
+    # Cancelled scanner's error should be recorded in scanner_results
+    cancelled_results = [
+        sr for sr in result.scanner_results
+        if sr.error is not None and "CancelledError" in sr.error
+    ]
+    assert len(cancelled_results) >= 1
+
+
+@pytest.mark.asyncio
+async def test_keyboard_interrupt_caught_at_boundary() -> None:
+    # Regression for PET-48: KeyboardInterrupt must not escape inspect()
+    # KI is tested at the inspect() boundary (not through a scanner inside
+    # asyncio.wait_for, because the event loop propagates KI from tasks
+    # before _scan_one's handler can catch it).
+    pipe = Pipeline()
+    with patch.object(pipe, "_inspect_inner", side_effect=KeyboardInterrupt("simulated")):
+        result = await pipe.inspect("test input")
+    assert isinstance(result, PipelineResult)
+    assert result.safe is False
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_logged() -> None:
+    # Regression for PET-48: non-Exception BaseExceptions are logged at inspect() boundary
+    pipe = Pipeline()
+    with (
+        patch.object(pipe, "_inspect_inner", side_effect=asyncio.CancelledError()),
+        patch("petasos.pipeline._logger") as mock_logger,
+    ):
+        result = await pipe.inspect("test input")
+    assert isinstance(result, PipelineResult)
+    assert result.safe is False
+    mock_logger.warning.assert_called_once()
+    args = mock_logger.warning.call_args
+    assert "CancelledError" in str(args)
+
+
+@pytest.mark.asyncio
+async def test_mid_gather_cancel_full_pipeline() -> None:
+    # Regression for PET-48: external task cancellation returns PipelineResult
+    started = asyncio.Event()
+    proceed = asyncio.Event()
+    pipe = Pipeline(scanners=[_BlockingScanner(started, proceed)])
+
+    async def run_and_cancel() -> PipelineResult:
+        task = asyncio.create_task(pipe.inspect("test input"))
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+        task.cancel()
+        proceed.set()
+        try:
+            return await task
+        except asyncio.CancelledError:
+            pytest.fail("inspect() raised CancelledError instead of returning PipelineResult")
+
+    result = await run_and_cancel()
+    assert isinstance(result, PipelineResult)
+    assert result.safe is False

--- a/tests/adversarial/pipeline/test_cancel_mid_gather.py
+++ b/tests/adversarial/pipeline/test_cancel_mid_gather.py
@@ -126,8 +126,7 @@ async def test_inspect_catches_cancelled_error() -> None:
     assert result.safe is False
     errors_joined = " ".join(result.errors)
     assert "CancelledError" in errors_joined or any(
-        sr.error is not None and "CancelledError" in sr.error
-        for sr in result.scanner_results
+        sr.error is not None and "CancelledError" in sr.error for sr in result.scanner_results
     )
 
 
@@ -135,9 +134,7 @@ async def test_inspect_catches_cancelled_error() -> None:
 async def test_scan_one_isolates_cancelled_scanner() -> None:
     # Regression for PET-48: _scan_one must catch BaseException
     scanner = _CancellingScanner()
-    result = await _scan_one(
-        scanner, "test", direction="inbound", session_id=None
-    )
+    result = await _scan_one(scanner, "test", direction="inbound", session_id=None)
     assert isinstance(result, ScanResult)
     assert result.error is not None
     assert "CancelledError" in result.error
@@ -153,7 +150,8 @@ async def test_gather_return_exceptions_isolates_failure() -> None:
     assert any(f.rule_id == "healthy.rule" for f in result.findings)
     # Cancelled scanner's error should be recorded in scanner_results
     cancelled_results = [
-        sr for sr in result.scanner_results
+        sr
+        for sr in result.scanner_results
         if sr.error is not None and "CancelledError" in sr.error
     ]
     assert len(cancelled_results) >= 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -245,7 +245,7 @@ class TestFanOutScan:
         bad_results = [r for r in result.scanner_results if r.scanner_name == "bad"]
         assert len(good_results) == 1
         assert len(bad_results) == 1
-        assert bad_results[0].error == "boom"
+        assert bad_results[0].error == "RuntimeError: boom"
         assert len(good_results[0].findings) == 1
 
     @pytest.mark.asyncio
@@ -621,7 +621,8 @@ class TestPipelineNeverThrows:
         assert len(result.errors) > 0
 
     @pytest.mark.asyncio
-    async def test_base_exception_propagates(self) -> None:
+    async def test_base_exception_caught_at_boundary(self) -> None:
+        # PET-48: BaseException (including SystemExit) is now caught by inspect()
         p = Pipeline()
 
         async def _raise_system_exit(
@@ -634,8 +635,10 @@ class TestPipelineNeverThrows:
             raise SystemExit(1)
 
         p._inspect_inner = _raise_system_exit  # type: ignore[method-assign]
-        with pytest.raises(SystemExit):
-            await p.inspect("test")
+        result = await p.inspect("test")
+        assert isinstance(result, PipelineResult)
+        assert result.safe is False
+        assert any("SystemExit" in e for e in result.errors)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Broadens `except Exception` to `except BaseException` at three sites in `pipeline.py` so `CancelledError`, `KeyboardInterrupt`, and `SystemExit` cannot escape `inspect()` — fixing a violation of the pipeline-never-throws invariant (OWASP ASI07)
- Adds `return_exceptions=True` to `asyncio.gather` with a `_normalize_gather_result` helper for belt-and-suspenders scanner isolation
- Adds `_logger` to `pipeline.py` and logs non-`Exception` `BaseException` types as warnings at the `inspect()` boundary

## Layered defense

Three layers prevent `BaseException` from escaping `inspect()`:

1. **`_scan_one`** catches `BaseException` — per-scanner isolation converts any exception (including `CancelledError`) to an errored `ScanResult`
2. **`asyncio.gather(return_exceptions=True)`** — if an exception somehow slips past `_scan_one`, the gather returns it as a value instead of raising; `_normalize_gather_result` converts it to an errored `ScanResult`
3. **`inspect()` outer handler** — final backstop catches `BaseException` and returns `PipelineResult(safe=False)` with a warning log

## Files changed

| File | Change |
|------|--------|
| `petasos/pipeline.py` | Adds `import logging` + `_logger`; broadens `_scan_one` catch to `BaseException` with type-name error format; adds `_normalize_gather_result` helper; adds `return_exceptions=True` to gather; broadens `inspect()` outer handler to `BaseException` with warning log |
| `tests/adversarial/pipeline/test_cancel_mid_gather.py` | New — 6 adversarial tests covering CancelledError isolation, KeyboardInterrupt at boundary, logger warning, and external task cancellation |
| `tests/test_pipeline.py` | Updates 2 existing tests: error format change (`"boom"` → `"RuntimeError: boom"`) and `test_base_exception_propagates` → `test_base_exception_caught_at_boundary` (SystemExit now caught per D7) |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/adversarial/pipeline/test_cancel_mid_gather.py -v` — 6/6 pass (full output: docs/specs/TODO/PET-48.test-output.txt)
- [x] Full suite: 710 passed, 0 failed (2 pre-existing benchmark ERRORs)
- [x] `ruff check .` — clean
- [x] `mypy --strict .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exception handling in scanning operations to prevent interruptions from system-level exceptions
  * Improved error message formatting for better diagnostics
  * Scanning now continues when individual scanners encounter failures, with errors properly reported

* **Tests**
  * Added comprehensive test coverage for exception handling and concurrent scanning scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->