### PR TITLE
chore: remove stale work-items references, fix version in deploy doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Petasos is Drawbridge-*inspired* but fully uncoupled — own repo, own ticket pr
 
 ## Status
 
-Greenfield project. The active spec is `petasos-spec.md`; work items are in `petasos-work-items.md`. The file `petasos-project-spec-DRAFT-PARKED.md` is a superseded earlier draft preserved for reference — it proposed Drawbridge coupling that was explicitly rejected.
+Work items tracked in Plane (PET project). The file `petasos-project-spec-DRAFT-PARKED.md` is a superseded earlier draft preserved for reference — it proposed Drawbridge coupling that was explicitly rejected.
 
 ## Build & Run
 
@@ -120,7 +120,7 @@ petasos/
 ## Project Management
 
 - Petasos tracks under the `PET` project in Plane (UUID `5bff6316-84ea-4103-b9e2-4861ac9c226a`).
-- Work items PET-1 through PET-12 are defined in `petasos-work-items.md` with a dependency graph. PET-2 is a parent container; PET-3/4/5 are its children (scanner wrappers).
+- PET-2 is a parent container; PET-3/4/5 are its children (scanner wrappers).
 - When creating Plane work items, set `description_html` (the canonical field).
 - Drawbridge syntactic rules source: `clawmoat-drawbridge-sanitizer/src/validation/index.ts` → `SYNTACTIC_RULES` export.
 - Drawbridge FrequencyTracker source: `clawmoat-drawbridge-sanitizer/src/frequency/index.ts`.

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -14,31 +14,63 @@ Hermes Desktop agent. Covers both macOS and Windows.
 Install Petasos into Hermes's Python environment — not system Python, not
 WSL Python. On Windows the venv lives inside the Hermes install directory.
 
-```bash
-# macOS
-~/.hermes/hermes-agent/venv/bin/pip install petasos
+**macOS:**
 
-# Windows (from Git Bash or PowerShell)
+```bash
+~/.hermes/hermes-agent/venv/bin/pip install petasos
+```
+
+**Windows (PowerShell / cmd):**
+
+```powershell
 %LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe -m pip install petasos
+```
+
+**Windows (Git Bash):**
+
+```bash
+/c/Users/$USER/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m pip install petasos
 ```
 
 For ML scanner backends (LLM Guard, LlamaFirewall, Presidio), install the
 `all` extra. This adds ~300MB of models. The plugin degrades gracefully
 to syntactic-only if these aren't installed.
 
+**macOS:**
+
 ```bash
-pip install "petasos[all]"
+~/.hermes/hermes-agent/venv/bin/pip install "petasos[all]"
 ```
 
-Verify:
+**Windows (PowerShell / cmd):**
+
+```powershell
+%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe -m pip install "petasos[all]"
+```
+
+**Windows (Git Bash):**
 
 ```bash
-python -c "from petasos import Pipeline; from petasos.scanners import MinimalScanner; print('OK')"
+/c/Users/$USER/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe -m pip install "petasos[all]"
+```
+
+Verify the install:
+
+**macOS:**
+
+```bash
+~/.hermes/hermes-agent/venv/bin/python -c "from petasos import Pipeline; from petasos.scanners import MinimalScanner; print('OK')"
+```
+
+**Windows (PowerShell / cmd):**
+
+```powershell
+%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe -c "from petasos import Pipeline; from petasos.scanners import MinimalScanner; print('OK')"
 ```
 
 ## 2. Generate credentials
 
-Three env vars, all generated once per deployment.
+Two env vars, generated once per deployment.
 
 ```bash
 # Session secret (HMAC session binding — prevents session spoofing)
@@ -48,8 +80,9 @@ python -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32
 python -c "import secrets; print(secrets.token_hex(32))"
 ```
 
-The license key is a signed JWT. If you have the Ed25519 private key
-(paired with `petasos/premium/_keys/public.pem`):
+License activation is optional — for supporter/compliance recognition only.
+Features are not gated by it. If you have an Ed25519 private key
+(paired with `petasos/session/_keys/public.pem`):
 
 ```python
 import jwt, time
