### PR TITLE
fix(pet-72): construction-time validation for types + scanner protocol

### DIFF
--- a/docs/specs/TODO/PET-72.test-output.txt
+++ b/docs/specs/TODO/PET-72.test-output.txt
@@ -1,0 +1,38 @@
+============================= test session starts =============================
+platform win32 -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-72-worktree
+configfile: pyproject.toml
+
+--- Targeted tests (18/18 pass) ---
+
+tests/adversarial/types/test_type_validation.py::TestPipelineResultImmutability::test_pipeline_result_dict_wrapped_as_proxy PASSED
+tests/adversarial/types/test_type_validation.py::TestPipelineResultImmutability::test_pipeline_result_proxy_mutation_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestPipelineResultImmutability::test_pipeline_result_none_stays_none PASSED
+tests/adversarial/types/test_type_validation.py::TestPipelineResultImmutability::test_pipeline_result_proxy_not_double_wrapped PASSED
+tests/adversarial/types/test_type_validation.py::TestPositionValidation::test_position_inverted_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestPositionValidation::test_position_negative_start_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestPositionValidation::test_position_zero_length_accepted PASSED
+tests/adversarial/types/test_type_validation.py::TestConfidenceValidation::test_confidence_above_one_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestConfidenceValidation::test_confidence_below_zero_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestConfidenceValidation::test_confidence_nan_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestConfidenceValidation::test_confidence_inf_raises PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_validate_scanner_accepts_valid PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_validate_scanner_missing_name PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_validate_scanner_missing_scan PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_validate_scanner_sync_scan_rejected PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_validate_scanner_accepts_kwargs_scan PASSED
+tests/adversarial/types/test_type_validation.py::TestValidateScanner::test_pipeline_rejects_invalid_scanner PASSED
+tests/adversarial/types/test_type_validation.py::TestRoundtripValidation::test_from_dict_roundtrip_preserves_validation PASSED
+
+--- Full suite (749 passed, 56 skipped, 1 xfailed, 1 xpassed) ---
+
+749 passed, 56 skipped, 1 xfailed, 1 xpassed in 2.58s
+
+--- ruff check . ---
+All checks passed!
+
+--- ruff format --check . ---
+63 files already formatted
+
+--- mypy --strict . ---
+Success: no issues found in 63 source files

--- a/petasos/_types.py
+++ b/petasos/_types.py
@@ -143,10 +143,15 @@ def _validate_scanner(obj: Any) -> None:
         ) from exc
 
     params = sig.parameters
+    param_names = set(params.keys())
+    has_var_positional = any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values())
     has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+    if "text" not in param_names and not has_var_positional:
+        raise TypeError(f"Scanner {type(obj).__name__!r}.scan() missing 'text' parameter")
+
     if not has_var_keyword:
