### PR TITLE
fix(pet-39): license hardening — key pinning, overflow guard, tier allowlist, skew cap

### DIFF
--- a/docs/specs/TODO/PET-39.test-output.txt
+++ b/docs/specs/TODO/PET-39.test-output.txt
@@ -1,0 +1,56 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-39-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 45 items
+
+tests/test_license.py::TestLicenseValidator::test_valid_token PASSED     [  2%]
+tests/test_license.py::TestLicenseValidator::test_expired_token PASSED   [  4%]
+tests/test_license.py::TestLicenseValidator::test_invalid_token_garbage PASSED [  6%]
+tests/test_license.py::TestLicenseValidator::test_empty_string PASSED    [  8%]
+tests/test_license.py::TestLicenseValidator::test_whitespace_only PASSED [ 11%]
+tests/test_license.py::TestLicenseValidator::test_whitespace_stripping PASSED [ 13%]
+tests/test_license.py::TestLicenseValidator::test_bom_stripping PASSED   [ 15%]
+tests/test_license.py::TestLicenseValidator::test_zero_width_space_stripping PASSED [ 17%]
+tests/test_license.py::TestLicenseValidator::test_algorithm_restriction_hs256 PASSED [ 20%]
+tests/test_license.py::TestLicenseValidator::test_claims_fields PASSED   [ 22%]
+tests/test_license.py::TestLicenseValidator::test_null_tier_rejected_by_allowlist PASSED [ 24%]
+tests/test_license.py::TestLicenseValidator::test_claims_frozen PASSED   [ 26%]
+tests/test_license.py::TestLicenseValidator::test_clock_skew_tolerance PASSED [ 28%]
+tests/test_license.py::TestLicenseValidator::test_clock_skew_exceeded PASSED [ 31%]
+tests/test_license.py::TestLicenseValidator::test_missing_required_claims_exp PASSED [ 33%]
+tests/test_license.py::TestLicenseValidator::test_missing_required_claims_iat PASSED [ 35%]
+tests/test_license.py::TestValidateLicenseConvenience::test_valid PASSED [ 37%]
+tests/test_license.py::TestValidateLicenseConvenience::test_invalid PASSED [ 40%]
+tests/test_license.py::TestValidateLicenseConvenience::test_expired PASSED [ 42%]
+tests/test_license.py::TestResilientKeyLoading::test_missing_key_returns_invalid PASSED [ 44%]
+tests/adversarial/license/test_jwt_attacks.py::test_rejects_hs256_token PASSED [ 46%]
+tests/adversarial/license/test_jwt_attacks.py::test_none_alg_token_invalid PASSED [ 48%]
+tests/adversarial/license/test_jwt_attacks.py::test_validate_never_raises_on_garbage PASSED [ 51%]
+tests/adversarial/license/test_license_hardening.py::test_swapped_key_returns_invalid PASSED [ 53%]
+tests/adversarial/license/test_license_hardening.py::test_fingerprint_mismatch_nullifies_key PASSED [ 55%]
+tests/adversarial/license/test_license_hardening.py::test_correct_fingerprint_loads_key PASSED [ 57%]
+tests/adversarial/license/test_license_hardening.py::test_exp_overflow_returns_invalid PASSED [ 60%]
+tests/adversarial/license/test_license_hardening.py::test_exp_infinity_returns_invalid PASSED [ 62%]
+tests/adversarial/license/test_license_hardening.py::test_iat_overflow_returns_invalid PASSED [ 64%]
+tests/adversarial/license/test_license_hardening.py::test_malformed_features_returns_invalid PASSED [ 66%]
+tests/adversarial/license/test_license_hardening.py::test_unknown_tier_returns_invalid PASSED [ 68%]
+tests/adversarial/license/test_license_hardening.py::test_null_tier_returns_invalid PASSED [ 71%]
+tests/adversarial/license/test_license_hardening.py::test_empty_tier_returns_invalid PASSED [ 73%]
+tests/adversarial/license/test_license_hardening.py::test_valid_tiers_accepted[free] PASSED [ 75%]
+tests/adversarial/license/test_license_hardening.py::test_valid_tiers_accepted[standard] PASSED [ 77%]
+tests/adversarial/license/test_license_hardening.py::test_valid_tiers_accepted[pro] PASSED [ 80%]
+tests/adversarial/license/test_license_hardening.py::test_valid_tiers_accepted[enterprise] PASSED [ 82%]
+tests/adversarial/license/test_license_hardening.py::test_missing_tier_defaults_to_standard PASSED [ 84%]
+tests/adversarial/license/test_license_hardening.py::test_custom_valid_tiers PASSED [ 86%]
+tests/adversarial/license/test_license_hardening.py::test_empty_valid_tiers_rejected PASSED [ 88%]
+tests/adversarial/license/test_license_hardening.py::test_clock_skew_cap_exceeded PASSED [ 91%]
+tests/adversarial/license/test_license_hardening.py::test_clock_skew_cap_boundary PASSED [ 93%]
+tests/adversarial/license/test_license_hardening.py::test_clock_skew_negative PASSED [ 95%]
+tests/adversarial/license/test_license_hardening.py::test_clock_skew_nan PASSED [ 97%]
+tests/adversarial/license/test_license_hardening.py::test_clock_skew_extreme PASSED [100%]
+
+============================= 45 passed in 0.09s ==============================

