### PR TITLE
test(pet-14-brief-7): callback isolation adversarial regression tests (AUD-01/02, ALRT-03/04)

### DIFF
--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -13,6 +13,15 @@ from petasos.premium.alerting import AlertManager
 from petasos.premium.frequency import FrequencyUpdateResult
 
 
+class _AlertCallbackKill(BaseException):
+    """A BaseException (not an Exception) raised by an on_alert callback.
+
+    Proves evaluate() isolates BaseException subclasses, not just Exception —
+    the pre-fix code caught only ``Exception`` and re-raised, so this would have
+    propagated straight through inspect().
+    """
+
+
 def _cfg(**overrides: object) -> PetasosConfig:
     defaults: dict[str, object] = {
         "alert_enabled": True,
@@ -924,3 +933,173 @@ class TestSessionContributionCap:
             alerts = mgr.evaluate(r, "fresh-session", None)
             hsf = [a for a in alerts if a.rule_id == "high_severity_finding"]
             assert len(hsf) == 1
+
+
+# ---------------------------------------------------------------------------
+# ALRT-03 (PET-18) — cross_session_burst counts distinct sessions accurately
+# even when the ring buffer evicts entries under flood.
+#
+# The pre-fix detector counted distinct sessions from the maxlen ring buffer
+# (`recent_sessions = {sid for ts, sid in buf ...}`), so padding the buffer with
+# duplicate sessions evicted the distinct ones and the count fell below the
+# threshold (or reported a truncated count). The fix tracks session -> last_seen
+# in a separate LRU-capped dict. Each test FAILS pre-fix / PASSES post-fix.
+#
+# Note: config enforces alert_cross_session_burst_count <= alert_ring_buffer_capacity,
+# so these tests stay within that invariant and exploit eviction directly.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSessionBurstAdversarial:
+    def test_burst_survives_ring_eviction_padding(self) -> None:
+        # ring capacity == threshold == 3. Interleave a repeated padding session
+        # so that no single evaluate ever holds 3 distinct sessions in the ring,
+        # yet 4 distinct sessions (s1, pad, s2, s3) appear within the window.
+        mgr = AlertManager(
+            _cfg(
+                alert_ring_buffer_capacity=3,
+                alert_cross_session_burst_count=3,
+                alert_cross_session_burst_window_seconds=600.0,
+                alert_rapid_fire_count=3,
+                alert_cooldown_seconds=0.001,
+                alert_per_minute_cap=50,
+                alert_per_hour_cap=50,
+                alert_per_session_contribution_cap=50,
+            )
+        )
+        r = _result(findings=(_finding(severity=Severity.LOW),))
+        sequence = ["s1", "pad", "pad", "s2", "pad", "pad", "s3"]
+        fired: list[Alert] = []
+        for sid in sequence:
+            alerts = mgr.evaluate(r, sid, None)
+            fired.extend(a for a in alerts if a.rule_id == "cross_session_burst")
+
+        # Pre-fix: ring-only count never reaches 3 -> no burst -> fired == [].
+        assert len(fired) >= 1
+        assert fired[0].context["distinct_sessions"] >= 3
+
+    def test_burst_reports_accurate_count_under_flood(self) -> None:
+        # 100 distinct sessions, ring capacity 60 (< 100). Pre-fix would report
+        # at most 60 distinct (ring maxlen); the fix reports the true 100.
+        mgr = AlertManager(
+            _cfg(
+                alert_ring_buffer_capacity=60,
+                alert_cross_session_burst_count=50,
+                alert_cross_session_burst_window_seconds=600.0,
+                alert_cooldown_seconds=0.001,
+                alert_per_minute_cap=500,
+                alert_per_hour_cap=500,
+                alert_per_session_contribution_cap=500,
+            )
+        )
+        r = _result(findings=(_finding(severity=Severity.LOW),))
+        last_burst: Alert | None = None
+        for i in range(100):
+            alerts = mgr.evaluate(r, f"sess-{i}", None)
+            for a in alerts:
+                if a.rule_id == "cross_session_burst":
+                    last_burst = a
+
+        assert last_burst is not None
+        # Pre-fix ring-only count is capped at maxlen (60); fix reports 100.
+        assert last_burst.context["distinct_sessions"] == 100
+
+    def test_cross_session_tracker_lru_capped(self) -> None:
+        # Flood far more distinct sessions than the tracker bound; the dict must
+        # stay capped at max(2 * ring_capacity, burst_count) and not grow O(n).
+        cap = 60
+        mgr = AlertManager(
+            _cfg(
+                alert_ring_buffer_capacity=cap,
+                alert_cross_session_burst_count=50,
+                alert_cross_session_burst_window_seconds=600.0,
+                alert_cooldown_seconds=0.001,
+                alert_per_minute_cap=500,
+                alert_per_hour_cap=500,
+                alert_per_session_contribution_cap=500,
+            )
+        )
+        r = _result(findings=(_finding(severity=Severity.LOW),))
+        for i in range(1000):
+            mgr.evaluate(r, f"flood-{i}", None)
+
+        # Pre-fix: no _cross_session_tracker attribute (AttributeError).
+        expected_cap = max(2 * cap, 50)
+        assert len(mgr._cross_session_tracker) <= expected_cap
+
+
+# ---------------------------------------------------------------------------
+# ALRT-04 (PET-19) — on_alert callback failures never reach the pipeline,
+# including under a critical-tier flood.
+#
+# The pre-fix evaluate() re-raised callback failures as RuntimeError (and caught
+# only Exception, so BaseException escaped). Post-fix swallows BaseException,
+# logs with exc_info, and accumulates the error in callback_errors for the
+# pipeline hook to fold into PipelineResult.errors. Each test FAILS pre-fix.
+# ---------------------------------------------------------------------------
+
+
+class TestAlertCallbackIsolationAdversarial:
+    def test_evaluate_swallows_baseexception_subclass(self) -> None:
+        def bad_cb(_: Alert) -> None:
+            raise _AlertCallbackKill("base-level kill")
+
+        mgr = AlertManager(_cfg(), on_alert=bad_cb)
+        r = _result(findings=(_finding(severity=Severity.HIGH),))
+        # Pre-fix caught only Exception, so this BaseException propagated.
+        alerts = mgr.evaluate(r, "s1", None)
+        assert len(alerts) >= 1
+        assert len(mgr.callback_errors) >= 1
+        assert "_AlertCallbackKill" in mgr.callback_errors[0]
+
+    def test_evaluate_never_raises_under_critical_flood(self) -> None:
+        call_count = 0
+
+        def bad_cb(_: Alert) -> None:
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("on_alert boom under flood")
+
+        mgr = AlertManager(_cfg(alert_critical_per_minute_cap=100), on_alert=bad_cb)
+        fr = _freq(previous_score=35.0, current_score=55.0, tier="tier3")
+        total_errors = 0
+        for i in range(50):
+            # Pre-fix: the first surviving critical alert re-raises and this
+            # loop blows up. Post-fix: every callback failure is contained.
+            alerts = mgr.evaluate(_result(), f"s{i}", fr)
+            total_errors += len(mgr.callback_errors)
+            assert all(a.rule_id == "tier_escalation" for a in alerts)
+        assert call_count > 0
+        assert total_errors > 0
+
+    def test_callback_errors_reset_per_evaluate(self) -> None:
+        state = {"fail": True}
+
+        def cb(_: Alert) -> None:
+            if state["fail"]:
+                raise RuntimeError("first evaluate fails")
+
+        mgr = AlertManager(_cfg(alert_cooldown_seconds=0.001), on_alert=cb)
+        r = _result(findings=(_finding(severity=Severity.HIGH),))
+        mgr.evaluate(r, "s1", None)
+        assert len(mgr.callback_errors) >= 1
+
+        state["fail"] = False
+        mgr.evaluate(r, "s2", None)
+        # A clean evaluate must not carry the prior call's errors forward.
+        assert mgr.callback_errors == ()
+
+    def test_surviving_alerts_unaffected_by_callback_failure(self) -> None:
+        def raising_cb(_: Alert) -> None:
+            raise RuntimeError("on_alert always fails")
+
+        good_received: list[Alert] = []
+        good = AlertManager(_cfg(), on_alert=good_received.append)
+        bad = AlertManager(_cfg(), on_alert=raising_cb)
+        r = _result(findings=(_finding(severity=Severity.HIGH),))
+
+        good_alerts = good.evaluate(r, "s1", None)
+        bad_alerts = bad.evaluate(r, "s1", None)
+        # The returned alert set is identical whether or not the callback raised.
+        assert [a.rule_id for a in bad_alerts] == [a.rule_id for a in good_alerts]
+        assert len(bad.callback_errors) == len(good_alerts)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from types import MappingProxyType
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +10,15 @@ from petasos._types import AuditEvent, PipelineResult, ScanFinding, ScanResult, 
 from petasos.config import PetasosConfig
 from petasos.premium.audit import AuditEmitter
 from petasos.premium.frequency import FrequencyUpdateResult
+
+
+class _AuditCallbackKill(BaseException):
+    """A BaseException (not an Exception) raised by a callback.
+
+    Used to prove emit() isolates BaseException subclasses, not just Exception —
+    the pre-fix code caught only ``Exception`` and re-raised, so this would have
+    propagated straight through inspect().
+    """
 
 
 def _cfg(**overrides: object) -> PetasosConfig:
@@ -324,3 +334,128 @@ class TestEdgeCases:
         assert e2.sequence_number == 1
         assert e3.sequence_number == 2
         assert emitter._global_sequence == 3
+
+
+# ---------------------------------------------------------------------------
+# AUD-01 (PET-20) — sequence chain survives session churn / TTL prune
+#
+# Regression for: "Reuse session_id after TTL prune -> sequence_number resets
+# to 0". The pre-fix emitter kept a per-session counter pruned on TTL, so a
+# reconnecting session restarted at 0 and the cross-session sequence had
+# duplicate values. The global monotonic counter is immune. Each test below
+# FAILS against the pre-fix per-session implementation and PASSES post-fix.
+# ---------------------------------------------------------------------------
+
+
+class TestSequenceAdversarial:
+    def test_reconnect_after_session_churn_no_reset(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        first = emitter.emit(_result(), "agent-A", None)
+        for i in range(50):
+            emitter.emit(_result(), f"churn-{i}", None)
+        again = emitter.emit(_result(), "agent-A", None)
+
+        assert first.sequence_number == 0
+        # Pre-fix (per-session counter) would give agent-A its own seq == 1 here.
+        assert again.sequence_number == 51
+        assert again.sequence_number > first.sequence_number
+
+    def test_sequence_globally_unique_under_session_reuse(self) -> None:
+        emitter = AuditEmitter(_cfg())
+        seqs: list[int] = []
+        for _ in range(4):
+            for sid in ("a", "b", "c"):
+                seqs.append(emitter.emit(_result(), sid, None).sequence_number)
+
+        # Pre-fix per-session counters produce duplicates ([0,0,0,1,1,1,...]).
+        assert len(set(seqs)) == len(seqs)
+        assert seqs == sorted(seqs)
+        assert seqs == list(range(12))
+
+    def test_sequence_does_not_reset_after_ttl_prune(self) -> None:
+        # Literal AUD-01 attack: let a session's TTL elapse (which pre-fix would
+        # prune), churn other sessions, then reconnect the original session_id.
+        emitter = AuditEmitter(_cfg(session_ttl_seconds=10.0))
+        with patch("petasos.premium.audit.time") as mock_time:
+            mock_time.time.return_value = 2000.0
+
+            mock_time.monotonic.return_value = 1000.0
+            first = emitter.emit(_result(), "agent-A", None)
+
+            # Advance well past the TTL while other sessions emit.
+            mock_time.monotonic.return_value = 1000.0 + 100.0
+            for i in range(5):
+                emitter.emit(_result(), f"churn-{i}", None)
+
+            # agent-A reconnects after its counter would have been pruned.
+            again = emitter.emit(_result(), "agent-A", None)
+
+        assert first.sequence_number == 0
+        # Pre-fix: pruned counter -> reconnect restarts at 0.
+        assert again.sequence_number == 6
+        assert again.sequence_number > first.sequence_number
+
+
+# ---------------------------------------------------------------------------
+# AUD-02 (PET-21) — on_audit callback failures never reach the pipeline
+#
+# Regression for: "on_audit raises RuntimeError -> propagates to pipeline,
+# breaking the never-throws invariant". The pre-fix emit() re-raised as
+# RuntimeError (and caught only Exception, so BaseException escaped entirely).
+# Post-fix swallows BaseException, logs with exc_info, and records the error
+# in last_callback_error for the pipeline hook to fold into PipelineResult.errors.
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackIsolationAdversarial:
+    def test_emit_does_not_raise_on_runtimeerror_callback(self) -> None:
+        def bad_cb(_: AuditEvent) -> None:
+            raise RuntimeError("on_audit boom")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        # Pre-fix this call raised RuntimeError; the assertions below were never
+        # reached. Post-fix it returns normally.
+        event = emitter.emit(_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "RuntimeError" in emitter.last_callback_error
+        assert "on_audit boom" in emitter.last_callback_error
+
+    def test_emit_swallows_baseexception_subclass(self) -> None:
+        def bad_cb(_: AuditEvent) -> None:
+            raise _AuditCallbackKill("base-level kill")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        # Pre-fix caught only Exception, so this BaseException propagated.
+        event = emitter.emit(_result(), "s1", None)
+        assert event is not None
+        assert emitter.last_callback_error is not None
+        assert "_AuditCallbackKill" in emitter.last_callback_error
+
+    def test_callback_error_cleared_on_next_success(self) -> None:
+        state = {"fail": True}
+
+        def cb(_: AuditEvent) -> None:
+            if state["fail"]:
+                raise RuntimeError("first emit fails")
+
+        emitter = AuditEmitter(_cfg(), on_audit=cb)
+        emitter.emit(_result(), "s1", None)
+        assert emitter.last_callback_error is not None
+
+        state["fail"] = False
+        emitter.emit(_result(), "s1", None)
+        # A clean emit must not carry the prior error into PipelineResult.errors.
+        assert emitter.last_callback_error is None
+
+    def test_sequence_advances_despite_callback_failure(self) -> None:
+        def bad_cb(_: AuditEvent) -> None:
+            raise RuntimeError("always boom")
+
+        emitter = AuditEmitter(_cfg(), on_audit=bad_cb)
+        e1 = emitter.emit(_result(), "s1", None)
+        e2 = emitter.emit(_result(), "s1", None)
+        # The event is still fully formed and the chain advances even though the
+        # callback failed on every emit.
+        assert e1.sequence_number == 0
+        assert e2.sequence_number == 1


### PR DESCRIPTION
## PET-14 Brief 7 · Callback Isolation — adversarial regression tests

**Scope:** `tests/test_audit.py` and `tests/test_alerting.py` only. No production code changes; `pipeline.py` untouched.

### Context — the production fixes already shipped

The four findings in Brief 7's remaining scope were remediated in **PET-53 (#42, `dee93f5`)** "callback isolation for audit/alerting subsystems". This PR does **not** re-implement them — it adds the dedicated adversarial regression tests that Brief 7's acceptance criteria require (≥3 per finding, each FAILing pre-fix and PASSing post-fix), which the original PR did not fully cover for the headline attack scenarios.

Verified the shipped code matches each prescribed remediation:

| Finding | Plane | Remediation (shipped in PET-53) | Location |
|---|---|---|---|
| AUD-02 | PET-21 | `emit()` catches `BaseException`, logs w/ `exc_info`, records `last_callback_error` — no re-raise | `audit.py:59-68` |
| AUD-01 | PET-20 | single `_global_sequence` monotonic counter; per-session counter + `_prune_stale` removed | `audit.py:30,44,57` |
| ALRT-04 | PET-19 | `evaluate()` callback path catches `BaseException`, logs, appends `callback_errors` | `alerting.py:167-179` |
| ALRT-03 | PET-18 | `_cross_session_tracker: dict[str,float]` counts distinct sessions independent of ring eviction; LRU-capped at `max(2×capacity, threshold)` | `alerting.py:53,293-344` |

PIPE-06 wiring confirmed (read-only): `pipeline.py:615-629` folds `last_callback_error` / `callback_errors` into `PipelineResult.errors`, so no callback exception reaches `inspect()`.

### Tests added (14)

- **ALRT-03 (3):** burst survives a ring-eviction *padding* attack (4 distinct sessions, capacity 3); reports accurate distinct count under a 100-session flood where the old ring-only count truncated to `maxlen`; tracker dict stays LRU-capped under a 1000-session flood.
- **ALRT-04 (4):** `BaseException` subclass swallowed; `evaluate()` never raises under a 50× critical-tier flood; `callback_errors` reset per call; surviving alerts identical with/without a failing callback.
- **AUD-01 (3):** sequence survives 50-session churn (reconnect → 51, not per-session 1); globally unique under session reuse; no reset after a simulated TTL-prune window.
- **AUD-02 (4):** `emit()` does not raise on a `RuntimeError` callback; `BaseException` subclass swallowed; `last_callback_error` cleared on the next clean emit; sequence still advances when the callback always fails.

### Evidence — FAIL pre-fix / PASS post-fix

Restored the pre-PET-53 sources (`git checkout dee93f5^ -- petasos/premium/audit.py petasos/premium/alerting.py`) and re-ran the new tests:

```
pre-fix:  14 failed   (RuntimeError propagation, count/sequence AssertionError, AttributeError on tracker)
post-fix: 14 passed
```

### Gate

```
ruff check         → All checks passed
mypy --strict      → Success: no issues found
pytest (owned)     → 101 passed
```
(Run in an isolated worktree against clean `master` + PET-53; repo-wide red on other paths is from sibling PET-14 briefs in flight, not this change.)

### Plane (close on merge)

PET-18 (ALRT-03), PET-19 (ALRT-04), PET-20 (AUD-01), PET-21 (AUD-02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for alerting and audit systems with adversarial edge-case scenarios, including callback isolation validation and session state management under stress conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vigil-Harbor/Petasos/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->