-        param_names = set(params.keys())
-        for required in ("text", "direction", "session_id"):
+        for required in ("direction", "session_id"):
             if required not in param_names:
                 raise TypeError(
                     f"Scanner {type(obj).__name__!r}.scan() missing '{required}' parameter"

--- a/petasos/_types.py
+++ b/petasos/_types.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import enum
+import inspect
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from types import MappingProxyType
+from types import MappingProxyType
+from typing import Any, Literal, Protocol, runtime_checkable
 
 Direction = Literal["inbound", "outbound"]
 
@@ -23,6 +22,12 @@ class Position:
     start: int
     end: int
 
+    def __post_init__(self) -> None:
+        if self.start < 0:
+            raise ValueError(f"Position.start must be >= 0, got {self.start}")
+        if self.end < self.start:
+            raise ValueError(f"Position.end ({self.end}) must be >= Position.start ({self.start})")
+
 
 @dataclass(frozen=True)
 class ScanFinding:
@@ -34,6 +39,12 @@ class ScanFinding:
     scanner_name: str
     position: Position | None = None
     matched_text: str | None = None
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.confidence <= 1.0):
+            raise ValueError(
+                f"ScanFinding.confidence must be in [0.0, 1.0], got {self.confidence}"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {
@@ -106,6 +117,42 @@ class Scanner(Protocol):
     ) -> ScanResult: ...
 
 
+def _validate_scanner(obj: Any) -> None:
+    """Structural validation beyond @runtime_checkable isinstance check."""
+    try:
+        has_name = hasattr(obj, "name")
+    except Exception as exc:
+        raise TypeError(
+            f"Scanner {type(obj).__name__!r}: accessing 'name' raised {type(exc).__name__}: {exc}"
+        ) from exc
+    if not has_name:
+        raise TypeError(f"Scanner object {type(obj).__name__!r} missing 'name' attribute")
+
+    scan = getattr(obj, "scan", None)
+    if scan is None or not callable(scan):
+        raise TypeError(f"Scanner object {type(obj).__name__!r} missing callable 'scan' method")
+
+    if not inspect.iscoroutinefunction(scan):
+        raise TypeError(f"Scanner {type(obj).__name__!r}.scan() must be async")
+
+    try:
+        sig = inspect.signature(scan)
+    except (ValueError, TypeError) as exc:
+        raise TypeError(
+            f"Scanner {type(obj).__name__!r}.scan(): cannot introspect signature: {exc}"
+        ) from exc
+
+    params = sig.parameters
+    has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+    if not has_var_keyword:
+        param_names = set(params.keys())
+        for required in ("text", "direction", "session_id"):
+            if required not in param_names:
+                raise TypeError(
+                    f"Scanner {type(obj).__name__!r}.scan() missing '{required}' parameter"
+                )
+
+
 @dataclass(frozen=True)
 class NormalizedText:
     original: str
@@ -149,3 +196,8 @@ class PipelineResult:
     escalation_tier: str | None = None
     session_score: float | None = None
     premium_features: MappingProxyType[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        pf = self.premium_features
+        if pf is not None and not isinstance(pf, MappingProxyType):
+            object.__setattr__(self, "premium_features", MappingProxyType(dict(pf)))

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -16,6 +16,7 @@ from petasos._types import (
     ScanFinding,
     ScanResult,
     Severity,
+    _validate_scanner,
 )
 from petasos.config import PetasosConfig
 from petasos.normalize import normalize
@@ -189,6 +190,9 @@ class Pipeline:
         self._license_claims: LicenseClaims | None = None
 
         scanner_list = list(scanners)
+        for s in scanner_list:
+            _validate_scanner(s)
+
         self._minimal_scanner: MinimalScanner | None = None
         self._ml_scanners: list[Scanner] = []
 

--- a/tests/adversarial/types/test_type_validation.py
+++ b/tests/adversarial/types/test_type_validation.py
@@ -160,6 +160,18 @@ class TestValidateScanner:
 
         _validate_scanner(KwargsScanner())
 
+    def test_validate_scanner_rejects_scan_without_text(self) -> None:
+        class KwargsOnlyScanner:
+            @property
+            def name(self) -> str:
+                return "kwargs_only"
+
+            async def scan(self, **kwargs: object) -> ScanResult:
+                return ScanResult(scanner_name="kwargs_only", findings=())
+
+        with pytest.raises(TypeError, match="missing 'text' parameter"):
+            _validate_scanner(KwargsOnlyScanner())
+
     def test_pipeline_rejects_invalid_scanner(self) -> None:
         class BadObj:
             pass

--- a/tests/adversarial/types/test_type_validation.py
+++ b/tests/adversarial/types/test_type_validation.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from petasos._types import (
+    PipelineResult,
+    Position,
+    ScanFinding,
+    ScanResult,
+    Severity,
+    _validate_scanner,
+)
+from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import MinimalScanner
+
+
+def _make_finding(*, confidence: float = 0.9) -> ScanFinding:
+    return ScanFinding(
+        rule_id="test.rule",
+        finding_type="injection",
+        severity=Severity.HIGH,
+        confidence=confidence,
+        message="test",
+        scanner_name="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# TYP-02: PipelineResult immutability enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineResultImmutability:
+    def test_pipeline_result_dict_wrapped_as_proxy(self) -> None:
+        r = PipelineResult(
+            safe=True,
+            findings=(),
+            premium_features={"frequency": "available"},  # type: ignore[arg-type]
+        )
+        assert isinstance(r.premium_features, MappingProxyType)
+
+    def test_pipeline_result_proxy_mutation_raises(self) -> None:
+        r = PipelineResult(
+            safe=True,
+            findings=(),
+            premium_features={"frequency": "available"},  # type: ignore[arg-type]
+        )
+        assert r.premium_features is not None
+        with pytest.raises(TypeError):
+            r.premium_features["frequency"] = "evil"  # type: ignore[index]
+
+    def test_pipeline_result_none_stays_none(self) -> None:
+        r = PipelineResult(safe=True, findings=())
+        assert r.premium_features is None
+
+    def test_pipeline_result_proxy_not_double_wrapped(self) -> None:
+        proxy = MappingProxyType({"frequency": "available"})
+        r = PipelineResult(safe=True, findings=(), premium_features=proxy)
+        assert r.premium_features is proxy
+
+
+# ---------------------------------------------------------------------------
+# TYP-03: Position + confidence validation
+# ---------------------------------------------------------------------------
+
+
+class TestPositionValidation:
+    def test_position_inverted_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be >= Position.start"):
+            Position(start=10, end=5)
+
+    def test_position_negative_start_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be >= 0"):
+            Position(start=-1, end=5)
+
+    def test_position_zero_length_accepted(self) -> None:
+        p = Position(start=5, end=5)
+        assert p.start == 5
+        assert p.end == 5
+
+
+class TestConfidenceValidation:
+    def test_confidence_above_one_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0\.0, 1\.0\]"):
+            _make_finding(confidence=1.5)
+
+    def test_confidence_below_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0\.0, 1\.0\]"):
+            _make_finding(confidence=-0.1)
+
+    def test_confidence_nan_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0\.0, 1\.0\]"):
+            _make_finding(confidence=float("nan"))
+
+    def test_confidence_inf_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0\.0, 1\.0\]"):
+            _make_finding(confidence=float("inf"))
+
+
+# ---------------------------------------------------------------------------
+# TYP-04: Scanner validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateScanner:
+    def test_validate_scanner_accepts_valid(self) -> None:
+        _validate_scanner(MinimalScanner())
+
+    def test_validate_scanner_missing_name(self) -> None:
+        class NoName:
+            async def scan(
+                self,
+                text: str,
+                *,
+                direction: str = "inbound",
+                session_id: str | None = None,
+            ) -> ScanResult:
+                return ScanResult(scanner_name="x", findings=())
+
+        with pytest.raises(TypeError, match="missing 'name' attribute"):
+            _validate_scanner(NoName())
+
+    def test_validate_scanner_missing_scan(self) -> None:
+        class NoScan:
+            @property
+            def name(self) -> str:
+                return "bad"
+
+        with pytest.raises(TypeError, match="missing callable 'scan' method"):
+            _validate_scanner(NoScan())
+
+    def test_validate_scanner_sync_scan_rejected(self) -> None:
+        class SyncScan:
+            @property
+            def name(self) -> str:
+                return "sync"
+
+            def scan(
+                self,
+                text: str,
+                *,
+                direction: str = "inbound",
+                session_id: str | None = None,
+            ) -> ScanResult:
+                return ScanResult(scanner_name="sync", findings=())
+
+        with pytest.raises(TypeError, match="must be async"):
+            _validate_scanner(SyncScan())
+
+    def test_validate_scanner_accepts_kwargs_scan(self) -> None:
+        class KwargsScanner:
+            @property
+            def name(self) -> str:
+                return "kwargs"
+
+            async def scan(self, text: str, **kwargs: object) -> ScanResult:
+                return ScanResult(scanner_name="kwargs", findings=())
+
+        _validate_scanner(KwargsScanner())
+
+    def test_pipeline_rejects_invalid_scanner(self) -> None:
+        class BadObj:
+            pass
+
+        with pytest.raises(TypeError):
+            Pipeline(scanners=[BadObj()])  # type: ignore[list-item]
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtripValidation:
+    def test_from_dict_roundtrip_preserves_validation(self) -> None:
+        f = _make_finding(confidence=0.8)
+        d = f.to_dict()
+        f2 = ScanFinding.from_dict(d)
+        assert f2.confidence == 0.8
+
+        d["confidence"] = 2.0
+        with pytest.raises(ValueError, match=r"must be in \[0\.0, 1\.0\]"):
+            ScanFinding.from_dict(d)
+
+        d["confidence"] = 0.5
+        d["position"] = {"start": 10, "end": 5}
+        with pytest.raises(ValueError, match="must be >= Position.start"):
+            ScanFinding.from_dict(d)


