### PR TITLE
fix(pet-82): replace HelpTip innerHTML with structured markup builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
       - run: pytest tests/ -v --tb=short
+
+  # PET-82: console frontend unit test (zero npm deps; node:test built-in
+  # runner). First non-Python job — no npm install, no cache (no lockfile).
+  js-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: node --test tests/js/richtext.test.mjs

--- a/docs/specs/TODO/PET-82.test-output.txt
+++ b/docs/specs/TODO/PET-82.test-output.txt
@@ -1,23 +1,23 @@
-✔ loader: petasos.js exports Pet.richText (0.5703ms)
-✔ #1 <b> renders a B element (0.2474ms)
-✔ #2 <code> renders a CODE element (0.3981ms)
-✔ #3 <em> is allow-listed (0.0947ms)
-✔ #4 nested tags build a nested tree (0.0978ms)
-✔ #5 uppercase tags are honored (case-insensitive) (0.1065ms)
-✔ #6 <script> is escaped to text, no element (0.2121ms)
-✔ #7 <img onerror> is escaped to text, no element (0.1094ms)
-✔ #8 <b class=...> degrades to text; </b> swallowed (0.0928ms)
-✔ #9 mis-nested tags pop by position (0.1073ms)
-✔ #10 truncated < is literal text (0.0646ms)
-✔ #11 lone </b> yields an empty fragment, no throw (0.0581ms)
-✔ #12 unclosed <b> still wraps trailing text (0.0491ms)
-✔ #13 null/undefined/empty return an empty fragment (0.0295ms)
-✔ #14 number input coerces to text (0.0438ms)
-✔ #15 plain text becomes a single text node (0.0305ms)
-✔ #16 whitespace and stray angle brackets (0.0533ms)
-✔ #17 astral characters survive intact (0.0993ms)
-✔ #18 security sweep: only b/code/em can become elements (0.0969ms)
-✔ #19 current caller strings render identically (structural) (0.2147ms)
+✔ loader: petasos.js exports Pet.richText (0.5199ms)
+✔ #1 <b> renders a B element (0.2277ms)
+✔ #2 <code> renders a CODE element (0.4366ms)
+✔ #3 <em> is allow-listed (0.1233ms)
+✔ #4 nested tags build a nested tree (0.1389ms)
+✔ #5 uppercase tags are honored (case-insensitive) (0.0796ms)
+✔ #6 <script> is escaped to text, no element (0.0629ms)
+✔ #7 <img onerror> is escaped to text, no element (0.1279ms)
+✔ #8 <b class=...> degrades to literal text (0.0735ms)
+✔ #9 mismatched </b> does not close the wrong element (0.1133ms)
+✔ #10 truncated < is literal text (0.0642ms)
+✔ #11 lone </b> is literal text, no throw (0.0475ms)
+✔ #12 unclosed <b> still wraps trailing text (0.0555ms)
+✔ #13 null/undefined/empty return an empty fragment (0.0336ms)
+✔ #14 number input coerces to text (0.0402ms)
+✔ #15 plain text becomes a single text node (0.0304ms)
+✔ #16 whitespace and stray angle brackets (0.0522ms)
+✔ #17 astral characters survive intact (0.0527ms)
+✔ #18 security sweep: only b/code/em can become elements (0.086ms)
+✔ #19 current caller strings render identically (structural) (0.2416ms)
 ℹ tests 20
 ℹ suites 0
 ℹ pass 20
@@ -25,4 +25,4 @@
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 56.5514
+ℹ duration_ms 54.6955

