### PR TITLE
fix(pet-53): callback isolation for audit/alerting subsystems

### DIFF
--- a/docs/specs/TODO/PET-53.test-output.txt
+++ b/docs/specs/TODO/PET-53.test-output.txt
@@ -1,0 +1,127 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-53-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 102 items
+
+tests/adversarial/pipeline/test_callback_isolation.py::TestAuditCallbackIsolation::test_audit_callback_runtime_error_swallowed PASSED [  0%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestAuditCallbackIsolation::test_audit_callback_base_exception_swallowed PASSED [  1%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestAuditCallbackIsolation::test_audit_callback_error_logged PASSED [  2%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestAlertCallbackIsolation::test_alert_callback_runtime_error_in_errors PASSED [  3%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestAlertCallbackIsolation::test_alert_callback_base_exception_swallowed PASSED [  4%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestAlertCallbackIsolation::test_alert_callback_error_logged PASSED [  5%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_audit_error_reaches_pipeline_result PASSED [  6%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_alert_error_reaches_pipeline_result PASSED [  7%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_both_callbacks_fail_both_errors_in_result PASSED [  8%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestCrossSessionBurstTracker::test_cross_session_burst_accurate_under_eviction PASSED [  9%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestCrossSessionBurstTracker::test_cross_session_tracker_time_window_eviction PASSED [ 10%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestCrossSessionBurstTracker::test_cross_session_tracker_cap_bounds_memory PASSED [ 11%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestGlobalMonotonicSequence::test_sequence_continues_after_ttl_prune_boundary PASSED [ 12%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestGlobalMonotonicSequence::test_sequence_global_monotonic_across_sessions PASSED [ 13%]
+tests/adversarial/pipeline/test_callback_isolation.py::TestGlobalMonotonicSequence::test_sequence_never_zero_after_first_emit PASSED [ 14%]
+tests/test_audit.py::TestAuditEventConstruction::test_frozen_dataclass_raises_on_mutation PASSED [ 15%]
+tests/test_audit.py::TestAuditEventConstruction::test_all_fields_populated PASSED [ 16%]
+tests/test_audit.py::TestAuditEventConstruction::test_event_id_is_valid_uuid4_hex PASSED [ 17%]
+tests/test_audit.py::TestVerbosityLevels::test_minimal_payload_keys PASSED [ 18%]
+tests/test_audit.py::TestVerbosityLevels::test_standard_payload_keys PASSED [ 19%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_payload_keys PASSED [ 20%]
+tests/test_audit.py::TestVerbosityLevels::test_minimal_no_extra_keys PASSED [ 21%]
+tests/test_audit.py::TestVerbosityLevels::test_standard_findings_content PASSED [ 22%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_scanner_results_content PASSED [ 23%]
+tests/test_audit.py::TestVerbosityLevels::test_verbose_config_snapshot_is_dict PASSED [ 24%]
+tests/test_audit.py::TestSequenceNumbers::test_first_emit_sequence_zero PASSED [ 25%]
+tests/test_audit.py::TestSequenceNumbers::test_sequential_emits_monotonic PASSED [ 26%]
+tests/test_audit.py::TestSequenceNumbers::test_different_sessions_global_sequence PASSED [ 27%]
+tests/test_audit.py::TestSequenceNumbers::test_none_session_shares_global_counter PASSED [ 28%]
+tests/test_audit.py::TestSequenceNumbers::test_no_gaps_across_100_emits PASSED [ 29%]
+tests/test_audit.py::TestCallbackBehavior::test_no_callback_completes_without_error PASSED [ 30%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_receives_exact_event PASSED [ 31%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_raises_valueerror_swallowed PASSED [ 32%]
+tests/test_audit.py::TestCallbackBehavior::test_callback_raises_generic_exception_swallowed PASSED [ 33%]
+tests/test_audit.py::TestEventTypes::test_event_type_is_scan_complete PASSED [ 34%]
+tests/test_audit.py::TestEdgeCases::test_empty_findings_zero_count PASSED [ 35%]
+tests/test_audit.py::TestEdgeCases::test_freq_result_none_standard_payload PASSED [ 36%]
+tests/test_audit.py::TestEdgeCases::test_multiple_sessions_interleaved_global PASSED [ 37%]
+tests/test_audit.py::TestEdgeCases::test_payload_is_immutable PASSED     [ 38%]
+tests/test_audit.py::TestEdgeCases::test_verbose_payload_redacts_hash_key PASSED [ 39%]
+tests/test_audit.py::TestEdgeCases::test_verbose_payload_no_raw_secret_in_str PASSED [ 40%]
+tests/test_audit.py::TestEdgeCases::test_global_sequence_continues_across_sessions PASSED [ 41%]
+tests/test_alerting.py::TestAlertConstruction::test_frozen_dataclass PASSED [ 42%]
+tests/test_alerting.py::TestAlertConstruction::test_all_fields_populated PASSED [ 43%]
+tests/test_alerting.py::TestTierEscalation::test_none_to_tier1_fires_warning PASSED [ 44%]
+tests/test_alerting.py::TestTierEscalation::test_tier1_to_tier2_fires_high PASSED [ 45%]
+tests/test_alerting.py::TestTierEscalation::test_tier2_to_tier3_fires_critical PASSED [ 46%]
+tests/test_alerting.py::TestTierEscalation::test_same_tier_does_not_fire PASSED [ 47%]
+tests/test_alerting.py::TestTierEscalation::test_freq_result_none_does_not_fire PASSED [ 48%]
+tests/test_alerting.py::TestTierEscalation::test_decay_re_entry_fires PASSED [ 49%]
+tests/test_alerting.py::TestTierEscalation::test_stable_tier1_no_decay_does_not_fire PASSED [ 50%]
+tests/test_alerting.py::TestHighSeverityFinding::test_high_finding_fires PASSED [ 50%]
+tests/test_alerting.py::TestHighSeverityFinding::test_medium_finding_does_not_fire_default PASSED [ 51%]
+tests/test_alerting.py::TestHighSeverityFinding::test_critical_finding_fires PASSED [ 52%]
+tests/test_alerting.py::TestHighSeverityFinding::test_configurable_threshold_medium PASSED [ 53%]
+tests/test_alerting.py::TestRapidFire::test_below_threshold_does_not_fire PASSED [ 54%]
+tests/test_alerting.py::TestRapidFire::test_at_threshold_fires PASSED    [ 55%]
+tests/test_alerting.py::TestRapidFire::test_session_scoped_no_cross_contamination PASSED [ 56%]
+tests/test_alerting.py::TestRapidFire::test_skipped_when_session_none PASSED [ 57%]
+tests/test_alerting.py::TestRapidFire::test_outside_window_does_not_fire PASSED [ 58%]
+tests/test_alerting.py::TestCrossSessionBurst::test_below_threshold_does_not_fire PASSED [ 59%]
+tests/test_alerting.py::TestCrossSessionBurst::test_at_threshold_fires PASSED [ 60%]
+tests/test_alerting.py::TestCrossSessionBurst::test_duplicate_sessions_count_as_one PASSED [ 61%]
+tests/test_alerting.py::TestCrossSessionBurst::test_none_session_excluded PASSED [ 62%]
+tests/test_alerting.py::TestPiiVolumeSpike::test_below_threshold_does_not_fire PASSED [ 63%]
+tests/test_alerting.py::TestPiiVolumeSpike::test_at_threshold_fires PASSED [ 64%]
+tests/test_alerting.py::TestPiiVolumeSpike::test_window_expiry PASSED    [ 65%]
+tests/test_alerting.py::TestRateLimiting::test_cooldown_suppresses_same_key PASSED [ 66%]
+tests/test_alerting.py::TestRateLimiting::test_per_minute_cap PASSED     [ 67%]
+tests/test_alerting.py::TestRateLimiting::test_per_hour_cap PASSED       [ 68%]
+tests/test_alerting.py::TestRateLimiting::test_100_rapid_triggers_bounded PASSED [ 69%]
+tests/test_alerting.py::TestRateLimiting::test_suppressed_and_rate_limited_counts PASSED [ 70%]
+tests/test_alerting.py::TestCriticalExemption::test_tier3_bypasses_cooldown PASSED [ 71%]
+tests/test_alerting.py::TestCriticalExemption::test_tier3_bypasses_per_minute_cap PASSED [ 72%]
+tests/test_alerting.py::TestCriticalExemption::test_tier3_bypasses_per_hour_cap PASSED [ 73%]
+tests/test_alerting.py::TestCriticalExemption::test_non_critical_still_rate_limited PASSED [ 74%]
+tests/test_alerting.py::TestCriticalCap::test_critical_cap_bounds_fanout PASSED [ 75%]
+tests/test_alerting.py::TestCriticalCap::test_critical_cap_default_allows_legitimate_burst PASSED [ 76%]
+tests/test_alerting.py::TestCriticalCap::test_critical_cap_per_rule_id_isolation PASSED [ 77%]
+tests/test_alerting.py::TestCriticalCap::test_critical_cap_resets_after_window PASSED [ 78%]
+tests/test_alerting.py::TestCriticalCap::test_tier3_bypasses_noncritical_caps PASSED [ 79%]
+tests/test_alerting.py::TestCriticalCap::test_critical_fanout_callback_bounded PASSED [ 80%]
+tests/test_alerting.py::TestRingBuffer::test_buffer_respects_maxlen PASSED [ 81%]
+tests/test_alerting.py::TestRingBuffer::test_buffer_entries_correct_shape PASSED [ 82%]
+tests/test_alerting.py::TestAlertCallbackBehavior::test_no_callback_returns_alerts PASSED [ 83%]
+tests/test_alerting.py::TestAlertCallbackBehavior::test_callback_receives_each_alert PASSED [ 84%]
+tests/test_alerting.py::TestAlertCallbackBehavior::test_callback_exception_swallowed PASSED [ 85%]
+tests/test_alerting.py::TestAlertStats::test_alert_count_reflects_fired PASSED [ 86%]
+tests/test_alerting.py::TestAlertStats::test_suppressed_count_reflects_dedup PASSED [ 87%]
+tests/test_alerting.py::TestAlertStats::test_rate_limited_count_reflects_caps PASSED [ 88%]
+tests/test_alerting.py::TestSessionContributionCap::test_session_contribution_cap_limits_single_session PASSED [ 89%]
+tests/test_alerting.py::TestSessionContributionCap::test_throwaway_sessions_cannot_exhaust_rule_cap PASSED [ 90%]
+tests/test_alerting.py::TestSessionContributionCap::test_session_contribution_independent_across_rules PASSED [ 91%]
+tests/test_alerting.py::TestSessionContributionCap::test_session_contribution_window_resets PASSED [ 92%]
+tests/test_alerting.py::TestSessionContributionCap::test_session_none_uses_none_key PASSED [ 93%]
+tests/test_alerting.py::TestSessionContributionCap::test_per_session_deque_pruned PASSED [ 94%]
+tests/test_alerting.py::TestSessionContributionCap::test_memory_bound_rejects_new_sessions PASSED [ 95%]
+tests/test_alerting.py::TestSessionContributionCap::test_cap_1_suppresses_reentry PASSED [ 96%]
+tests/test_alerting.py::TestSessionContributionCap::test_three_gate_composition PASSED [ 97%]
+tests/test_alerting.py::TestSessionContributionCap::test_session_rate_limited_count_separate PASSED [ 98%]
+tests/test_alerting.py::TestSessionContributionCap::test_cross_field_validation_cap_gt_per_minute PASSED [ 99%]
+tests/test_alerting.py::TestSessionContributionCap::test_memory_bound_recovery_after_expiry PASSED [100%]
+
+============================== warnings summary ===============================
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_audit_error_reaches_pipeline_result
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-53-worktree\tests\adversarial\pipeline\test_callback_isolation.py:196: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_alert_error_reaches_pipeline_result
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-53-worktree\tests\adversarial\pipeline\test_callback_isolation.py:206: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+tests/adversarial/pipeline/test_callback_isolation.py::TestPipelineCallbackPropagation::test_both_callbacks_fail_both_errors_in_result
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-53-worktree\tests\adversarial\pipeline\test_callback_isolation.py:220: DeprecationWarning: There is no current event loop
+    result = asyncio.get_event_loop().run_until_complete(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================= 102 passed, 3 warnings in 0.23s =======================

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -502,13 +502,16 @@ class Pipeline:
 
         # Stage 10: Premium audit hook
         try:
-            await self._premium_audit_hook(result, session_id, freq_result)
+            audit_cb_error = await self._premium_audit_hook(result, session_id, freq_result)
+            if audit_cb_error is not None:
+                errors.append(audit_cb_error)
         except Exception as exc:
             errors.append(f"audit hook: {exc}")
 
         # Stage 11: Premium alert hook
         try:
-            await self._premium_alert_hook(result, session_id, freq_result)
+            alert_cb_errors = await self._premium_alert_hook(result, session_id, freq_result)
+            errors.extend(alert_cb_errors)
         except Exception as exc:
             errors.append(f"alert hook: {exc}")
 
@@ -571,21 +574,23 @@ class Pipeline:
         result: PipelineResult,
         session_id: str | None,
         freq_result: FrequencyUpdateResult | None,
-    ) -> None:
+    ) -> str | None:
         if not self._check_premium("audit"):
-            return
+            return None
         if not self._config.audit_enabled:
-            return
+            return None
         self._audit_emitter.emit(result, session_id, freq_result)
+        return self._audit_emitter.last_callback_error
 
     async def _premium_alert_hook(
         self,
         result: PipelineResult,
         session_id: str | None,
         freq_result: FrequencyUpdateResult | None,
-    ) -> None:
+    ) -> tuple[str, ...]:
         if not self._check_premium("alerting"):
-            return
+            return ()
         if not self._config.alert_enabled:
-            return
+            return ()
         self._alert_manager.evaluate(result, session_id, freq_result)
+        return self._alert_manager.callback_errors

--- a/petasos/premium/alerting.py
+++ b/petasos/premium/alerting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 import uuid
 from collections import deque
@@ -8,6 +9,8 @@ from typing import TYPE_CHECKING
 
 from petasos._types import Alert, Severity
 from petasos.premium.escalation import evaluate_tier
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -23,9 +26,6 @@ _SEVERITY_RANK: dict[Severity, int] = {
     Severity.LOW: 3,
     Severity.INFO: 4,
 }
-
-_NONE_SENTINEL: object = object()
-
 
 class AlertManager:
     def __init__(
@@ -49,6 +49,12 @@ class AlertManager:
         self._suppressed_count: int = 0
         self._rate_limited_count: int = 0
         self._session_rate_limited_count: int = 0
+        self._cross_session_tracker: dict[str, float] = {}
+        self._callback_errors: list[str] = []
+
+    @property
+    def callback_errors(self) -> tuple[str, ...]:
+        return tuple(self._callback_errors)
 
     @property
     def alert_count(self) -> int:
@@ -74,6 +80,7 @@ class AlertManager:
     ) -> list[Alert]:
         now = time.monotonic()
         self._prune_stale(now)
+        self._callback_errors = []
 
         candidates: list[Alert] = []
 
@@ -159,8 +166,16 @@ class AlertManager:
             if self._on_alert is not None:
                 try:
                     self._on_alert(candidate)
-                except Exception as exc:
-                    raise RuntimeError(f"on_alert callback failed: {exc}") from exc
+                except BaseException as exc:
+                    _logger.exception(
+                        "on_alert callback failed for rule_id=%s",
+                        candidate.rule_id,
+                    )
+                    self._callback_errors.append(
+                        f"on_alert callback ({candidate.rule_id}, {type(exc).__name__}): {exc}"
+                        if str(exc)
+                        else f"on_alert callback ({candidate.rule_id}, {type(exc).__name__})"
+                    )
 
         return surviving
 
@@ -292,10 +307,24 @@ class AlertManager:
         )
         buf.append((now, session_id))
 
+        self._cross_session_tracker[session_id] = now
         window = self._config.alert_cross_session_burst_window_seconds
-        recent_sessions = {sid for ts, sid in buf if (now - ts) <= window}
+        stale_sids = [
+            sid for sid, ts in self._cross_session_tracker.items() if (now - ts) > window
+        ]
+        for sid in stale_sids:
+            del self._cross_session_tracker[sid]
+        tracker_cap = max(
+            2 * self._config.alert_ring_buffer_capacity,
+            self._config.alert_cross_session_burst_count,
+        )
+        if len(self._cross_session_tracker) > tracker_cap:
+            sorted_entries = sorted(self._cross_session_tracker.items(), key=lambda x: x[1])
+            for sid, _ in sorted_entries[: len(self._cross_session_tracker) - tracker_cap]:
+                del self._cross_session_tracker[sid]
 
-        if len(recent_sessions) >= self._config.alert_cross_session_burst_count:
+        distinct_count = len(self._cross_session_tracker)
+        if distinct_count >= self._config.alert_cross_session_burst_count:
             return Alert(
                 alert_id=uuid.uuid4().hex,
                 timestamp=time.time(),
@@ -303,11 +332,11 @@ class AlertManager:
                 severity="high",
                 session_id=session_id,
                 message=(
-                    f"Cross-session burst: {len(recent_sessions)} distinct sessions in {window}s"
+                    f"Cross-session burst: {distinct_count} distinct sessions in {window}s"
                 ),
                 context=MappingProxyType(
                     {
-                        "distinct_sessions": len(recent_sessions),
+                        "distinct_sessions": distinct_count,
                         "window_seconds": window,
                         "threshold": self._config.alert_cross_session_burst_count,
                     }
@@ -403,3 +432,12 @@ class AlertManager:
                 stale_ring_keys.append(rk)
         for rk in stale_ring_keys:
             del self._ring_buffers[rk]
+
+        burst_window = self._config.alert_cross_session_burst_window_seconds
+        stale_tracker_keys = [
+            sid
+            for sid, ts in self._cross_session_tracker.items()
+            if (now - ts) > burst_window
+        ]
+        for sid in stale_tracker_keys:
+            del self._cross_session_tracker[sid]

--- a/petasos/premium/alerting.py
+++ b/petasos/premium/alerting.py
@@ -27,6 +27,7 @@ _SEVERITY_RANK: dict[Severity, int] = {
     Severity.INFO: 4,
 }
 
+
 class AlertManager:
     def __init__(
         self,
@@ -331,9 +332,7 @@ class AlertManager:
                 rule_id="cross_session_burst",
                 severity="high",
                 session_id=session_id,
-                message=(
-                    f"Cross-session burst: {distinct_count} distinct sessions in {window}s"
-                ),
+                message=(f"Cross-session burst: {distinct_count} distinct sessions in {window}s"),
                 context=MappingProxyType(
                     {
                         "distinct_sessions": distinct_count,
@@ -435,9 +434,7 @@ class AlertManager:
 
         burst_window = self._config.alert_cross_session_burst_window_seconds
         stale_tracker_keys = [
-            sid
-            for sid, ts in self._cross_session_tracker.items()
-            if (now - ts) > burst_window
+            sid for sid, ts in self._cross_session_tracker.items() if (now - ts) > burst_window
         ]
         for sid in stale_tracker_keys:
             del self._cross_session_tracker[sid]

--- a/petasos/premium/audit.py
+++ b/petasos/premium/audit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 import uuid
 from types import MappingProxyType
@@ -7,14 +8,14 @@ from typing import TYPE_CHECKING, Any
 
 from petasos._types import AuditEvent
 
+_logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from petasos._types import PipelineResult
     from petasos.config import PetasosConfig
     from petasos.premium.frequency import FrequencyUpdateResult
-
-_NONE_SENTINEL: object = object()
 
 
 class AuditEmitter:
@@ -26,8 +27,12 @@ class AuditEmitter:
     ) -> None:
         self._config = config
         self._on_audit = on_audit
-        self._sequence_counters: dict[object, int] = {}
-        self._last_emit_time: dict[object, float] = {}
+        self._global_sequence: int = 0
+        self._last_callback_error: str | None = None
+
+    @property
+    def last_callback_error(self) -> str | None:
+        return self._last_callback_error
 
     def emit(
         self,
@@ -35,11 +40,8 @@ class AuditEmitter:
         session_id: str | None,
         freq_result: FrequencyUpdateResult | None,
     ) -> AuditEvent:
-        now_mono = time.monotonic()
-        self._prune_stale(now_mono)
-
-        session_key: object = session_id if session_id is not None else _NONE_SENTINEL
-        seq = self._sequence_counters.get(session_key, 0)
+        self._last_callback_error = None
+        seq = self._global_sequence
 
         payload = self._build_payload(result, freq_result)
 
@@ -52,14 +54,18 @@ class AuditEmitter:
             sequence_number=seq,
         )
 
-        self._sequence_counters[session_key] = seq + 1
-        self._last_emit_time[session_key] = now_mono
+        self._global_sequence = seq + 1
 
         if self._on_audit is not None:
             try:
                 self._on_audit(event)
-            except Exception as exc:
-                raise RuntimeError(f"on_audit callback failed: {exc}") from exc
+            except BaseException as exc:
+                _logger.error("on_audit callback failed: %s", exc, exc_info=True)
+                self._last_callback_error = (
+                    f"on_audit callback ({type(exc).__name__}): {exc}"
+                    if str(exc)
+                    else f"on_audit callback ({type(exc).__name__})"
+                )
 
         return event
 
@@ -102,10 +108,3 @@ class AuditEmitter:
             }
 
         return MappingProxyType(data)
-
-    def _prune_stale(self, now: float) -> None:
-        ttl = self._config.session_ttl_seconds
-        stale_keys = [k for k, t in self._last_emit_time.items() if (now - t) > ttl]
-        for k in stale_keys:
-            del self._last_emit_time[k]
-            self._sequence_counters.pop(k, None)

--- a/tests/adversarial/pipeline/test_callback_isolation.py
+++ b/tests/adversarial/pipeline/test_callback_isolation.py
@@ -1,0 +1,328 @@
+"""PET-53: Callback isolation — adversarial tests for AUD-02, ALRT-04, PIPE-06, ALRT-03, AUD-01."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from petasos._types import (
+    Alert,
+    AuditEvent,
+    PipelineResult,
+    ScanFinding,
+    ScanResult,
+    Severity,
+)
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+from petasos.premium.alerting import AlertManager
+from petasos.premium.audit import AuditEmitter
+from petasos.premium.frequency import FrequencyUpdateResult
+from petasos.premium.license import LicenseClaims, LicenseState
+from petasos.scanners.minimal import MinimalScanner
+
+
+def _cfg(**overrides: object) -> PetasosConfig:
+    defaults: dict[str, object] = {
+        "audit_enabled": True,
+        "alert_enabled": True,
+        "frequency_enabled": True,
+        "escalation_enabled": True,
+    }
+    defaults.update(overrides)
+    return PetasosConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _pipeline_result(
+    *,
+    safe: bool = True,
+    findings: tuple[ScanFinding, ...] = (),
+) -> PipelineResult:
+    return PipelineResult(safe=safe, findings=findings)
+
+
+def _finding(
+    rule_id: str = "test.rule",
+    severity: Severity = Severity.HIGH,
+) -> ScanFinding:
+    return ScanFinding(
+        rule_id=rule_id,
+        finding_type="injection",
+        severity=severity,
+        confidence=0.9,
+        message="test",
+        scanner_name="minimal",
+    )
+
+
+def _freq_result(
+    previous_score: float = 0.0,
+    current_score: float = 10.0,
+    tier: str = "tier1",
+) -> FrequencyUpdateResult:
+    return FrequencyUpdateResult(
+        previous_score=previous_score,
+        current_score=current_score,
+        tier=tier,
+        terminated=False,
+    )
+
+
+def _mock_claims() -> LicenseClaims:
+    return LicenseClaims(
+        tier="pro",
+        customer_id="test",
+        expiry=datetime.now(tz=timezone.utc) + timedelta(days=365),
+        issued_at=datetime.now(tz=timezone.utc),
+        features=frozenset(),
+    )
+
+
+def _premium_pipeline(
+    *,
+    on_audit: Any = None,
+    on_alert: Any = None,
+) -> Pipeline:
+    with patch.object(
+        Pipeline,
+        "activate",
+        return_value=LicenseState.VALID,
+    ):
+        p = Pipeline(
+            [MinimalScanner()],
+            config=_cfg(),
+            on_audit=on_audit,
+            on_alert=on_alert,
+        )
+        p._license_state = LicenseState.VALID
+        p._license_claims = _mock_claims()
+        return p
+
+
+# ---------------------------------------------------------------------------
+# AUD-02: on_audit callback isolation
+# ---------------------------------------------------------------------------
+
+
+class TestAuditCallbackIsolation:
+    def test_audit_callback_runtime_error_swallowed(self) -> None:
+        def bad_cb(e: AuditEvent) -> None:
+            raise RuntimeError("boom")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        event = emitter.emit(_pipeline_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "RuntimeError" in emitter.last_callback_error
+        assert "boom" in emitter.last_callback_error
+
+    def test_audit_callback_base_exception_swallowed(self) -> None:
+        def bad_cb(e: AuditEvent) -> None:
+            raise KeyboardInterrupt("simulated")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        event = emitter.emit(_pipeline_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "KeyboardInterrupt" in emitter.last_callback_error
+
+    def test_audit_callback_error_logged(self) -> None:
+        def bad_cb(e: AuditEvent) -> None:
+            raise ValueError("bad")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        with patch("petasos.premium.audit._logger") as mock_logger:
+            emitter.emit(_pipeline_result(), "s1", None)
+            mock_logger.error.assert_called_once()
+            call_kwargs = mock_logger.error.call_args
+            assert call_kwargs[1].get("exc_info") is True
+
+
+# ---------------------------------------------------------------------------
+# ALRT-04: on_alert callback isolation
+# ---------------------------------------------------------------------------
+
+
+class TestAlertCallbackIsolation:
+    def test_alert_callback_runtime_error_in_errors(self) -> None:
+        def bad_cb(a: Alert) -> None:
+            raise RuntimeError("alert-boom")
+
+        mgr = AlertManager(_cfg(alert_cooldown_seconds=0.001), on_alert=bad_cb)
+        r = _pipeline_result(findings=(_finding(severity=Severity.HIGH),))
+        alerts = mgr.evaluate(r, "s1", None)
+        assert len(alerts) >= 1
+        assert len(mgr.callback_errors) >= 1
+        assert "RuntimeError" in mgr.callback_errors[0]
+        assert "alert-boom" in mgr.callback_errors[0]
+
+    def test_alert_callback_base_exception_swallowed(self) -> None:
+        def bad_cb(a: Alert) -> None:
+            raise KeyboardInterrupt("simulated")
+
+        mgr = AlertManager(_cfg(alert_cooldown_seconds=0.001), on_alert=bad_cb)
+        r = _pipeline_result(findings=(_finding(severity=Severity.HIGH),))
+        alerts = mgr.evaluate(r, "s1", None)
+        assert len(alerts) >= 1
+        assert len(mgr.callback_errors) >= 1
+        assert "KeyboardInterrupt" in mgr.callback_errors[0]
+
+    def test_alert_callback_error_logged(self) -> None:
+        def bad_cb(a: Alert) -> None:
+            raise ValueError("bad-alert")
+
+        mgr = AlertManager(_cfg(alert_cooldown_seconds=0.001), on_alert=bad_cb)
+        r = _pipeline_result(findings=(_finding(severity=Severity.HIGH),))
+        with patch("petasos.premium.alerting._logger") as mock_logger:
+            mgr.evaluate(r, "s1", None)
+            mock_logger.exception.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# PIPE-06: Pipeline-level callback error propagation
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineCallbackPropagation:
+    def test_audit_error_reaches_pipeline_result(self) -> None:
+        def bad_audit(e: AuditEvent) -> None:
+            raise RuntimeError("audit-fail")
+
+        pipeline = _premium_pipeline(on_audit=bad_audit)
+        result = asyncio.get_event_loop().run_until_complete(
+            pipeline.inspect("hello", session_id="s1")
+        )
+        assert any("on_audit callback" in e for e in result.errors)
+
+    def test_alert_error_reaches_pipeline_result(self) -> None:
+        def bad_alert(a: Alert) -> None:
+            raise RuntimeError("alert-fail")
+
+        pipeline = _premium_pipeline(on_alert=bad_alert)
+        result = asyncio.get_event_loop().run_until_complete(
+            pipeline.inspect("ignore previous instructions", session_id="s1")
+        )
+        alert_errors = [e for e in result.errors if "on_alert callback" in e]
+        assert len(alert_errors) >= 1
+
+    def test_both_callbacks_fail_both_errors_in_result(self) -> None:
+        def bad_audit(e: AuditEvent) -> None:
+            raise RuntimeError("audit-fail")
+
+        def bad_alert(a: Alert) -> None:
+            raise RuntimeError("alert-fail")
+
+        pipeline = _premium_pipeline(on_audit=bad_audit, on_alert=bad_alert)
+        result = asyncio.get_event_loop().run_until_complete(
+            pipeline.inspect("ignore previous instructions", session_id="s1")
+        )
+        audit_errors = [e for e in result.errors if "on_audit" in e]
+        alert_errors = [e for e in result.errors if "on_alert" in e]
+        assert len(audit_errors) >= 1
+        assert len(alert_errors) >= 1
+
+
+# ---------------------------------------------------------------------------
+# ALRT-03: Cross-session burst tracker accuracy
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSessionBurstTracker:
+    def test_cross_session_burst_accurate_under_eviction(self) -> None:
+        mgr = AlertManager(
+            _cfg(
+                alert_ring_buffer_capacity=5,
+                alert_cross_session_burst_count=4,
+                alert_rapid_fire_count=5,
+                alert_cooldown_seconds=1.0,
+                alert_cross_session_burst_window_seconds=60.0,
+            )
+        )
+        r = _pipeline_result(findings=(_finding(),))
+        base = 1000.0
+        with patch("petasos.premium.alerting.time") as mock_time:
+            mock_time.time.return_value = base
+            for i in range(6):
+                mock_time.monotonic.return_value = base + i * 0.1
+                mgr.evaluate(r, f"s{i}", None)
+            for j in range(2):
+                mock_time.monotonic.return_value = base + 0.6 + j * 0.1
+                mgr.evaluate(r, "s5", None)
+            mock_time.monotonic.return_value = base + 2.0
+            last_alerts = mgr.evaluate(r, "s5", None)
+        csb = [a for a in last_alerts if a.rule_id == "cross_session_burst"]
+        assert len(csb) >= 1
+
+    def test_cross_session_tracker_time_window_eviction(self) -> None:
+        base = MagicMock()
+        base_time = 1000.0
+        mgr = AlertManager(
+            _cfg(
+                alert_cross_session_burst_count=3,
+                alert_cross_session_burst_window_seconds=10.0,
+                alert_cooldown_seconds=0.001,
+            )
+        )
+        r = _pipeline_result(findings=(_finding(),))
+        with patch("petasos.premium.alerting.time") as mock_time:
+            mock_time.time.return_value = base_time
+            mock_time.monotonic.return_value = base_time
+            for i in range(3):
+                mgr.evaluate(r, f"wave1-s{i}", None)
+
+            mock_time.monotonic.return_value = base_time + 15.0
+            mock_time.time.return_value = base_time + 15.0
+            alerts = mgr.evaluate(r, "wave2-s0", None)
+
+        csb = [a for a in alerts if a.rule_id == "cross_session_burst"]
+        assert len(csb) == 0
+
+    def test_cross_session_tracker_cap_bounds_memory(self) -> None:
+        mgr = AlertManager(
+            _cfg(
+                alert_ring_buffer_capacity=50,
+                alert_cross_session_burst_count=3,
+                alert_cooldown_seconds=0.001,
+            )
+        )
+        r = _pipeline_result(findings=(_finding(),))
+        for i in range(200):
+            mgr.evaluate(r, f"s{i}", None)
+        assert len(mgr._cross_session_tracker) <= 100
+
+
+# ---------------------------------------------------------------------------
+# AUD-01: Global monotonic sequence
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalMonotonicSequence:
+    def test_sequence_continues_after_ttl_prune_boundary(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        e1 = emitter.emit(_pipeline_result(), "s1", None)
+        e2 = emitter.emit(_pipeline_result(), "s1", None)
+        last_seq = e2.sequence_number
+        e3 = emitter.emit(_pipeline_result(), "s1", None)
+        assert e3.sequence_number > last_seq
+
+    def test_sequence_global_monotonic_across_sessions(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        all_seqs: list[int] = []
+        for _ in range(5):
+            for sid in ("a", "b", "c"):
+                e = emitter.emit(_pipeline_result(), sid, None)
+                all_seqs.append(e.sequence_number)
+        assert all_seqs == list(range(15))
+
+    def test_sequence_never_zero_after_first_emit(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        e1 = emitter.emit(_pipeline_result(), "s1", None)
+        assert e1.sequence_number == 0
+        e2 = emitter.emit(_pipeline_result(), "s1", None)
+        assert e2.sequence_number > 0
+        e3 = emitter.emit(_pipeline_result(), "s2", None)
+        assert e3.sequence_number > 0

--- a/tests/adversarial/pipeline/test_callback_isolation.py
+++ b/tests/adversarial/pipeline/test_callback_isolation.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from petasos._types import (
     Alert,
     AuditEvent,
     PipelineResult,
     ScanFinding,
-    ScanResult,
     Severity,
 )
 from petasos.config import PetasosConfig
@@ -188,28 +184,24 @@ class TestAlertCallbackIsolation:
 
 
 class TestPipelineCallbackPropagation:
-    def test_audit_error_reaches_pipeline_result(self) -> None:
+    async def test_audit_error_reaches_pipeline_result(self) -> None:
         def bad_audit(e: AuditEvent) -> None:
             raise RuntimeError("audit-fail")
 
         pipeline = _premium_pipeline(on_audit=bad_audit)
-        result = asyncio.get_event_loop().run_until_complete(
-            pipeline.inspect("hello", session_id="s1")
-        )
+        result = await pipeline.inspect("hello", session_id="s1")
         assert any("on_audit callback" in e for e in result.errors)
 
-    def test_alert_error_reaches_pipeline_result(self) -> None:
+    async def test_alert_error_reaches_pipeline_result(self) -> None:
         def bad_alert(a: Alert) -> None:
             raise RuntimeError("alert-fail")
 
         pipeline = _premium_pipeline(on_alert=bad_alert)
-        result = asyncio.get_event_loop().run_until_complete(
-            pipeline.inspect("ignore previous instructions", session_id="s1")
-        )
+        result = await pipeline.inspect("ignore previous instructions", session_id="s1")
         alert_errors = [e for e in result.errors if "on_alert callback" in e]
         assert len(alert_errors) >= 1
 
-    def test_both_callbacks_fail_both_errors_in_result(self) -> None:
+    async def test_both_callbacks_fail_both_errors_in_result(self) -> None:
         def bad_audit(e: AuditEvent) -> None:
             raise RuntimeError("audit-fail")
 
@@ -217,9 +209,7 @@ class TestPipelineCallbackPropagation:
             raise RuntimeError("alert-fail")
 
         pipeline = _premium_pipeline(on_audit=bad_audit, on_alert=bad_alert)
-        result = asyncio.get_event_loop().run_until_complete(
-            pipeline.inspect("ignore previous instructions", session_id="s1")
-        )
+        result = await pipeline.inspect("ignore previous instructions", session_id="s1")
         audit_errors = [e for e in result.errors if "on_audit" in e]
         alert_errors = [e for e in result.errors if "on_alert" in e]
         assert len(audit_errors) >= 1
@@ -258,7 +248,6 @@ class TestCrossSessionBurstTracker:
         assert len(csb) >= 1
 
     def test_cross_session_tracker_time_window_eviction(self) -> None:
-        base = MagicMock()
         base_time = 1000.0
         mgr = AlertManager(
             _cfg(
@@ -303,7 +292,7 @@ class TestCrossSessionBurstTracker:
 class TestGlobalMonotonicSequence:
     def test_sequence_continues_after_ttl_prune_boundary(self) -> None:
         emitter = AuditEmitter(_cfg())
-        e1 = emitter.emit(_pipeline_result(), "s1", None)
+        emitter.emit(_pipeline_result(), "s1", None)
         e2 = emitter.emit(_pipeline_result(), "s1", None)
         last_seq = e2.sequence_number
         e3 = emitter.emit(_pipeline_result(), "s1", None)

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -608,14 +608,16 @@ class TestAlertCallbackBehavior:
         alerts = mgr.evaluate(r, "s1", None)
         assert len(received) == len(alerts)
 
-    def test_callback_exception_raises_runtime(self) -> None:
+    def test_callback_exception_swallowed(self) -> None:
         def bad_cb(a: Alert) -> None:
             raise ValueError("boom")
 
         mgr = AlertManager(_cfg(), on_alert=bad_cb)
         r = _result(findings=(_finding(severity=Severity.HIGH),))
-        with pytest.raises(RuntimeError, match="on_alert callback failed"):
-            mgr.evaluate(r, "s1", None)
+        alerts = mgr.evaluate(r, "s1", None)
+        assert len(alerts) >= 1
+        assert len(mgr.callback_errors) >= 1
+        assert "ValueError" in mgr.callback_errors[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from types import MappingProxyType
-from unittest.mock import patch
 
 import pytest
 
@@ -182,23 +181,23 @@ class TestSequenceNumbers:
         events = [emitter.emit(_result(), "s1", None) for _ in range(5)]
         assert [e.sequence_number for e in events] == [0, 1, 2, 3, 4]
 
-    def test_different_sessions_independent(self) -> None:
+    def test_different_sessions_global_sequence(self) -> None:
         emitter = AuditEmitter(_cfg())
         e1 = emitter.emit(_result(), "s1", None)
         e2 = emitter.emit(_result(), "s2", None)
         e3 = emitter.emit(_result(), "s1", None)
         assert e1.sequence_number == 0
-        assert e2.sequence_number == 0
-        assert e3.sequence_number == 1
+        assert e2.sequence_number == 1
+        assert e3.sequence_number == 2
 
-    def test_none_session_uses_dedicated_counter(self) -> None:
+    def test_none_session_shares_global_counter(self) -> None:
         emitter = AuditEmitter(_cfg())
         e1 = emitter.emit(_result(), None, None)
         e2 = emitter.emit(_result(), "s1", None)
         e3 = emitter.emit(_result(), None, None)
         assert e1.sequence_number == 0
-        assert e2.sequence_number == 0
-        assert e3.sequence_number == 1
+        assert e2.sequence_number == 1
+        assert e3.sequence_number == 2
 
     def test_no_gaps_across_100_emits(self) -> None:
         emitter = AuditEmitter(_cfg())
@@ -224,21 +223,26 @@ class TestCallbackBehavior:
         assert len(received) == 1
         assert received[0] is event
 
-    def test_callback_raises_valueerror_wrapped_as_runtime(self) -> None:
+    def test_callback_raises_valueerror_swallowed(self) -> None:
         def bad_cb(e: AuditEvent) -> None:
             raise ValueError("bad")
 
         emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
-        with pytest.raises(RuntimeError, match="on_audit callback failed"):
-            emitter.emit(_result(), "s1", None)
+        event = emitter.emit(_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "ValueError" in emitter.last_callback_error
+        assert "bad" in emitter.last_callback_error
 
-    def test_callback_raises_generic_exception_wrapped(self) -> None:
+    def test_callback_raises_generic_exception_swallowed(self) -> None:
         def bad_cb(e: AuditEvent) -> None:
             raise Exception("generic")
 
         emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
-        with pytest.raises(RuntimeError, match="on_audit callback failed"):
-            emitter.emit(_result(), "s1", None)
+        event = emitter.emit(_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "generic" in emitter.last_callback_error
 
 
 # ---------------------------------------------------------------------------
@@ -270,16 +274,16 @@ class TestEdgeCases:
         assert event.payload["session_score"] is None
         assert event.payload["escalation_tier"] is None
 
-    def test_multiple_sessions_interleaved(self) -> None:
+    def test_multiple_sessions_interleaved_global(self) -> None:
         emitter = AuditEmitter(_cfg())
         seq: dict[str, list[int]] = {"s1": [], "s2": [], "s3": []}
         for _ in range(3):
             for sid in ("s1", "s2", "s3"):
                 e = emitter.emit(_result(), sid, None)
                 seq[sid].append(e.sequence_number)
-        assert seq["s1"] == [0, 1, 2]
-        assert seq["s2"] == [0, 1, 2]
-        assert seq["s3"] == [0, 1, 2]
+        assert seq["s1"] == [0, 3, 6]
+        assert seq["s2"] == [1, 4, 7]
+        assert seq["s3"] == [2, 5, 8]
 
     def test_payload_is_immutable(self) -> None:
         emitter = AuditEmitter(_cfg(audit_verbosity="minimal"))
@@ -311,18 +315,12 @@ class TestEdgeCases:
         event = emitter.emit(_result(), "s1", _freq_result())
         assert raw_key not in str(event.payload)
 
-    def test_stale_session_pruning(self) -> None:
-        cfg = _cfg(session_ttl_seconds=1.0)
-        emitter = AuditEmitter(cfg)
-
-        with patch("petasos.premium.audit.time") as mock_time:
-            mock_time.monotonic.return_value = 100.0
-            mock_time.time.return_value = 100.0
-            emitter.emit(_result(), "old_session", None)
-
-            mock_time.monotonic.return_value = 200.0
-            mock_time.time.return_value = 200.0
-            emitter.emit(_result(), "new_session", None)
-
-        assert "old_session" not in emitter._sequence_counters
-        assert "new_session" in emitter._sequence_counters
+    def test_global_sequence_continues_across_sessions(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        e1 = emitter.emit(_result(), "s1", None)
+        e2 = emitter.emit(_result(), "s2", None)
+        e3 = emitter.emit(_result(), "s1", None)
+        assert e1.sequence_number == 0
+        assert e2.sequence_number == 1
+        assert e3.sequence_number == 2
+        assert emitter._global_sequence == 3

--- a/tests/test_premium_integration.py
+++ b/tests/test_premium_integration.py
@@ -475,7 +475,7 @@ class TestAuditAlertingIntegration:
         pipe = Pipeline(config=cfg, on_audit=bad_audit)
         pipe.activate(valid_key)
         result = await pipe.inspect("hello", session_id="s1")
-        assert any("audit hook" in e for e in result.errors)
+        assert any("on_audit callback" in e for e in result.errors)
 
     async def test_alert_callback_error_lands_in_errors(self, valid_key: str) -> None:
         def bad_alert(a: Alert) -> None:
@@ -485,7 +485,7 @@ class TestAuditAlertingIntegration:
         pipe = Pipeline(config=cfg, on_alert=bad_alert)
         pipe.activate(valid_key)
         result = await pipe.inspect("ignore previous instructions", session_id="s1")
-        assert any("alert hook" in e for e in result.errors)
+        assert any("on_alert callback" in e for e in result.errors)
 
     async def test_tier3_critical_alert_fires(self, valid_key: str) -> None:
         fired: list[Alert] = []

--- a/tests/test_presidio_scanner.py
+++ b/tests/test_presidio_scanner.py
@@ -377,7 +377,7 @@ class TestPresidioScannerIntegration:
         return PresidioScanner()
 
     def test_detect_email(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("Contact us at john@example.com for details")
         )
         assert result.error is None
@@ -389,7 +389,7 @@ class TestPresidioScannerIntegration:
         assert f.matched_text == "john@example.com"
 
     def test_detect_phone(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("Call me at 555-123-4567")
         )
         assert result.error is None
@@ -397,7 +397,7 @@ class TestPresidioScannerIntegration:
         assert len(phone_findings) > 0
 
     def test_detect_person(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("My name is John Smith and I live in New York")
         )
         assert result.error is None
@@ -405,7 +405,7 @@ class TestPresidioScannerIntegration:
         assert len(persons) > 0
 
     def test_detect_credit_card(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("My credit card is 4111-1111-1111-1111")
         )
         assert result.error is None
@@ -414,38 +414,38 @@ class TestPresidioScannerIntegration:
         assert cc[0].severity == Severity.CRITICAL
 
     def test_no_pii_clean(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("The weather is nice today")
         )
         assert result.error is None
         assert len(result.findings) == 0
 
     def test_empty_text(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan(""))
+        result = asyncio.run(scanner.scan(""))
         assert result.error is None
         assert len(result.findings) == 0
 
     def test_position_accuracy(self, scanner: PresidioScanner) -> None:
         text = "Email john@example.com now"
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+        result = asyncio.run(scanner.scan(text))
         for f in result.findings:
             if f.position is not None and f.matched_text is not None:
                 assert text[f.position.start : f.position.end] == f.matched_text
 
     def test_confidence_range(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("john@example.com, 555-1234, John Smith")
         )
         for f in result.findings:
             assert 0.0 < f.confidence <= 1.0
 
     def test_duration_tracked(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan("john@example.com"))
+        result = asyncio.run(scanner.scan("john@example.com"))
         assert result.duration_ms > 0
 
     def test_score_threshold_filtering(self) -> None:
         scanner = PresidioScanner(score_threshold=0.9)
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("Maybe John from somewhere")
         )
         assert result.error is None
@@ -454,7 +454,7 @@ class TestPresidioScannerIntegration:
 
     def test_custom_entities_filter(self) -> None:
         scanner = PresidioScanner(entities=["EMAIL_ADDRESS"])
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("John at john@example.com")
         )
         assert result.error is None
@@ -462,14 +462,14 @@ class TestPresidioScannerIntegration:
             assert "email" in f.rule_id
 
     def test_multi_finding_message(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(
+        result = asyncio.run(
             scanner.scan("Contact John Smith at john@example.com or 555-123-4567")
         )
         assert result.error is None
         assert len(result.findings) >= 2
 
     def test_scanner_name_in_findings(self, scanner: PresidioScanner) -> None:
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan("john@example.com"))
+        result = asyncio.run(scanner.scan("john@example.com"))
         for f in result.findings:
             assert f.scanner_name == "presidio"
 
@@ -483,7 +483,7 @@ class TestAnonymizeIntegration:
         hash_key: str | None = None,
     ) -> str:
         scanner = PresidioScanner()
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+        result = asyncio.run(scanner.scan(text))
         return anonymize(
             text,
             list(result.findings),
@@ -512,7 +512,7 @@ class TestAnonymizeIntegration:
     def test_mask_shows_trailing(self) -> None:
         text = "SSN is 123-45-6789"
         scanner = PresidioScanner()
-        result = asyncio.get_event_loop().run_until_complete(scanner.scan(text))
+        result = asyncio.run(scanner.scan(text))
         ssn_findings = [f for f in result.findings if f.position is not None]
         if ssn_findings:
             masked = anonymize(text, list(result.findings), mode="mask")

--- a/tests/test_presidio_scanner.py
+++ b/tests/test_presidio_scanner.py
@@ -377,9 +377,7 @@ class TestPresidioScannerIntegration:
         return PresidioScanner()
 
     def test_detect_email(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("Contact us at john@example.com for details")
-        )
+        result = asyncio.run(scanner.scan("Contact us at john@example.com for details"))
         assert result.error is None
         assert len(result.findings) > 0
         emails = [f for f in result.findings if "email" in f.rule_id]
@@ -389,34 +387,26 @@ class TestPresidioScannerIntegration:
         assert f.matched_text == "john@example.com"
 
     def test_detect_phone(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("Call me at 555-123-4567")
-        )
+        result = asyncio.run(scanner.scan("Call me at 555-123-4567"))
         assert result.error is None
         phone_findings = [f for f in result.findings if "phone" in f.rule_id]
         assert len(phone_findings) > 0
 
     def test_detect_person(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("My name is John Smith and I live in New York")
-        )
+        result = asyncio.run(scanner.scan("My name is John Smith and I live in New York"))
         assert result.error is None
         persons = [f for f in result.findings if "person" in f.rule_id]
         assert len(persons) > 0
 
     def test_detect_credit_card(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("My credit card is 4111-1111-1111-1111")
-        )
+        result = asyncio.run(scanner.scan("My credit card is 4111-1111-1111-1111"))
         assert result.error is None
         cc = [f for f in result.findings if "credit_card" in f.rule_id]
         assert len(cc) > 0
         assert cc[0].severity == Severity.CRITICAL
 
     def test_no_pii_clean(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("The weather is nice today")
-        )
+        result = asyncio.run(scanner.scan("The weather is nice today"))
         assert result.error is None
         assert len(result.findings) == 0
 
@@ -433,9 +423,7 @@ class TestPresidioScannerIntegration:
                 assert text[f.position.start : f.position.end] == f.matched_text
 
     def test_confidence_range(self, scanner: PresidioScanner) -> None:
-        result = asyncio.run(
-            scanner.scan("john@example.com, 555-1234, John Smith")
-        )
+        result = asyncio.run(scanner.scan("john@example.com, 555-1234, John Smith"))
         for f in result.findings:
             assert 0.0 < f.confidence <= 1.0
 
@@ -445,18 +433,14 @@ class TestPresidioScannerIntegration:
 
     def test_score_threshold_filtering(self) -> None:
         scanner = PresidioScanner(score_threshold=0.9)
-        result = asyncio.run(
-            scanner.scan("Maybe John from somewhere")
-        )
+        result = asyncio.run(scanner.scan("Maybe John from somewhere"))
         assert result.error is None
         for f in result.findings:
             assert f.confidence >= 0.9
 
     def test_custom_entities_filter(self) -> None:
         scanner = PresidioScanner(entities=["EMAIL_ADDRESS"])
-        result = asyncio.run(
-            scanner.scan("John at john@example.com")
-        )
+        result = asyncio.run(scanner.scan("John at john@example.com"))
         assert result.error is None
         for f in result.findings:
             assert "email" in f.rule_id


### PR DESCRIPTION
## Summary
- Catch `BaseException` (not just `Exception`) in audit and alerting callback handlers — prevents `KeyboardInterrupt`, `SystemExit`, `CancelledError` from escaping the pipeline
- Replace per-session audit sequence counters with a global monotonic counter — immune to TTL-prune reset vulnerability (AUD-01)
- Add cross-session burst tracker dict alongside ring buffer for accurate distinct session counting under eviction (ALRT-03)

## Layered defense
Three layers protect against callback exceptions:
1. **Module level** (audit.py/alerting.py): `except BaseException` catches and logs, stores error for pipeline to read
2. **Pipeline hook level** (pipeline.py Stages 10-11): `except Exception` as belt-and-suspenders for non-callback errors
3. **Boundary level** (pipeline.py `inspect()`): PET-48's `except BaseException` at the outermost handler

## Files changed

| File | Change |
|------|--------|
| `petasos/premium/audit.py` | Callback catch BaseException + global sequence + logger + `last_callback_error` property |
| `petasos/premium/alerting.py` | Callback catch BaseException + cross-session tracker + logger + `callback_errors` property |
| `petasos/pipeline.py` | Read callback errors via properties, append to PipelineResult.errors |
| `tests/adversarial/pipeline/test_callback_isolation.py` | New — 15 adversarial tests (3 per finding) |
| `tests/test_audit.py` | Update 6 tests for global sequence + callback swallowing |
| `tests/test_alerting.py` | Update 1 test for callback swallowing |
| `tests/test_premium_integration.py` | Update 2 tests for new error format |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/adversarial/pipeline/test_callback_isolation.py tests/test_audit.py tests/test_alerting.py -v` — 102/102 pass (full output: docs/specs/TODO/PET-53.test-output.txt)
- [x] Full test suite — 772 passed, 0 failed (2 benchmark errors pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exceptions from audit and alert callbacks are now swallowed, recorded, and surfaced in pipeline results without interrupting processing.
  * Cross-session burst counting fixed to prevent stale counts and unbounded memory growth.

* **Refactor**
  * Audit sequence numbering made globally monotonic for consistent ordering across sessions.
  * Alert/audit callback failures are captured for reporting instead of being raised.

* **Tests**
  * New and updated tests for callback isolation, error propagation, burst-tracking, sequencing, and async scanner execution.

* **Documentation**
  * Added pytest run output artifact documenting test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->