### PR TITLE
fix(pet-81): SDK auth, runtime Request import, switch CSS reset

### DIFF
--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -17,12 +17,9 @@ import logging
 import os
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from fastapi import APIRouter, HTTPException
-
-if TYPE_CHECKING:
-    from fastapi import Request
+from fastapi import APIRouter, HTTPException, Request
 
 logger = logging.getLogger("petasos.dashboard")
 

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -183,7 +183,7 @@
 .pet .seg button { height: 26px; padding: 0 14px; border: none; background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--tx-mut); border-radius: 5px; transition: background .12s, color .12s; }
 .pet .seg button.on { background: var(--acc); color: var(--color-primary-foreground, #fff); }
 
-.pet .switch { width: 38px; height: 22px; border-radius: 11px; background: var(--bg-active); position: relative; flex: 0 0 38px; transition: background .15s; cursor: pointer; }
+.pet .switch { width: 38px; height: 22px; border-radius: 11px; background: var(--bg-active); position: relative; flex: 0 0 38px; transition: background .15s; cursor: pointer; border: none; padding: 0; appearance: none; }
 .pet .switch.on { background: var(--acc); }
 .pet .switch::after { content: ''; position: absolute; top: 3px; left: 3px; width: 16px; height: 16px; border-radius: 50%; background: #fff; transition: left .15s; }
 .pet .switch.on::after { left: 19px; }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -574,11 +574,15 @@
             formArea.querySelectorAll(".pet-field-err").forEach(function (el) { el.remove(); });
             applyBtn.disabled = true;
             Pet.api.putConfig(Pet.state.configDirty).then(function (d) {
-              console.log("[petasos] putConfig response:", d);
               if (d._status && d.detail) {
-                var details = Array.isArray(d.detail) ? d.detail : [d.detail];
+                var raw = Array.isArray(d.detail) ? d.detail : [d.detail];
+                var details = raw.map(function (el) {
+                  if (typeof el === "string") return { field: "?", message: el };
+                  if (!el || typeof el !== "object") return { field: "?", message: String(el) };
+                  return { field: el.field || el.name || el.path || "?", message: el.message || el.msg || el.detail || String(el) };
+                });
                 details.forEach(function (err) {
-                  if (!err || typeof err !== "object" || !err.field) return;
+                  if (err.field === "?") return;
                   var fieldEl = null;
                   formArea.querySelectorAll("[data-field]").forEach(function (el) {
                     if (el.dataset.field === err.field) fieldEl = el;
@@ -588,16 +592,11 @@
                     (wrapper || fieldEl).appendChild(Pet.h("div", {
                       className: "pet-field-err",
                       style: { color: "var(--err)", fontSize: "11px", marginTop: "4px" }
-                    }, err.message || String(err)));
+                    }, err.message));
                   }
                 });
                 if (!formArea.querySelector(".pet-field-err")) {
-                  var msg = typeof d.detail === "string" ? d.detail
-                    : Array.isArray(d.detail) ? d.detail.map(function (e) {
-                        if (typeof e === "string") return e;
-                        return (e.field || "?") + ": " + (e.message || e.msg || JSON.stringify(e));
-                      }).join("; ")
-                    : JSON.stringify(d.detail);
+                  var msg = details.map(function (e) { return e.field + ": " + e.message; }).join("; ");
                   formArea.insertBefore(Pet.h("div", {
                     className: "pet-field-err",
                     style: { color: "var(--err)", fontSize: "12px", padding: "8px 12px", background: "var(--bg-raised)", borderRadius: "var(--r-card)", marginBottom: "8px" }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -183,6 +183,21 @@
     baseUrl: "/api",
     _req: function (path, opts) {
       var url = this.baseUrl + path;
+      var sdk = window.__HERMES_PLUGIN_SDK__;
+      if (sdk && sdk.fetchJSON) {
+        return sdk.fetchJSON(url, opts)
+          .then(function (r) { return r; })
+          .catch(function (e) {
+            var msg = e.message || "";
+            var match = msg.match(/^(\d+):\s*([\s\S]*)/);
+            if (match) {
+              var status = parseInt(match[1], 10);
+              try { var body = JSON.parse(match[2]); body._status = status; return body; } catch (_) {}
+              return { error: match[2], _status: status };
+            }
+            return { error: msg };
+          });
+      }
       return fetch(url, opts).then(function (r) {
         return r.json().then(function (data) {
           if (!r.ok) data._status = r.status;
@@ -559,27 +574,30 @@
             formArea.querySelectorAll(".pet-field-err").forEach(function (el) { el.remove(); });
             applyBtn.disabled = true;
             Pet.api.putConfig(Pet.state.configDirty).then(function (d) {
+              console.log("[petasos] putConfig response:", d);
               if (d._status && d.detail) {
-                if (Array.isArray(d.detail)) {
-                  d.detail.forEach(function (err) {
-                    if (!err || !err.field) return;
-                    var fieldEl = null;
-                    formArea.querySelectorAll("[data-field]").forEach(function (el) {
-                      if (el.dataset.field === err.field) fieldEl = el;
-                    });
-                    if (fieldEl) {
-                      var wrapper = fieldEl.querySelector(".pet-ctrl-wrap");
-                      (wrapper || fieldEl).appendChild(Pet.h("div", {
-                        className: "pet-field-err",
-                        style: { color: "var(--err)", fontSize: "11px", marginTop: "4px" }
-                      }, err.message));
-                    }
+                var details = Array.isArray(d.detail) ? d.detail : [d.detail];
+                details.forEach(function (err) {
+                  if (!err || typeof err !== "object" || !err.field) return;
+                  var fieldEl = null;
+                  formArea.querySelectorAll("[data-field]").forEach(function (el) {
+                    if (el.dataset.field === err.field) fieldEl = el;
                   });
-                }
+                  if (fieldEl) {
+                    var wrapper = fieldEl.querySelector(".pet-ctrl-wrap");
+                    (wrapper || fieldEl).appendChild(Pet.h("div", {
+                      className: "pet-field-err",
+                      style: { color: "var(--err)", fontSize: "11px", marginTop: "4px" }
+                    }, err.message || String(err)));
+                  }
+                });
                 if (!formArea.querySelector(".pet-field-err")) {
-                  var msg = Array.isArray(d.detail)
-                    ? d.detail.map(function (e) { return (e.field || "?") + ": " + (e.message || String(e)); }).join("; ")
-                    : String(d.detail);
+                  var msg = typeof d.detail === "string" ? d.detail
+                    : Array.isArray(d.detail) ? d.detail.map(function (e) {
+                        if (typeof e === "string") return e;
+                        return (e.field || "?") + ": " + (e.message || e.msg || JSON.stringify(e));
+                      }).join("; ")
+                    : JSON.stringify(d.detail);
                   formArea.insertBefore(Pet.h("div", {
                     className: "pet-field-err",
                     style: { color: "var(--err)", fontSize: "12px", padding: "8px 12px", background: "var(--bg-raised)", borderRadius: "var(--r-card)", marginBottom: "8px" }


### PR DESCRIPTION
﻿## Summary
- **plugin_api.py**: Move `Request` from `TYPE_CHECKING` to runtime import. `from __future__ import annotations` made FastAPI unable to resolve the parameter type, causing every PUT to return 422 from Pydantic validation
- **petasos.js**: Use SDK `fetchJSON` when available for session-token auth (fixes 401 on all plugin API calls), with error-message parsing to recover structured 422 detail
- **petasos.css**: Reset browser button defaults on `.switch` toggle

## Files changed

| File | Change |
|------|--------|
| `petasos/console/hermes/plugin_api.py` | Move `Request` to runtime import, drop unused `TYPE_CHECKING` |
| `petasos/console/static/petasos.js` | SDK fetchJSON auth path + robust error display |
| `petasos/console/static/petasos.css` | Button reset on `.switch` class |

## Test plan
- [x] Live dashboard: config loads (GET 200), toggle + Apply persists (PUT 200), switches render as pills
- [x] Console confirms `{config: {...}, fields: Array(45)}` on save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional integration with the Hermes plugin SDK for request handling, falling back to the previous behavior when unavailable.

* **Bug Fixes**
  * Improved error parsing and reporting in the configuration editor; normalizes error details and renders field-specific messages when present.

* **Style**
  * Adjusted switch component styling for border, padding, and native appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->