@@ -68,15 +101,15 @@ token = jwt.encode({
 print(token)
 ```
 
-Add all three to Hermes's `.env` file:
+Add credentials to Hermes's `.env` file:
 
 ```bash
 # macOS: ~/.hermes/.env
 # Windows: %LOCALAPPDATA%\hermes\.env
 
-PETASOS_LICENSE_KEY=eyJhbG...
 PETASOS_SESSION_SECRET=<base64 output>
 PETASOS_HASH_KEY=<hex output>
+# PETASOS_LICENSE_KEY is optional — supporter/compliance recognition only
 ```
 
 These match `*_KEY` / `*_SECRET` patterns so Hermes automatically strips
@@ -90,7 +123,7 @@ a code fork. The plugin runs in-process with zero subprocess overhead.
 
 Create the plugin directory:
 
-```
+```text
 # macOS
 ~/.hermes/plugins/petasos/
 
@@ -134,10 +167,9 @@ Key architectural decisions in the plugin:
   Everything not in that set is treated as dangerous for
   `param_scan_unsafe` enforcement.
 
-- **Graceful degradation.** Missing `PETASOS_LICENSE_KEY` → OSS-only
-  (MinimalScanner, no premium). Missing `PETASOS_SESSION_SECRET` →
-  HMAC binding disabled. Missing config section → defaults (all
-  features disabled). Plugin never crashes Hermes.
+- **Graceful degradation.** Missing `PETASOS_SESSION_SECRET` → HMAC
+  binding disabled. Missing config section → defaults apply (all
+  features enabled as of PET-78). Plugin never crashes Hermes.
 
 ## 4. Enable the plugin
 
@@ -175,7 +207,7 @@ petasos:
   pii_entities: ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD"]
   redaction_mode: "hash"
 
-  # Premium features (all require valid license)
+  # Session features (all default true — no license required)
   frequency_enabled: true
   escalation_enabled: true
   tool_guard_enabled: true
@@ -191,14 +223,14 @@ petasos:
 | `fail_mode` | `"degraded"` | `"closed"` | Degraded is too permissive — blocks on total ML failure but passes on partial |
 | `host_id` | `""` | Set to stable ID | HMAC session binding requires non-empty host_id. Changing it invalidates all session tokens |
 | `anonymize` | `false` | `true` | PII detection + hash anonymization for audit correlation |
-| `frequency_enabled` | `false` | `true` | Per-session frequency tracking and escalation |
-| `tool_guard_enabled` | `false` | `true` | ToolCallGuard evaluation on every tool dispatch |
-| `audit_enabled` | `false` | `true` | Structured audit events to Hermes logger |
 
 ### What stays at defaults
 
 | Key | Default | Why it's fine |
 |-----|---------|---------------|
+| `frequency_enabled` | `true` | Enabled out of the box |
+| `tool_guard_enabled` | `true` | Enabled out of the box |
+| `audit_enabled` | `true` | Enabled out of the box |
 | `scanner_timeout_seconds` | 10.0 | Generous for cold-start, capped at 60 |
 | `tier1_threshold` / `tier2_threshold` | 15.0 / 30.0 | Battle-tested from Drawbridge |
 | `tier3_threshold` | 50.0 | Floor hardcoded at 30.0 — can't go lower |
@@ -213,12 +245,11 @@ close Hermes Desktop entirely and reopen.
 
 Check `agent.log` for the initialization sequence:
 
-```
+```text
 INFO  petasos.plugin: Petasos plugin registered — hooks active, scanner init in background
 INFO  petasos.plugin: LLM Guard scanner loaded
 INFO  petasos.plugin: LlamaFirewall scanner loaded
 INFO  petasos.plugin: Presidio scanner loaded
-INFO  petasos.plugin: Petasos premium activated (enterprise)
 INFO  petasos.plugin: Petasos initialized: scanners=['minimal', 'llm_guard', ...], fail_mode=closed, host_id=...
 INFO  petasos.plugin: PETASOS_SESSION_START — Petasos content security active
 ```
@@ -226,13 +257,20 @@ INFO  petasos.plugin: PETASOS_SESSION_START — Petasos content security active
 A standalone verification script (`verify.py` in the plugin directory)
 checks all components:
 
+**macOS:**
+
 ```bash
-python plugins/petasos/verify.py
+~/.hermes/hermes-agent/venv/bin/python plugins/petasos/verify.py
 ```
 
-Expected output: 7 checks, all PASS (scanner imports, plugin files,
-config validation, env vars, license, premium activation, injection
-detection).
+**Windows (PowerShell / cmd):**
+
+```powershell
+%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe plugins/petasos/verify.py
+```
+
+Expected output: checks for scanner imports, plugin files, config
+validation, env vars, and injection detection — all PASS.
 
 ## 7. What's enforced
 
@@ -284,7 +322,7 @@ Check `agent.log` for `Skipping 'petasos'`:
 
 ### Scanner import failures
 
-```
+```text
 INFO petasos.plugin: LLM Guard not installed — syntactic-only for that backend
 ```
 
@@ -294,12 +332,13 @@ still runs without ML.
 
 ### License invalid
 
-```
+```text
 WARNING petasos.plugin: Petasos license invalid (state=LicenseState.EXPIRED)
 ```
 
-Mint a new JWT. Check that `PETASOS_LICENSE_KEY` in `.env` has no trailing
-whitespace or newlines.
+License is optional — features are not gated by it. If you want
+supporter/compliance recognition, mint a new JWT. Check that
+`PETASOS_LICENSE_KEY` in `.env` has no trailing whitespace or newlines.
 
 ### Config section wiped
 
@@ -309,7 +348,7 @@ update that overwrote the file.
 
 ### ToolCallGuard constructor error
 
-```
+```text
 ERROR petasos.plugin: ToolCallGuard.__init__() missing 2 required positional arguments
 ```
 

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -1,0 +1,325 @@
+# Deploying Petasos on Hermes Desktop
+
+How to go from `pip install petasos` (zero enforcement) to a locked-down
+Hermes Desktop agent. Covers both macOS and Windows.
+
+**Hermes version:** v0.15.0+  
+**Petasos version:** 0.1.0+  
+**Time:** ~15 minutes (plus ML model download on first scan)
+
+---
+
+## 1. Install
+
+Install Petasos into Hermes's Python environment — not system Python, not
+WSL Python. On Windows the venv lives inside the Hermes install directory.
+
+```bash
+# macOS
+~/.hermes/hermes-agent/venv/bin/pip install petasos
+
+# Windows (from Git Bash or PowerShell)
+%LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe -m pip install petasos
+```
+
+For ML scanner backends (LLM Guard, LlamaFirewall, Presidio), install the
+`all` extra. This adds ~300MB of models. The plugin degrades gracefully
+to syntactic-only if these aren't installed.
+
+```bash
+pip install "petasos[all]"
+```
+
+Verify:
+
+```bash
+python -c "from petasos import Pipeline; from petasos.scanners import MinimalScanner; print('OK')"
+```
+
+## 2. Generate credentials
+
+Three env vars, all generated once per deployment.
+
+```bash
+# Session secret (HMAC session binding — prevents session spoofing)
+python -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
+
+# Hash key (PII anonymization — HMAC key for correlatable hashing)
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+The license key is a signed JWT. If you have the Ed25519 private key
+(paired with `petasos/premium/_keys/public.pem`):
+
+```python
+import jwt, time
+from pathlib import Path
+
+private_key = Path("tests/fixtures/test_private.pem").read_bytes()
+now = int(time.time())
+token = jwt.encode({
+    "sub": "your-agent-id",
+    "customer_id": "your-org",
+    "tier": "enterprise",
+    "features": ["frequency", "escalation", "tool_guard", "audit", "alerting"],
+    "iat": now,
+    "exp": now + (365 * 24 * 3600),
+}, private_key, algorithm="EdDSA")
+print(token)
+```
+
+Add all three to Hermes's `.env` file:
+
+```bash
+# macOS: ~/.hermes/.env
+# Windows: %LOCALAPPDATA%\hermes\.env
+
+PETASOS_LICENSE_KEY=eyJhbG...
+PETASOS_SESSION_SECRET=<base64 output>
+PETASOS_HASH_KEY=<hex output>
+```
+
+These match `*_KEY` / `*_SECRET` patterns so Hermes automatically strips
+them from terminal subprocess environments (no credential leakage into
+agent-executed commands).
+
+## 3. Create the plugin
+
+Petasos integrates via Hermes's plugin hook system — not shell hooks, not
+a code fork. The plugin runs in-process with zero subprocess overhead.
+
+Create the plugin directory:
+
+```
+# macOS
+~/.hermes/plugins/petasos/
+
+# Windows
+%LOCALAPPDATA%\hermes\plugins\petasos\
+```
+
+Two files required:
+
+### `plugin.yaml`
+
+```yaml
+name: petasos
+version: 1.0.0
+description: "Content security pipeline — tool call guard, content scanning, audit"
+hooks:
+  - pre_tool_call
+  - post_tool_call
+  - on_session_start
+```
+
+### `__init__.py`
+
+The reference implementation is maintained at
+[`docs/deployment/reference-plugin/`](reference-plugin/) in this repo.
+
+Key architectural decisions in the plugin:
+
+- **Lazy init.** Scanners load in a background thread. The plugin
+  registers hooks and returns immediately so Hermes Desktop doesn't
+  stall on ML model cold-start. Early tool calls during init use
+  MinimalScanner-only (17 regex rules, <1ms).
+
+- **Async bridge.** `ToolCallGuard.evaluate()` is async (it calls
+  `Pipeline.inspect()` for param scanning). Hermes's `invoke_hook()`
+  is sync. The plugin runs a dedicated asyncio event loop in a daemon
+  thread and bridges with `run_coroutine_threadsafe().result()`.
+
+- **Inverted tool coverage.** Instead of enumerating dangerous tools
+  (incomplete — there are 70+), maintain a `READ_ONLY_TOOLS` frozenset.
+  Everything not in that set is treated as dangerous for
+  `param_scan_unsafe` enforcement.
+
+- **Graceful degradation.** Missing `PETASOS_LICENSE_KEY` → OSS-only
+  (MinimalScanner, no premium). Missing `PETASOS_SESSION_SECRET` →
+  HMAC binding disabled. Missing config section → defaults (all
+  features disabled). Plugin never crashes Hermes.
+
+## 4. Enable the plugin
+
+Hermes's plugin loader requires explicit opt-in. Add a `plugins:` section
+to `config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - petasos
+```
+
+**This step is easy to miss.** Without it, the plugin is discovered but
+skipped: `Skipping 'petasos' (not in plugins.enabled)` in the agent log.
+
+## 5. Configure
+
+Add a top-level `petasos:` section to `config.yaml`. This key survives
+Desktop UI model switches (the UI only rewrites the `model:` section).
+
+```yaml
+petasos:
+  enabled: true
+  fail_mode: "closed"
+  host_id: "your-agent-id"
+
+  # Normalization (all default true — listed for visibility)
+  normalize_nfkc: true
+  strip_zero_width: true
+  map_homoglyphs: true
+  detect_rtl_override: true
+
+  # PII anonymization
+  anonymize: true
+  pii_entities: ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD"]
+  redaction_mode: "hash"
+
+  # Premium features (all require valid license)
+  frequency_enabled: true
+  escalation_enabled: true
+  tool_guard_enabled: true
+  audit_enabled: true
+  alert_enabled: true
+  audit_verbosity: "standard"
+```
+
+### Config reference
+
+| Key | Default | Production | Why |
+|-----|---------|------------|-----|
+| `fail_mode` | `"degraded"` | `"closed"` | Degraded is too permissive — blocks on total ML failure but passes on partial |
+| `host_id` | `""` | Set to stable ID | HMAC session binding requires non-empty host_id. Changing it invalidates all session tokens |
+| `anonymize` | `false` | `true` | PII detection + hash anonymization for audit correlation |
+| `frequency_enabled` | `false` | `true` | Per-session frequency tracking and escalation |
+| `tool_guard_enabled` | `false` | `true` | ToolCallGuard evaluation on every tool dispatch |
+| `audit_enabled` | `false` | `true` | Structured audit events to Hermes logger |
+
+### What stays at defaults
+
+| Key | Default | Why it's fine |
+|-----|---------|---------------|
+| `scanner_timeout_seconds` | 10.0 | Generous for cold-start, capped at 60 |
+| `tier1_threshold` / `tier2_threshold` | 15.0 / 30.0 | Battle-tested from Drawbridge |
+| `tier3_threshold` | 50.0 | Floor hardcoded at 30.0 — can't go lower |
+| `session_ttl_seconds` | 3600.0 | 1-hour TTL matches typical chat session |
+| Normalization toggles | all `true` | No reason to disable any |
+
+## 6. Restart and verify
+
+**Full app restart required.** Plugin discovery runs at app startup, not
+per-session. Closing a chat tab and opening a new one is not enough —
+close Hermes Desktop entirely and reopen.
+
+Check `agent.log` for the initialization sequence:
+
+```
+INFO  petasos.plugin: Petasos plugin registered — hooks active, scanner init in background
+INFO  petasos.plugin: LLM Guard scanner loaded
+INFO  petasos.plugin: LlamaFirewall scanner loaded
+INFO  petasos.plugin: Presidio scanner loaded
+INFO  petasos.plugin: Petasos premium activated (enterprise)
+INFO  petasos.plugin: Petasos initialized: scanners=['minimal', 'llm_guard', ...], fail_mode=closed, host_id=...
+INFO  petasos.plugin: PETASOS_SESSION_START — Petasos content security active
+```
+
+A standalone verification script (`verify.py` in the plugin directory)
+checks all components:
+
+```bash
+python plugins/petasos/verify.py
+```
+
+Expected output: 7 checks, all PASS (scanner imports, plugin files,
+config validation, env vars, license, premium activation, injection
+detection).
+
+## 7. What's enforced
+
+When a tool call arrives at `pre_tool_call`:
+
+| Condition | Action | Log marker |
+|-----------|--------|------------|
+| `allowed=False` | Block, return reason to model | `PETASOS_BLOCK` |
+| `allowed=True`, `param_scan_unsafe=True`, non-read-only tool | Block | `PETASOS_QUARANTINE` |
+| `allowed=True`, HIGH/CRITICAL findings, non-read-only tool | Block | `PETASOS_QUARANTINE` |
+| `tier == "tier3"` | Block all subsequent calls for session | `PETASOS_TIER3` |
+| `allowed=True`, clean or read-only tool | Allow | (no log) |
+
+The guard scans tool **parameters** through the full pipeline (normalize →
+syntactic pre-filter → ML fan-out → merge → fail-mode). This catches
+injection payloads smuggled via tool arguments, not just chat messages.
+
+## Platform notes
+
+### macOS
+
+Straightforward. System shell, native Python, no translation layers.
+
+### Windows
+
+- **No Git Bash overhead.** Plugin hooks run in-process, not as
+  subprocesses. The 100-200ms MINGW64 overhead that affects shell hooks
+  does not apply.
+- **Python path.** Use Hermes's bundled venv, not system/WSL Python.
+  Wrong Python → scanner imports fail silently.
+- **Config paths.** `%LOCALAPPDATA%\hermes\config.yaml` and
+  `%LOCALAPPDATA%\hermes\.env`.
+- **Credential env var isolation.** `PETASOS_*` vars matching
+  `*_KEY`/`*_SECRET` patterns are auto-stripped from terminal subprocess
+  env by `_build_provider_env_blocklist()`.
+
+## Troubleshooting
+
+### Plugin not loading
+
+Check `agent.log` for `Skipping 'petasos'`:
+
+- `"not in plugins.enabled"` → Add `plugins: enabled: [petasos]` to
+  config.yaml.
+- `"exclusive plugin"` → Your `__init__.py` contains `MemoryProvider` or
+  `register_memory_provider` strings. Remove them.
+- No mention of petasos at all → `plugin.yaml` missing or in wrong
+  directory. Check `~/.hermes/plugins/petasos/plugin.yaml` exists.
+
+### Scanner import failures
+
+```
+INFO petasos.plugin: LLM Guard not installed — syntactic-only for that backend
+```
+
+This is graceful degradation, not an error. Install `petasos[all]` in
+Hermes's venv for ML backends. The syntactic pre-filter (17 regex rules)
+still runs without ML.
+
+### License invalid
+
+```
+WARNING petasos.plugin: Petasos license invalid (state=LicenseState.EXPIRED)
+```
+
+Mint a new JWT. Check that `PETASOS_LICENSE_KEY` in `.env` has no trailing
+whitespace or newlines.
+
+### Config section wiped
+
+The `petasos:` section is a top-level key — it survives UI model switches.
+If it disappears, check for concurrent config.yaml editors or a Hermes
+update that overwrote the file.
+
+### ToolCallGuard constructor error
+
+```
+ERROR petasos.plugin: ToolCallGuard.__init__() missing 2 required positional arguments
+```
+
+ToolCallGuard requires `(pipeline, frequency_tracker, config)`. If using
+the reference plugin, this is wired automatically. If writing custom
+integration, construct a `FrequencyTracker(config)` and pass it.
+
+### Model confabulates about blocked commands
+
+The model may claim a blocked command "ran but produced no output."
+This is a model behavior issue, not a Petasos issue. Improve the block
+message to include `[BLOCKED]` and `was NOT executed` so the model
+reports accurately. See GAV-5.


### PR DESCRIPTION
## Summary
- Remove stale `petasos-work-items.md` references from CLAUDE.md
- Fix Petasos version `1.0.0+` → `0.1.0+` in `docs/deployment/hermes-desktop.md`

## Files changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Remove two references to deleted `petasos-work-items.md` |
| `docs/deployment/hermes-desktop.md` | Version string fix |

## Test plan
- [x] Doc-only — no code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified project guidance to point work-item tracking to the PET project and mark the prior draft spec as superseded; simplified PET item hierarchy.
  * Added a detailed Hermes Desktop deployment guide for the content-security plugin covering installation, environment configuration, plugin enablement, behavior expectations, enforcement rules, platform notes (Windows/macOS), verification steps, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->