### PR TITLE
feat(pet-77): block message formatting utility for model context

### DIFF
--- a/docs/specs/TODO/PET-77.test-output.txt
+++ b/docs/specs/TODO/PET-77.test-output.txt
@@ -1,0 +1,31 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-77-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 20 items
+
+tests/test_formatting.py::TestTier3BlockMessage::test_tier3_block_message PASSED [  5%]
+tests/test_formatting.py::TestTier2BlockMessage::test_tier2_block_message PASSED [ 10%]
+tests/test_formatting.py::TestInvalidToolNameBlockMessage::test_invalid_tool_name_block_message PASSED [ 15%]
+tests/test_formatting.py::TestParamScanUnsafe::test_param_scan_unsafe_block_message PASSED [ 20%]
+tests/test_formatting.py::TestParamScanUnsafe::test_param_scan_unsafe_allowed_true PASSED [ 25%]
+tests/test_formatting.py::TestCatchAllBlock::test_catch_all_block_unknown_reason PASSED [ 30%]
+tests/test_formatting.py::TestPipelineBlockMessage::test_pipeline_block_message PASSED [ 35%]
+tests/test_formatting.py::TestPipelineBlockMessage::test_pipeline_safe_returns_empty PASSED [ 40%]
+tests/test_formatting.py::TestNoBlockReturnsEmpty::test_allowed_no_unsafe_returns_empty PASSED [ 45%]
+tests/test_formatting.py::TestNoBlockReturnsEmpty::test_tier1_no_unsafe_returns_empty PASSED [ 50%]
+tests/test_formatting.py::TestShortenRuleId::test_strips_prefix PASSED   [ 55%]
+tests/test_formatting.py::TestShortenRuleId::test_passthrough PASSED     [ 60%]
+tests/test_formatting.py::TestTopFindingSelection::test_selects_highest_severity PASSED [ 65%]
+tests/test_formatting.py::TestTopFindingSelection::test_additional_findings_count_plural PASSED [ 70%]
+tests/test_formatting.py::TestTopFindingSelection::test_additional_findings_count_singular PASSED [ 75%]
+tests/test_formatting.py::TestTopFindingSelection::test_no_findings_no_clause PASSED [ 80%]
+tests/test_formatting.py::TestInternalReasonStrings::test_internal_reason_strings_not_in_output PASSED [ 85%]
+tests/test_formatting.py::TestMessageLimits::test_worst_case_under_200_words PASSED [ 90%]
+tests/test_formatting.py::TestMessageLimits::test_long_finding_message_truncated PASSED [ 95%]
+tests/test_formatting.py::TestMessageLimits::test_severity_displayed_uppercase PASSED [100%]
+
+============================= 20 passed in 0.04s ==============================

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -16,6 +16,11 @@ from petasos.pipeline import Pipeline
 from petasos.premium.alerting import AlertManager
 from petasos.premium.audit import AuditEmitter
 from petasos.premium.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
+from petasos.premium.formatting import (
+    format_block_message,
+    format_pipeline_block_message,
+    shorten_rule_id,
+)
 from petasos.premium.guard import GuardResult, ToolCallGuard
 from petasos.premium.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
 from petasos.premium.profiles import ProfileResolver, ResolvedProfile, TierThresholds