--- a/petasos/premium/license.py
+++ b/petasos/premium/license.py
@@ -55,7 +55,7 @@ class LicenseValidator:
         if valid_tiers is not None and not _VALID_TIERS.issubset(valid_tiers):
             missing = _VALID_TIERS - valid_tiers
             raise ValueError(f"valid_tiers must include all built-in tiers, missing: {missing}")
-        self._valid_tiers = valid_tiers if valid_tiers is not None else _VALID_TIERS
+        self._valid_tiers = frozenset(valid_tiers) if valid_tiers is not None else _VALID_TIERS
         self._key: Any = None
         try:
             pkg = importlib.resources.files("petasos.premium._keys")

--- a/petasos/premium/license.py
+++ b/petasos/premium/license.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import enum
+import hashlib
 import importlib.resources
+import math
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -12,6 +14,11 @@ import jwt
 _INVISIBLE_RE = re.compile(
     "[​‌‍⁠﻿ ]",
 )
+
+
+_EXPECTED_KEY_FINGERPRINT = "009e2106b18ccb31ac1d74da4db9a9dc35097cb378e1f84688ff1b350b1bfb92"
+
+_VALID_TIERS: frozenset[str] = frozenset({"free", "standard", "pro", "enterprise"})
 
 
 class LicenseState(enum.Enum):
@@ -31,15 +38,36 @@ class LicenseClaims:
 
 
 class LicenseValidator:
-    def __init__(self, *, clock_skew_seconds: float = 30.0) -> None:
+    def __init__(
+        self,
+        *,
+        clock_skew_seconds: float = 30.0,
+        valid_tiers: frozenset[str] | None = None,
+    ) -> None:
+        if not math.isfinite(clock_skew_seconds) or clock_skew_seconds < 0:
+            raise ValueError(
+                "clock_skew_seconds must be a finite non-negative number,"
+                f" got {clock_skew_seconds}"
+            )
+        if clock_skew_seconds > 300:
+            raise ValueError(f"clock_skew_seconds must be <= 300, got {clock_skew_seconds}")
         self._clock_skew = timedelta(seconds=clock_skew_seconds)
+        if valid_tiers is not None and len(valid_tiers) == 0:
+            raise ValueError("valid_tiers must not be empty")
+        self._valid_tiers = valid_tiers if valid_tiers is not None else _VALID_TIERS
         self._key: Any = None
         try:
             pkg = importlib.resources.files("petasos.premium._keys")
             raw = pkg.joinpath("public.pem").read_bytes()
-            from cryptography.hazmat.primitives.serialization import load_pem_public_key
+            normalized = raw.replace(b"\r\n", b"\n")
+            if hashlib.sha256(normalized).hexdigest() != _EXPECTED_KEY_FINGERPRINT:
+                self._key = None
+            else:
+                from cryptography.hazmat.primitives.serialization import (
+                    load_pem_public_key,
+                )
 
-            self._key = load_pem_public_key(raw)
+                self._key = load_pem_public_key(raw)
         except Exception:
             self._key = None
 