--- a/docs/specs/TODO/PET-82.test-output.txt
+++ b/docs/specs/TODO/PET-82.test-output.txt
@@ -1,0 +1,28 @@
+✔ loader: petasos.js exports Pet.richText (0.5703ms)
+✔ #1 <b> renders a B element (0.2474ms)
+✔ #2 <code> renders a CODE element (0.3981ms)
+✔ #3 <em> is allow-listed (0.0947ms)
+✔ #4 nested tags build a nested tree (0.0978ms)
+✔ #5 uppercase tags are honored (case-insensitive) (0.1065ms)
+✔ #6 <script> is escaped to text, no element (0.2121ms)
+✔ #7 <img onerror> is escaped to text, no element (0.1094ms)
+✔ #8 <b class=...> degrades to text; </b> swallowed (0.0928ms)
+✔ #9 mis-nested tags pop by position (0.1073ms)
+✔ #10 truncated < is literal text (0.0646ms)
+✔ #11 lone </b> yields an empty fragment, no throw (0.0581ms)
+✔ #12 unclosed <b> still wraps trailing text (0.0491ms)
+✔ #13 null/undefined/empty return an empty fragment (0.0295ms)
+✔ #14 number input coerces to text (0.0438ms)
+✔ #15 plain text becomes a single text node (0.0305ms)
+✔ #16 whitespace and stray angle brackets (0.0533ms)
+✔ #17 astral characters survive intact (0.0993ms)
+✔ #18 security sweep: only b/code/em can become elements (0.0969ms)
+✔ #19 current caller strings render identically (structural) (0.2147ms)
+ℹ tests 20
+ℹ suites 0
+ℹ pass 20
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 56.5514

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -104,11 +104,57 @@
     info: { cls: "sev-info", col: "var(--info)", short: "INFO" },
   };
 