@@ -30,6 +35,8 @@ __all__ = [
     "FrequencyTracker",
     "FrequencyUpdateResult",
     "GuardResult",
+    "format_block_message",
+    "format_pipeline_block_message",
     "LicenseClaims",
     "LicenseState",
     "LicenseValidator",
@@ -50,6 +57,7 @@ __all__ = [
     "TierThresholds",
     "ToolCallGuard",
     "normalize",
+    "shorten_rule_id",
     "validate_license",
 ]
 

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -15,12 +15,12 @@ from petasos.normalize import normalize
 from petasos.pipeline import Pipeline
 from petasos.premium.alerting import AlertManager
 from petasos.premium.audit import AuditEmitter
-from petasos.premium.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
 from petasos.premium.formatting import (
     format_block_message,
     format_pipeline_block_message,
     shorten_rule_id,
 )
+from petasos.premium.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
 from petasos.premium.guard import GuardResult, ToolCallGuard
 from petasos.premium.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
 from petasos.premium.profiles import ProfileResolver, ResolvedProfile, TierThresholds

--- a/petasos/premium/__init__.py
+++ b/petasos/premium/__init__.py
@@ -8,6 +8,11 @@ from petasos.premium.escalation import (
     evaluate_escalation,
     evaluate_tier,
 )
+from petasos.premium.formatting import (
+    format_block_message,
+    format_pipeline_block_message,
+    shorten_rule_id,
+)
 from petasos.premium.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
 from petasos.premium.guard import GuardResult, ToolCallGuard
 from petasos.premium.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
@@ -27,6 +32,8 @@ __all__ = [
     "derive_tier",
     "FrequencyUpdateResult",
     "GuardResult",
+    "format_block_message",
+    "format_pipeline_block_message",
     "LicenseClaims",
     "LicenseState",
     "LicenseValidator",
@@ -38,5 +45,6 @@ __all__ = [
     "ToolCallGuard",
     "evaluate_escalation",
     "evaluate_tier",
+    "shorten_rule_id",
     "validate_license",
 ]

--- a/petasos/premium/formatting.py
+++ b/petasos/premium/formatting.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from petasos._types import PipelineResult, ScanFinding, Severity
+
+if TYPE_CHECKING:
+    from petasos.premium.guard import GuardResult
+
+_SEVERITY_RANK: dict[Severity, int] = {
+    Severity.CRITICAL: 0,
+    Severity.HIGH: 1,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 3,
+    Severity.INFO: 4,
+}
+
+_STRIP_PREFIX = "petasos.syntactic."
+
+_PREFIX = "[BLOCKED by Petasos]"
+
+_MAX_MESSAGE_LEN = 200
+
+
+def shorten_rule_id(rule_id: str) -> str:
+    if rule_id.startswith(_STRIP_PREFIX):
+        return rule_id[len(_STRIP_PREFIX) :]
+    return rule_id
+
+
+def _top_finding_clause(findings: tuple[ScanFinding, ...]) -> str:
+    if not findings:
+        return ""
+
+    top = min(findings, key=lambda f: _SEVERITY_RANK.get(f.severity, 999))
+
+    short_id = shorten_rule_id(top.rule_id)
+    severity = top.severity.name
+
+    message = top.message
+    if len(message) > _MAX_MESSAGE_LEN:
+        message = message[:_MAX_MESSAGE_LEN] + "…"
+
+    clause = f'Top finding: {short_id} ({severity}) — "{message}".'
+
+    extra = len(findings) - 1
+    if extra == 1:
+        clause += " (+1 additional finding)"
+    elif extra > 1:
+        clause += f" (+{extra} additional findings)"
+
+    return clause
+
+
+def format_block_message(result: GuardResult, tool_name: str) -> str:
+    if result.tier == "tier3":
+        return (
+            f"{_PREFIX} Tool '{tool_name}' was NOT executed. "
+            "Session terminated (tier3) — escalation threshold exceeded. "
+            "All tool calls are blocked for this session."
+        )
+
+    if not result.allowed and result.tier == "tier2":
+        clause = _top_finding_clause(result.findings)
+        msg = (
+            f"{_PREFIX} Tool '{tool_name}' was NOT executed."
+            " Session under enhanced scrutiny (tier2)."
+        )
+        if clause:
+            msg += " " + clause
+        return msg
+
+    if not result.allowed and "invalid tool name" in result.reason:
+        return (
+            f"{_PREFIX} Tool call rejected — tool name invalid "
+            "after normalization. Call was NOT executed."
+        )
+
+    if result.param_scan_unsafe:
+        clause = _top_finding_clause(result.findings)
+        msg = (
+            f"{_PREFIX} Tool '{tool_name}' was NOT executed. "
+            "Injection pattern detected in parameters."
+        )
+        if clause:
+            msg += " " + clause
+        return msg
+
+    if not result.allowed:
+        clause = _top_finding_clause(result.findings)
+        msg = f"{_PREFIX} Tool '{tool_name}' was NOT executed."
+        if clause:
+            msg += " " + clause
+        return msg
+
+    return ""
+
+
+def format_pipeline_block_message(result: PipelineResult) -> str:
+    if result.safe:
+        return ""
+
+    clause = _top_finding_clause(result.findings)
+    msg = f"{_PREFIX} Message blocked — content not forwarded."
+    if clause:
+        msg += " " + clause
+    return msg

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from petasos._types import PipelineResult, ScanFinding, Severity
+from petasos.premium.formatting import (
+    format_block_message,
+    format_pipeline_block_message,
+    shorten_rule_id,
+)
+from petasos.premium.guard import GuardResult
+
+_PREFIX = "[BLOCKED by Petasos]"
+
+_INTERNAL_REASONS = [
+    "session terminated (tier3)",
+    "tier2: tool calls blocked",
+    "invalid tool name: empty after normalization",
+    "exempt-with-scan",
+    "tool exempt per profile",
+    "tier1: allowed with warnings",
+    "allowed",
+    "premium inactive",
+]
+
+
+def _finding(
+    *,
+    rule_id: str = "petasos.syntactic.injection.ignore-previous",
+    severity: Severity = Severity.HIGH,
+    message: str = "Injection pattern matched: ignore-previous",
+) -> ScanFinding:
+    return ScanFinding(
+        rule_id=rule_id,
+        finding_type="injection",
+        severity=severity,
+        confidence=0.95,
+        message=message,
+        scanner_name="minimal",
+    )
+
+
+def _guard(
+    *,
+    allowed: bool = False,
+    reason: str = "blocked",
+    findings: tuple[ScanFinding, ...] = (),
+    tier: str = "none",
+    param_scan_unsafe: bool = False,
+) -> GuardResult:
+    return GuardResult(
+        allowed=allowed,
+        reason=reason,
+        findings=findings,
+        tier=tier,
+        param_scan_unsafe=param_scan_unsafe,
+    )
+
+
+class TestTier3BlockMessage:
+    def test_tier3_block_message(self) -> None:
+        result = _guard(tier="tier3", reason="session terminated (tier3)")
+        msg = format_block_message(result, "terminal")
+
+        assert _PREFIX in msg
+        assert "'terminal'" in msg
+        assert "was NOT executed" in msg
+        assert "tier3" in msg
+        assert "All tool calls are blocked" in msg
+        assert "Top finding" not in msg
+
+
+class TestTier2BlockMessage:
+    def test_tier2_block_message(self) -> None:
+        result = _guard(
+            tier="tier2",
+            reason="tier2: tool calls blocked",
+            findings=(_finding(),),
+        )
+        msg = format_block_message(result, "terminal")
+
+        assert _PREFIX in msg
+        assert "'terminal'" in msg
+        assert "was NOT executed" in msg
+        assert "tier2" in msg
+        assert "injection.ignore-previous" in msg
+        assert "(HIGH)" in msg
+        assert "Injection pattern matched" in msg
+
+
+class TestInvalidToolNameBlockMessage:
+    def test_invalid_tool_name_block_message(self) -> None:
+        result = _guard(reason="invalid tool name: empty after normalization")
+        msg = format_block_message(result, "")
+
+        assert _PREFIX in msg
+        assert "tool name invalid" in msg
+        assert "was NOT executed" in msg
+
+
+class TestParamScanUnsafe:
+    def test_param_scan_unsafe_block_message(self) -> None:
+        result = _guard(
+            allowed=False,
+            reason="tier2: tool calls blocked",
+            param_scan_unsafe=True,
+            findings=(_finding(),),
+            tier="tier2",
+        )
+        msg = format_block_message(result, "bash")
+
+        assert _PREFIX in msg
+        assert "was NOT executed" in msg
+
+    def test_param_scan_unsafe_allowed_true(self) -> None:
+        result = _guard(
+            allowed=True,
+            reason="exempt-with-scan",
+            param_scan_unsafe=True,
+            findings=(_finding(),),
+        )
+        msg = format_block_message(result, "bash")
+
+        assert _PREFIX in msg
+        assert "'bash'" in msg
+        assert "was NOT executed" in msg
+        assert "Injection pattern detected in parameters" in msg
+        assert "injection.ignore-previous" in msg
+
+
+class TestCatchAllBlock:
+    def test_catch_all_block_unknown_reason(self) -> None:
+        result = _guard(allowed=False, reason="future_reason", findings=(_finding(),))
+        msg = format_block_message(result, "custom_tool")
+
+        assert _PREFIX in msg
+        assert "'custom_tool'" in msg
+        assert "was NOT executed" in msg
+        assert "injection.ignore-previous" in msg
+
+
+class TestPipelineBlockMessage:
+    def test_pipeline_block_message(self) -> None:
+        result = PipelineResult(safe=False, findings=(_finding(),))
+        msg = format_pipeline_block_message(result)
+
+        assert _PREFIX in msg
+        assert "Message blocked" in msg
+        assert "not forwarded" in msg
+        assert "injection.ignore-previous" in msg
+
+    def test_pipeline_safe_returns_empty(self) -> None:
+        result = PipelineResult(safe=True, findings=())
+        assert format_pipeline_block_message(result) == ""
+
+
+class TestNoBlockReturnsEmpty:
+    def test_allowed_no_unsafe_returns_empty(self) -> None:
+        result = _guard(allowed=True, reason="allowed", param_scan_unsafe=False)
+        assert format_block_message(result, "read") == ""
+
+    def test_tier1_no_unsafe_returns_empty(self) -> None:
+        result = _guard(
+            allowed=True,
+            reason="tier1: allowed with warnings",
+            tier="tier1",
+            param_scan_unsafe=False,
+        )
+        assert format_block_message(result, "read") == ""
+
+
+class TestShortenRuleId:
+    def test_strips_prefix(self) -> None:
+        assert (
+            shorten_rule_id("petasos.syntactic.injection.ignore-previous")
+            == "injection.ignore-previous"
+        )
+
+    def test_passthrough(self) -> None:
+        assert shorten_rule_id("llm_guard.threat") == "llm_guard.threat"
+
+
+class TestTopFindingSelection:
+    def test_selects_highest_severity(self) -> None:
+        findings = (
+            _finding(
+                severity=Severity.LOW,
+                rule_id="petasos.syntactic.encoding.base64-in-text",
+                message="Low",
+            ),
+            _finding(
+                severity=Severity.CRITICAL,
+                rule_id="petasos.syntactic.structural.oversized-payload",
+                message="Critical",
+            ),
+            _finding(severity=Severity.HIGH, message="High"),
+        )
+        result = _guard(
+            findings=findings, param_scan_unsafe=True, allowed=True, reason="exempt-with-scan"
+        )
+        msg = format_block_message(result, "bash")
+
+        assert "structural.oversized-payload" in msg
+        assert "(CRITICAL)" in msg
+
+    def test_additional_findings_count_plural(self) -> None:
+        findings = (
+            _finding(),
+            _finding(severity=Severity.MEDIUM, message="m1"),
+            _finding(severity=Severity.LOW, message="m2"),
+        )
+        result = _guard(
+            findings=findings, param_scan_unsafe=True, allowed=True, reason="exempt-with-scan"
+        )
+        msg = format_block_message(result, "bash")
+
+        assert "(+2 additional findings)" in msg
+
+    def test_additional_findings_count_singular(self) -> None:
+        findings = (_finding(), _finding(severity=Severity.LOW, message="m1"))
+        result = _guard(
+            findings=findings, param_scan_unsafe=True, allowed=True, reason="exempt-with-scan"
+        )
+        msg = format_block_message(result, "bash")
+
+        assert "(+1 additional finding)" in msg
+
+    def test_no_findings_no_clause(self) -> None:
+        result = _guard(tier="tier2", reason="tier2: tool calls blocked")
+        msg = format_block_message(result, "bash")
+
+        assert "Top finding" not in msg
+
+
+class TestInternalReasonStrings:
+    def test_internal_reason_strings_not_in_output(self) -> None:
+        cases = [
+            _guard(tier="tier3", reason="session terminated (tier3)"),
+            _guard(tier="tier2", reason="tier2: tool calls blocked", findings=(_finding(),)),
+            _guard(reason="invalid tool name: empty after normalization"),
+            _guard(
+                allowed=True,
+                reason="exempt-with-scan",
+                param_scan_unsafe=True,
+                findings=(_finding(),),
+            ),
+            _guard(allowed=False, reason="future_reason"),
+        ]
+        for gr in cases:
+            msg = format_block_message(gr, "tool")
+            for reason in _INTERNAL_REASONS:
+                assert reason not in msg, f"Internal string {reason!r} leaked in: {msg}"
+
+
+class TestMessageLimits:
+    def test_worst_case_under_200_words(self) -> None:
+        long_message = "A" * 500
+        findings = tuple(
+            _finding(message=long_message, severity=s)
+            for s in [Severity.HIGH, Severity.MEDIUM, Severity.LOW, Severity.INFO, Severity.INFO]
+        )
+        result = _guard(tier="tier2", reason="tier2: tool calls blocked", findings=findings)
+        msg = format_block_message(result, "terminal")
+
+        assert len(msg.split()) < 200
+
+    def test_long_finding_message_truncated(self) -> None:
+        long_message = "X" * 500
+        result = _guard(
+            param_scan_unsafe=True,
+            allowed=True,
+            reason="exempt-with-scan",
+            findings=(_finding(message=long_message),),
+        )
+        msg = format_block_message(result, "bash")
+
+        assert "X" * 200 in msg
+        assert "…" in msg
+        assert "X" * 201 not in msg
+
+    def test_severity_displayed_uppercase(self) -> None:
+        result = _guard(
+            param_scan_unsafe=True,
+            allowed=True,
+            reason="exempt-with-scan",
+            findings=(_finding(severity=Severity.HIGH),),
+        )
+        msg = format_block_message(result, "bash")
+
+        assert "(HIGH)" in msg
+        assert "(high)" not in msg


### PR DESCRIPTION
## Summary
- Adds `format_block_message()` and `format_pipeline_block_message()` to the Petasos library — transforms `GuardResult`/`PipelineResult` into unambiguous, model-readable block messages
- Every message uses the `[BLOCKED by Petasos]` prefix and explicitly states the tool was NOT executed, preventing model confabulation
- Covers 5 enforcement paths: tier3 termination, tier2 scrutiny, invalid tool name, param-scan-unsafe, and a catch-all for forward compatibility

## Files changed

| File | Change |
|------|--------|
| `petasos/premium/formatting.py` | New — `format_block_message()`, `format_pipeline_block_message()`, `shorten_rule_id()` with severity ranking, rule-id shortening, 200-char message truncation |
| `petasos/__init__.py` | Adds three new public exports |
| `petasos/premium/__init__.py` | Adds three new public exports |
| `tests/test_formatting.py` | 20 tests: one per enforcement path + edge cases (severity selection, singular/plural, internal-string leak, truncation, 200-word guard) |

## Test plan
- [x] `pytest tests/test_formatting.py -v` — 20/20 pass (full output: docs/specs/TODO/PET-77.test-output.txt)
- [x] Full suite: 967 passed, 28 skipped, 1 xfailed, 2 pre-existing benchmark errors
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed premium formatting utilities to the public API and enabled tier-specific blocked messaging with severity ranking and message truncation.

* **Tests**
  * Added a comprehensive test suite validating formatting and guard behavior across many scenarios; test run recorded all tests passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->