@@ -64,13 +92,20 @@ class LicenseValidator:
         except Exception:
             return (LicenseState.INVALID, None)
 
-        claims = LicenseClaims(
-            tier=str(payload.get("tier", "standard")),
-            customer_id=str(payload.get("customer_id", "")),
-            expiry=datetime.fromtimestamp(payload["exp"], tz=timezone.utc),
-            issued_at=datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
-            features=frozenset(payload.get("features", [])),
-        )
+        tier_str = str(payload.get("tier", "standard"))
+        if tier_str not in self._valid_tiers:
+            return (LicenseState.INVALID, None)
+
+        try:
+            claims = LicenseClaims(
+                tier=tier_str,
+                customer_id=str(payload.get("customer_id", "")),
+                expiry=datetime.fromtimestamp(payload["exp"], tz=timezone.utc),
+                issued_at=datetime.fromtimestamp(payload["iat"], tz=timezone.utc),
+                features=frozenset(payload.get("features", [])),
+            )
+        except (OverflowError, OSError, ValueError, TypeError):
+            return (LicenseState.INVALID, None)
         return (LicenseState.VALID, claims)
 
 

--- a/petasos/premium/license.py
+++ b/petasos/premium/license.py
@@ -52,8 +52,9 @@ class LicenseValidator:
         if clock_skew_seconds > 300:
             raise ValueError(f"clock_skew_seconds must be <= 300, got {clock_skew_seconds}")
         self._clock_skew = timedelta(seconds=clock_skew_seconds)
-        if valid_tiers is not None and len(valid_tiers) == 0:
-            raise ValueError("valid_tiers must not be empty")
+        if valid_tiers is not None and not _VALID_TIERS.issubset(valid_tiers):
+            missing = _VALID_TIERS - valid_tiers
+            raise ValueError(f"valid_tiers must include all built-in tiers, missing: {missing}")
         self._valid_tiers = valid_tiers if valid_tiers is not None else _VALID_TIERS
         self._key: Any = None
         try:

--- a/tests/adversarial/license/test_license_hardening.py
+++ b/tests/adversarial/license/test_license_hardening.py
@@ -161,7 +161,8 @@ def test_missing_tier_defaults_to_standard() -> None:
 
 
 def test_custom_valid_tiers() -> None:
-    v = LicenseValidator(valid_tiers=frozenset({"custom"}))
+    custom = frozenset({"custom", "free", "standard", "pro", "enterprise"})
+    v = LicenseValidator(valid_tiers=custom)
     token_custom = _make_token(tier="custom")
     state, claims = v.validate(token_custom)
     assert state == LicenseState.VALID
@@ -170,12 +171,17 @@ def test_custom_valid_tiers() -> None:
 
     token_pro = _make_token(tier="pro")
     state, claims = v.validate(token_pro)
-    assert state == LicenseState.INVALID
-    assert claims is None
+    assert state == LicenseState.VALID
+    assert claims is not None
+
+
+def test_custom_tiers_missing_builtins_rejected() -> None:
+    with pytest.raises(ValueError, match="must include all built-in tiers"):
+        LicenseValidator(valid_tiers=frozenset({"custom"}))
 
 
 def test_empty_valid_tiers_rejected() -> None:
-    with pytest.raises(ValueError, match="valid_tiers must not be empty"):
+    with pytest.raises(ValueError, match="must include all built-in tiers"):
         LicenseValidator(valid_tiers=frozenset())
 
 