### PR DESCRIPTION
## Summary
- Adds `__post_init__` validation to `Position` (rejects inverted/negative spans), `ScanFinding` (rejects out-of-range confidence including NaN/inf), and `PipelineResult` (enforces `MappingProxyType` wrapping on `premium_features`)
- Adds `_validate_scanner()` structural check that catches non-conforming scanner objects at `Pipeline` registration — validates name attribute, async scan method, and signature parameters (with `**kwargs` bypass)
- 18 adversarial tests covering all three findings (TYP-02, TYP-03, TYP-04)

## Layered defense

Three layers of construction-time hardening:

1. **Type validation** (`Position`, `ScanFinding`): `__post_init__` rejects semantically invalid values before they enter the pipeline
2. **Immutability enforcement** (`PipelineResult`): `__post_init__` wraps plain dict `premium_features` in `MappingProxyType(dict(...))` to sever retained references
3. **Protocol verification** (`_validate_scanner`): structural check beyond `@runtime_checkable` — catches wrong object types, missing methods, sync-instead-of-async at registration rather than at first `await`

## Files changed

| File | Change |
|------|--------|
| `petasos/_types.py` | Adds `__post_init__` to `Position`, `ScanFinding`, `PipelineResult`; promotes `MappingProxyType` to runtime import; adds `_validate_scanner()` |
| `petasos/pipeline.py` | Calls `_validate_scanner()` for each scanner in `Pipeline.__init__` |
| `tests/adversarial/types/test_type_validation.py` | New: 18 tests covering TYP-02/TYP-03/TYP-04 |
| `docs/specs/TODO/PET-72.test-output.txt` | Test evidence |

## Test plan
- [x] `py -3.13 -m pytest tests/adversarial/types/test_type_validation.py -v` — 18/18 pass
- [x] `py -3.13 -m pytest --tb=short -q` — 749/749 pass (full output: docs/specs/TODO/PET-72.test-output.txt)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --strict .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter runtime validation rejects invalid positions, out-of-range or non-finite confidence scores, and improperly formed scanner integrations.
  * Premium feature settings are now enforced as immutable when provided as mutable mappings.

* **Tests**
  * Expanded test coverage for validation logic; full test suite and tooling checks reported successful runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->