+  // Parses a restricted markup subset into a DocumentFragment of real DOM nodes.
+  // Recognized (opening + closing, any case): <b> <code> <em>.
+  // Every other "<" is treated as a literal character and escaped to a text node.
+  // No HTML string is ever constructed; no innerHTML/DOMParser is ever used.
+  // NOTE: ALLOWED must never gain a "g" flag — RegExp.exec with /g is stateful
+  // (lastIndex persists across calls) and would make richText non-deterministic.
+  Pet.richText = function (markup) {
+    var frag = document.createDocumentFragment();
+    if (markup == null) return frag;
+    markup = String(markup);
+    var ALLOWED = /^<(\/?)(b|code|em)>$/i;
+    var stack = [frag];
+    var buf = "";
+    var i = 0;
+    var flush = function () {
+      if (buf) {
+        stack[stack.length - 1].appendChild(document.createTextNode(buf));
+        buf = "";
+      }
+    };
+    while (i < markup.length) {
+      if (markup[i] === "<") {
+        var close = markup.indexOf(">", i);
+        if (close !== -1) {
+          var m = ALLOWED.exec(markup.substring(i, close + 1));
+          if (m) {
+            flush();
+            if (m[1] === "/") {
+              if (stack.length > 1) stack.pop();
+            } else {
+              var el = document.createElement(m[2].toLowerCase());
+              stack[stack.length - 1].appendChild(el);
+              stack.push(el);
+            }
+            i = close + 1;
+            continue;
+          }
+        }
+      }
+      buf += markup[i];
+      i++;
+    }
+    flush();
+    return frag;
+  };
+
   Pet.HelpTip = function (html) {
     var btn = Pet.h("span", { className: "help", tabIndex: "0" });
     btn.appendChild(Pet.Icon("q"));
     var tip = Pet.h("span", { className: "tip" });
-    tip.innerHTML = html;
+    tip.appendChild(Pet.richText(html));
     btn.appendChild(tip);
     var position = function () {
       var r = btn.getBoundingClientRect();

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -107,6 +107,8 @@
   // Parses a restricted markup subset into a DocumentFragment of real DOM nodes.
   // Recognized (opening + closing, any case): <b> <code> <em>.
   // Every other "<" is treated as a literal character and escaped to a text node.
+  // A closing tag that does not match the current open element is treated as
+  // literal text — mismatched/unbalanced structure is never silently suppressed.
   // No HTML string is ever constructed; no innerHTML/DOMParser is ever used.
   // NOTE: ALLOWED must never gain a "g" flag — RegExp.exec with /g is stateful
   // (lastIndex persists across calls) and would make richText non-deterministic.
@@ -130,16 +132,25 @@
         if (close !== -1) {
           var m = ALLOWED.exec(markup.substring(i, close + 1));
           if (m) {
-            flush();
             if (m[1] === "/") {
-              if (stack.length > 1) stack.pop();
+              // Closing tag: only pop when it matches the current open element.
+              var closing = m[2].toLowerCase();
+              var top = stack[stack.length - 1];
+              if (stack.length > 1 && top.tagName && top.tagName.toLowerCase() === closing) {
+                flush();
+                stack.pop();
+                i = close + 1;
+                continue;
+              }
+              // Mismatched/unbalanced closer — fall through to literal text.
             } else {
+              flush();
               var el = document.createElement(m[2].toLowerCase());
               stack[stack.length - 1].appendChild(el);
               stack.push(el);
+              i = close + 1;
+              continue;
             }
-            i = close + 1;
-            continue;
           }
         }
       }

--- a/tests/js/richtext.test.mjs
+++ b/tests/js/richtext.test.mjs
@@ -1,0 +1,280 @@
+// Unit tests for Pet.richText (petasos/console/static/petasos.js).
+//
+// Regression for PET-82: HelpTip used `tip.innerHTML = html`, a variable-fed
+// innerHTML sink. richText replaces it with a restricted-markup builder that
+// only ever creates <b>/<code>/<em> elements and escapes everything else to
+// text — so a future dynamic tooltip cannot smuggle an XSS payload.
+//
+// Zero npm dependencies: Node's built-in test runner + assert, a minimal DOM
+// shim, and node:vm to evaluate the real shipped petasos.js. Run with:
+//   node --test tests/js/richtext.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Minimal DOM shim ──────────────────────────────────────────────────────
+// Models exactly the surface richText touches. richText only ever appends
+// freshly-created nodes (never re-parents, never appends a fragment into a
+// node), so the shim does not model real-DOM appendChild re-parenting or
+// DocumentFragment flattening — see spec D3 "Fidelity boundary".
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase(); // mirrors real DOM (uppercase for HTML)
+    el.localName = tag;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ──────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// Guards spec D5: the export ran and richText is present.
+test("loader: petasos.js exports Pet.richText", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.richText, "function");
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+// Depth-first list of every element node's tagName in the subtree.
+function tagNames(node) {
+  const out = [];
+  for (const child of node.childNodes) {
+    if (child.nodeType === 1) {
+      out.push(child.tagName);
+      out.push(...tagNames(child));
+    }
+  }
+  return out;
+}
+
+// ── Test matrix ─────────────────────────────────────────────────────────
+
+// #1 allowed <b>
+test("#1 <b> renders a B element", () => {
+  const f = Pet.richText("<b>hi</b>");
+  assert.equal(f.childNodes.length, 1);
+  assert.equal(f.childNodes[0].tagName, "B");
+  assert.equal(f.childNodes[0].textContent, "hi");
+});
+
+// #2 allowed <code>
+test("#2 <code> renders a CODE element", () => {
+  const f = Pet.richText("<code>x</code>");
+  assert.deepEqual(tagNames(f), ["CODE"]);
+  assert.equal(f.textContent, "x");
+});
+
+// #3 allowed <em>
+test("#3 <em> is allow-listed", () => {
+  const f = Pet.richText("<em>y</em>");
+  assert.deepEqual(tagNames(f), ["EM"]);
+  assert.equal(f.textContent, "y");
+});
+
+// #4 nesting
+test("#4 nested tags build a nested tree", () => {
+  const f = Pet.richText("a <b>b <code>c</code></b> d");
+  assert.equal(f.textContent, "a b c d");
+  assert.deepEqual(tagNames(f), ["B", "CODE"]);
+  // structure: text, B(text, CODE(text)), text
+  assert.equal(f.childNodes[1].tagName, "B");
+  assert.equal(f.childNodes[1].childNodes[1].tagName, "CODE");
+});
+
+// #5 case-insensitive (pins D2)
+test("#5 uppercase tags are honored (case-insensitive)", () => {
+  assert.deepEqual(tagNames(Pet.richText("<B>X</B>")), ["B"]);
+  assert.deepEqual(tagNames(Pet.richText("<CODE>x</CODE>")), ["CODE"]);
+});
+
+// #6 disallowed <script> escaped
+test("#6 <script> is escaped to text, no element", () => {
+  const f = Pet.richText("<script>alert(1)</script>");
+  assert.deepEqual(tagNames(f), []);
+  assert.equal(f.textContent, "<script>alert(1)</script>");
+});
+
+// #7 disallowed <img onerror> escaped
+test("#7 <img onerror> is escaped to text, no element", () => {
+  const input = "<img src=x onerror=alert(1)>";
+  const f = Pet.richText(input);
+  assert.deepEqual(tagNames(f), []);
+  assert.equal(f.textContent, input);
+});
+
+// #8 attribute-bearing allowed tag is NOT honored (most error-prone assertion)
+test("#8 <b class=...> degrades to text; </b> swallowed", () => {
+  const f = Pet.richText('<b class="x">y</b>');
+  assert.deepEqual(tagNames(f), []);
+  // Neither the full input nor tags-stripped: the </b> is consumed by the
+  // guarded pop, leaving the open-tag-with-attributes as literal text.
+  assert.equal(f.textContent, '<b class="x">y');
+});
+
+// #9 mis-nested: positional pop (documented non-adoption-agency behavior)
+test("#9 mis-nested tags pop by position", () => {
+  const f = Pet.richText("<b><code>x</b></code>");
+  assert.deepEqual(tagNames(f), ["B", "CODE"]);
+  assert.equal(f.textContent, "x");
+  assert.equal(f.childNodes[0].tagName, "B");
+  assert.equal(f.childNodes[0].childNodes[0].tagName, "CODE");
+});
+
+// #10 truncated "<"
+test("#10 truncated < is literal text", () => {
+  const f = Pet.richText("<b");
+  assert.deepEqual(tagNames(f), []);
+  assert.equal(f.textContent, "<b");
+});
+
+// #11 lone close tag
+test("#11 lone </b> yields an empty fragment, no throw", () => {
+  const f = Pet.richText("</b>");
+  assert.equal(f.childNodes.length, 0);
+});
+
+// #12 unclosed open tag
+test("#12 unclosed <b> still wraps trailing text", () => {
+  const f = Pet.richText("<b>hi");
+  assert.deepEqual(tagNames(f), ["B"]);
+  assert.equal(f.childNodes[0].textContent, "hi");
+});
+
+// #13 null / undefined / empty (D7 contract)
+test("#13 null/undefined/empty return an empty fragment", () => {
+  assert.equal(Pet.richText("").childNodes.length, 0);
+  assert.equal(Pet.richText(null).childNodes.length, 0);
+  assert.equal(Pet.richText(undefined).childNodes.length, 0);
+});
+
+// #14 number coercion (D7 contract)
+test("#14 number input coerces to text", () => {
+  const f = Pet.richText(123);
+  assert.equal(f.childNodes.length, 1);
+  assert.equal(f.childNodes[0].nodeType, 3);
+  assert.equal(f.textContent, "123");
+});
+
+// #15 plain text
+test("#15 plain text becomes a single text node", () => {
+  const f = Pet.richText("plain text");
+  assert.equal(f.childNodes.length, 1);
+  assert.equal(f.childNodes[0].nodeType, 3);
+  assert.equal(f.textContent, "plain text");
+});
+
+// #16 whitespace / stray angle brackets
+test("#16 whitespace and stray angle brackets", () => {
+  // trailing-space tag → escaped
+  let f = Pet.richText("<b >text");
+  assert.deepEqual(tagNames(f), []);
+  assert.equal(f.textContent, "<b >text");
+
+  // bare > with no < → plain text
+  f = Pet.richText("a > b");
+  assert.equal(f.childNodes.length, 1);
+  assert.equal(f.childNodes[0].nodeType, 3);
+  assert.equal(f.textContent, "a > b");
+
+  // "<<b>>" → text "<", then unclosed B holding trailing ">"
+  f = Pet.richText("<<b>>");
+  assert.deepEqual(tagNames(f), ["B"]);
+  assert.equal(f.textContent, "<>");
+  assert.equal(f.childNodes.length, 2);
+  assert.equal(f.childNodes[0].nodeType, 3);
+  assert.equal(f.childNodes[0].nodeValue, "<");
+  assert.equal(f.childNodes[1].tagName, "B");
+  assert.equal(f.childNodes[1].textContent, ">");
+});
+
+// #17 astral / surrogate pair preserved
+test("#17 astral characters survive intact", () => {
+  const f = Pet.richText("<b>\u{1F600}</b>");
+  assert.deepEqual(tagNames(f), ["B"]);
+  assert.equal(f.textContent, "\u{1F600}");
+});
+
+// #18 security sweep — no element may ever be smuggled
+test("#18 security sweep: only b/code/em can become elements", () => {
+  const attacks = [
+    "<script>alert(1)</script>",
+    "<img src=x onerror=alert(1)>",
+    "<svg/onload=1>",
+    "<iframe>",
+    "<a href=javascript:1>z</a>",
+    '<b title=">">x',
+    "<b/>",
+    "<b\nclass=x>",
+  ];
+  for (const input of attacks) {
+    const f = Pet.richText(input);
+    assert.deepEqual(
+      tagNames(f),
+      [],
+      `expected no elements for: ${JSON.stringify(input)}`
+    );
+  }
+});
+
+// #19 regression: the 6 current HelpTip caller strings render with only
+// B/CODE elements and text identical to the tags-stripped string.
+test("#19 current caller strings render identically (structural)", () => {
+  const callers = [
+    "<b>Scanner Health</b> — status of each loaded scanner backend (MinimalScanner, LLM Guard, Presidio, etc). <code>ready</code> means the scanner is initialized and processing.",
+    "<b>Scan History</b> — recent pipeline scans with severity, direction, and timing. Each row is one <code>Pipeline.evaluate()</code> call.",
+    "<b>Findings</b> — individual detections from each scanner. Severity ranges from <code>INFO</code> to <code>CRITICAL</code>. High+ on dangerous tools triggers a block.",
+    "<b>Session Overlay</b> — cumulative session risk score and escalation tier. Score rises with repeated violations; tier thresholds trigger progressively stricter enforcement.",
+    "<b>Scan Playground</b> — paste text and run it through the full pipeline. Choose <code>inbound</code> (user→agent) or <code>outbound</code> (agent→user) direction. Optionally bind to a session ID for frequency tracking.",
+    "<b>Support</b> — Petasos is free and open source (MIT). Sponsorship helps fund continued development but unlocks nothing — every feature is available to everyone.",
+  ];
+  for (const s of callers) {
+    const f = Pet.richText(s);
+    // only B/CODE elements
+    for (const t of tagNames(f)) {
+      assert.ok(t === "B" || t === "CODE", `unexpected element ${t} in: ${s}`);
+    }
+    const stripped = s.replace(/<\/?(?:b|code)>/g, "");
+    // tripwire: equivalence holds only because these strings contain no
+    // entities and no stray angle brackets outside the b/code tags.
+    assert.ok(!s.includes("&"), `caller string contains '&': ${s}`);
+    assert.ok(
+      !stripped.includes("<") && !stripped.includes(">"),
+      `caller string has stray angle brackets: ${s}`
+    );
+    assert.equal(f.textContent, stripped);
+  }
+});

--- a/tests/js/richtext.test.mjs
+++ b/tests/js/richtext.test.mjs
@@ -136,22 +136,24 @@ test("#7 <img onerror> is escaped to text, no element", () => {
   assert.equal(f.textContent, input);
 });
 
-// #8 attribute-bearing allowed tag is NOT honored (most error-prone assertion)
-test("#8 <b class=...> degrades to text; </b> swallowed", () => {
+// #8 attribute-bearing allowed tag is NOT honored
+test("#8 <b class=...> degrades to literal text", () => {
   const f = Pet.richText('<b class="x">y</b>');
   assert.deepEqual(tagNames(f), []);
-  // Neither the full input nor tags-stripped: the </b> is consumed by the
-  // guarded pop, leaving the open-tag-with-attributes as literal text.
-  assert.equal(f.textContent, '<b class="x">y');
+  // The open-tag-with-attributes never opens a B, so the trailing </b> has no
+  // matching element and is also literal: the whole input round-trips to text.
+  assert.equal(f.textContent, '<b class="x">y</b>');
 });
 
-// #9 mis-nested: positional pop (documented non-adoption-agency behavior)
-test("#9 mis-nested tags pop by position", () => {
-  const f = Pet.richText("<b><code>x</b></code>");
-  assert.deepEqual(tagNames(f), ["B", "CODE"]);
-  assert.equal(f.textContent, "x");
+// #9 mismatched closer is treated as literal text (structural rule not suppressed)
+test("#9 mismatched </b> does not close the wrong element", () => {
+  const f = Pet.richText("<b><em>x</b>");
+  // </b> does not match the open <em>, so it is literal text, not a close.
+  assert.deepEqual(tagNames(f), ["B", "EM"]);
+  assert.equal(f.textContent, "x</b>");
   assert.equal(f.childNodes[0].tagName, "B");
-  assert.equal(f.childNodes[0].childNodes[0].tagName, "CODE");
+  assert.equal(f.childNodes[0].childNodes[0].tagName, "EM");
+  assert.equal(f.childNodes[0].childNodes[0].textContent, "x</b>");
 });
 
 // #10 truncated "<"
@@ -161,10 +163,11 @@ test("#10 truncated < is literal text", () => {
   assert.equal(f.textContent, "<b");
 });
 
-// #11 lone close tag
-test("#11 lone </b> yields an empty fragment, no throw", () => {
+// #11 lone close tag has no matching element → literal text
+test("#11 lone </b> is literal text, no throw", () => {
   const f = Pet.richText("</b>");
-  assert.equal(f.childNodes.length, 0);
+  assert.deepEqual(tagNames(f), []);
+  assert.equal(f.textContent, "</b>");
 });
 
 // #12 unclosed open tag


### PR DESCRIPTION
## Summary
- Replaces the only variable-fed `innerHTML` sink in the console frontend (`Pet.HelpTip`) with `Pet.richText`, a zero-dependency markup builder that parses a restricted tag subset (`<b>`, `<code>`, `<em>`) into real DOM nodes and escapes everything else to text.
- No XSS sink can be smuggled through a future dynamic tooltip — only `b`/`code`/`em` bare tags can ever become elements; no attribute, event handler, or foreign element is creatable.
- Adds the repo's first JS test (Node built-in runner, zero npm deps) plus a CI `js-test` job so the helper is guarded on every PR.

## Layered defense
`Pet.richText` never constructs an HTML string and never touches `innerHTML`/`DOMParser`. The allow-list regex `^<(\/?)(b|code|em)>$/i` is anchored, so any tag with attributes, whitespace, an embedded `>`, or a slash (`<b/>`) fails the match and degrades to a literal text node. `createElement` is only ever called with the captured tag name (`b`/`code`/`em`, lowercased) — an attacker cannot reach attribute or handler creation. All 6 current callers pass static `<b>`/`<code>` literals and render unchanged.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Adds `Pet.richText`; `HelpTip` now `appendChild(Pet.richText(html))` instead of `innerHTML = html` |
| `tests/js/richtext.test.mjs` | New — 20-case unit test; minimal DOM shim; loads the real `petasos.js` via `node:vm` |
| `.github/workflows/ci.yml` | New `js-test` job (setup-node, pinned Node 22, no npm install) |

## Test plan
- [x] `node --test tests/js/richtext.test.mjs` — 20/20 pass (full output: docs/specs/TODO/PET-82.test-output.txt)
- [x] Allowed (`<b>`/`<code>`/`<em>`), nested, case-insensitive, mis-nested, unclosed/unbalanced, truncated, whitespace, astral, and number-coercion cases
- [x] Adversarial security sweep (`<script>`, `<img onerror>`, `<svg/onload>`, `<iframe>`, `<a href=javascript:>`, `<b title=">">`, `<b/>`, newline-in-tag) — no element ever smuggled
- [x] Structural equivalence for all 6 current HelpTip caller strings + `&`/stray-angle-bracket tripwire
- [ ] Manual visual spot-check of the running console tooltips (Observability, Scan Playground, About) — post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Help tips now render safe rich text (bold, code, emphasis) while preventing unsafe markup.

* **Tests**
  * Added comprehensive unit tests covering parsing edge cases, nesting, case-insensitivity, text coercion, and security/XSS checks.

* **Chores**
  * Added a CI job to run the new JavaScript tests in the pipeline.

* **Documentation**
  * Added a recorded test run output documenting passing results and behavior observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->