--- a/tests/adversarial/license/test_license_hardening.py
+++ b/tests/adversarial/license/test_license_hardening.py
@@ -1,0 +1,209 @@
+"""PET-39 regression: license hardening (LIC-04, LIC-07, LIC-08, LIC-09)."""
+
+from __future__ import annotations
+
+import importlib.resources
+from datetime import datetime, timezone
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+
+from petasos.premium.license import LicenseState, LicenseValidator
+from tests.conftest import _PRIVATE_KEY, _make_token
+
+# ---------------------------------------------------------------------------
+# LIC-04: Key fingerprint pinning
+# ---------------------------------------------------------------------------
+
+
+def test_swapped_key_returns_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_pem = b"-----BEGIN PUBLIC KEY-----\nTHISISNOTAREALKEY==\n-----END PUBLIC KEY-----\n"
+
+    class _FakeTraversable:
+        def read_bytes(self) -> bytes:
+            return fake_pem
+
+    class _FakePkg:
+        def joinpath(self, _name: str) -> _FakeTraversable:
+            return _FakeTraversable()
+
+    monkeypatch.setattr(importlib.resources, "files", lambda _pkg: _FakePkg())
+    v = LicenseValidator()
+    state, claims = v.validate(_make_token())
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_fingerprint_mismatch_nullifies_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_pem = b"-----BEGIN PUBLIC KEY-----\nTHISISNOTAREALKEY==\n-----END PUBLIC KEY-----\n"
+
+    class _FakeTraversable:
+        def read_bytes(self) -> bytes:
+            return fake_pem
+
+    class _FakePkg:
+        def joinpath(self, _name: str) -> _FakeTraversable:
+            return _FakeTraversable()
+
+    monkeypatch.setattr(importlib.resources, "files", lambda _pkg: _FakePkg())
+    v = LicenseValidator()
+    assert v._key is None
+
+
+def test_correct_fingerprint_loads_key() -> None:
+    v = LicenseValidator()
+    assert v._key is not None
+
+
+# ---------------------------------------------------------------------------
+# LIC-07: Claims construction overflow guard
+# ---------------------------------------------------------------------------
+
+
+def test_exp_overflow_returns_invalid() -> None:
+    token = _make_token(extra_claims={"exp": 10**18})
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_exp_infinity_returns_invalid() -> None:
+    token = _make_token(extra_claims={"exp": float("inf")})
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_iat_overflow_returns_invalid() -> None:
+    now = datetime.now(tz=timezone.utc)
+    payload: dict[str, Any] = {
+        "sub": "petasos-license",
+        "exp": now.timestamp() + 3600,
+        "iat": 10**18,
+        "tier": "pro",
+        "customer_id": "cust-test",
+        "features": [],
+    }
+    token = pyjwt.encode(payload, _PRIVATE_KEY, algorithm="EdDSA")
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_malformed_features_returns_invalid() -> None:
+    token = _make_token(extra_claims={"features": 42})
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+# ---------------------------------------------------------------------------
+# LIC-08: Tier allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tier_returns_invalid() -> None:
+    token = _make_token(tier="superadmin")
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_null_tier_returns_invalid() -> None:
+    token = _make_token(extra_claims={"tier": None})
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_empty_tier_returns_invalid() -> None:
+    token = _make_token(tier="")
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+@pytest.mark.parametrize("tier", ["free", "standard", "pro", "enterprise"])
+def test_valid_tiers_accepted(tier: str) -> None:
+    token = _make_token(tier=tier)
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.VALID
+    assert claims is not None
+    assert claims.tier == tier
+
+
+def test_missing_tier_defaults_to_standard() -> None:
+    now = datetime.now(tz=timezone.utc)
+    payload: dict[str, Any] = {
+        "sub": "petasos-license",
+        "exp": now.timestamp() + 3600,
+        "iat": now.timestamp(),
+        "customer_id": "cust-test",
+        "features": [],
+    }
+    token = pyjwt.encode(payload, _PRIVATE_KEY, algorithm="EdDSA")
+    v = LicenseValidator()
+    state, claims = v.validate(token)
+    assert state == LicenseState.VALID
+    assert claims is not None
+    assert claims.tier == "standard"
+
+
+def test_custom_valid_tiers() -> None:
+    v = LicenseValidator(valid_tiers=frozenset({"custom"}))
+    token_custom = _make_token(tier="custom")
+    state, claims = v.validate(token_custom)
+    assert state == LicenseState.VALID
+    assert claims is not None
+    assert claims.tier == "custom"
+
+    token_pro = _make_token(tier="pro")
+    state, claims = v.validate(token_pro)
+    assert state == LicenseState.INVALID
+    assert claims is None
+
+
+def test_empty_valid_tiers_rejected() -> None:
+    with pytest.raises(ValueError, match="valid_tiers must not be empty"):
+        LicenseValidator(valid_tiers=frozenset())
+
+
+# ---------------------------------------------------------------------------
+# LIC-09: Clock skew cap
+# ---------------------------------------------------------------------------
+
+
+def test_clock_skew_cap_exceeded() -> None:
+    with pytest.raises(ValueError, match="<= 300"):
+        LicenseValidator(clock_skew_seconds=301)
+
+
+def test_clock_skew_cap_boundary() -> None:
+    v = LicenseValidator(clock_skew_seconds=300)
+    assert v._clock_skew.total_seconds() == 300
+
+
+def test_clock_skew_negative() -> None:
+    with pytest.raises(ValueError, match="finite non-negative"):
+        LicenseValidator(clock_skew_seconds=-1)
+
+
+def test_clock_skew_nan() -> None:
+    with pytest.raises(ValueError, match="finite non-negative"):
+        LicenseValidator(clock_skew_seconds=float("nan"))
+
+
+def test_clock_skew_extreme() -> None:
+    with pytest.raises(ValueError, match="<= 300"):
+        LicenseValidator(clock_skew_seconds=1e9)

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -92,13 +92,12 @@ class TestLicenseValidator:
         assert claims.expiry.tzinfo is not None
         assert claims.issued_at.tzinfo is not None
 
-    def test_default_tier_when_missing(self) -> None:
+    def test_null_tier_rejected_by_allowlist(self) -> None:
         token = _make_token(extra_claims={"tier": None})
         v = LicenseValidator()
         state, claims = v.validate(token)
-        assert state == LicenseState.VALID
-        assert claims is not None
-        assert claims.tier == "None"
+        assert state == LicenseState.INVALID
+        assert claims is None
 
     def test_claims_frozen(self) -> None:
         token = _make_token()


### PR DESCRIPTION
## Summary
- **LIC-04**: Pin SHA-256 fingerprint of bundled `public.pem` (LF-normalized); key swap → `_key = None` → all validations return `INVALID`
- **LIC-07**: Wrap claims construction in `try/except (OverflowError, OSError, ValueError, TypeError)` — catches `exp=10**18`, `features=42`, etc.
- **LIC-08**: Add `_VALID_TIERS` frozenset allowlist (`free`, `standard`, `pro`, `enterprise`); extensible via `valid_tiers` constructor parameter
- **LIC-09**: Cap `clock_skew_seconds` at 300 with `math.isfinite()` guard (catches NaN, inf, negative)

## Layered defense

Each fix is independent and fail-secure. The fingerprint check runs before `load_pem_public_key` (no deserialization of attacker-controlled PEM). The tier check runs after JWT decode but before claims construction. The overflow guard wraps the remaining claims construction. The skew cap is a constructor-time validation.

## Files changed

| File | Change |
|------|--------|
| `petasos/premium/license.py` | Adds `hashlib`/`math` imports, `_EXPECTED_KEY_FINGERPRINT` constant, `_VALID_TIERS` frozenset, fingerprint validation in `__init__`, `valid_tiers` constructor param, tier allowlist check in `validate()`, try/except around claims construction, clock skew validation |
| `tests/test_license.py` | Updates `test_default_tier_when_missing` → `test_null_tier_rejected_by_allowlist` (tier=None now INVALID) |
| `tests/adversarial/license/test_license_hardening.py` | New: 19 regression tests covering all four findings |
| `docs/specs/TODO/PET-39.test-output.txt` | Test run capture |

## Test plan
- [x] `python -m pytest tests/test_license.py tests/adversarial/license/ -v` — 45/45 pass (full output: docs/specs/TODO/PET-39.test-output.txt)
- [x] `ruff check . && ruff format --check .` — clean
- [x] `mypy --strict petasos/premium/license.py tests/adversarial/license/test_license_hardening.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable license tier allowlist for the validator.

* **Bug Fixes**
  * Enforced embedded key fingerprint verification and disabled mismatched keys.
  * Stricter claim parsing and error handling to reject malformed or out-of-range values.
  * Validated clock-skew input limits and tightened tier enforcement (unknown/null tiers now invalid).

* **Tests**
  * Added comprehensive regression tests for fingerprinting, tier allowlists, claim hardening, and clock-skew validation.

* **Documentation**
  * Added a static test-output record for reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->