### PR TITLE
fix(pet-85): sanitize session_id at the console boundary

### DIFF
--- a/docs/specs/TODO/PET-85.test-output.txt
+++ b/docs/specs/TODO/PET-85.test-output.txt
@@ -1,0 +1,134 @@
+=== PET-85 test gate — Python 3.11.14 ===
+
+$ python -m pytest tests/test_console_validation.py tests/test_console_handlers.py tests/test_plugin_api_sse.py -v
+============================= test session starts =============================
+platform win32 -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\zioni\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-85-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0, timeout-2.4.0
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 81 items
+
+tests/test_console_validation.py::test_null_session_id_passes[standalone] PASSED [  1%]
+tests/test_console_validation.py::test_null_session_id_passes[plugin] PASSED [  2%]
+tests/test_console_validation.py::test_non_string_rejected[standalone-123] PASSED [  3%]
+tests/test_console_validation.py::test_non_string_rejected[standalone-bad1] PASSED [  4%]
+tests/test_console_validation.py::test_non_string_rejected[plugin-123] PASSED [  6%]
+tests/test_console_validation.py::test_non_string_rejected[plugin-bad1] PASSED [  7%]
+tests/test_console_validation.py::test_empty_string_rejected[standalone] PASSED [  8%]
+tests/test_console_validation.py::test_empty_string_rejected[plugin] PASSED [  9%]
+tests/test_console_validation.py::test_whitespace_only_rejected[standalone] PASSED [ 11%]
+tests/test_console_validation.py::test_whitespace_only_rejected[plugin] PASSED [ 12%]
+tests/test_console_validation.py::test_oversize_rejected[standalone] PASSED [ 13%]
+tests/test_console_validation.py::test_oversize_rejected[plugin] PASSED  [ 14%]
+tests/test_console_validation.py::test_control_chars_rejected[standalone-abc\ndef] PASSED [ 16%]
+tests/test_console_validation.py::test_control_chars_rejected[standalone-abc\x00def] PASSED [ 17%]
+tests/test_console_validation.py::test_control_chars_rejected[plugin-abc\ndef] PASSED [ 18%]
+tests/test_console_validation.py::test_control_chars_rejected[plugin-abc\x00def] PASSED [ 19%]
+tests/test_console_validation.py::test_trailing_newline_trimmed[standalone] PASSED [ 20%]
+tests/test_console_validation.py::test_trailing_newline_trimmed[plugin] PASSED [ 22%]
+tests/test_console_validation.py::test_zero_width_rejected[standalone-sess\u200bion] PASSED [ 23%]
+tests/test_console_validation.py::test_zero_width_rejected[standalone-\u202esession] PASSED [ 24%]
+tests/test_console_validation.py::test_zero_width_rejected[plugin-sess\u200bion] PASSED [ 25%]
+tests/test_console_validation.py::test_zero_width_rejected[plugin-\u202esession] PASSED [ 27%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+2800] PASSED [ 28%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+3164] PASSED [ 29%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+FFA0] PASSED [ 30%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+115F] PASSED [ 32%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+1160] PASSED [ 33%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+034F] PASSED [ 34%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+180F] PASSED [ 35%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+17B4] PASSED [ 37%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+17B5] PASSED [ 38%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+FE0F] PASSED [ 39%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+16FE4] PASSED [ 40%]
+tests/test_console_validation.py::test_invisible_printable_rejected[standalone-U+1BC9D] PASSED [ 41%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+2800] PASSED [ 43%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+3164] PASSED [ 44%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+FFA0] PASSED [ 45%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+115F] PASSED [ 46%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+1160] PASSED [ 48%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+034F] PASSED [ 49%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+180F] PASSED [ 50%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+17B4] PASSED [ 51%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+17B5] PASSED [ 53%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+FE0F] PASSED [ 54%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+16FE4] PASSED [ 55%]
+tests/test_console_validation.py::test_invisible_printable_rejected[plugin-U+1BC9D] PASSED [ 56%]
+tests/test_console_validation.py::test_default_ignorable_rejected PASSED [ 58%]
+tests/test_console_validation.py::test_leading_combining_mark_rejected[\xa8] PASSED [ 59%]
+tests/test_console_validation.py::test_leading_combining_mark_rejected[\u0301abc] PASSED [ 60%]
+tests/test_console_validation.py::test_leading_combining_mark_rejected[\u093fabc] PASSED [ 61%]
+tests/test_console_validation.py::test_leading_combining_mark_rejected[\u20ddx] PASSED [ 62%]
+tests/test_console_validation.py::test_spacing_accent_accepted_visibly PASSED [ 64%]
+tests/test_console_validation.py::test_homoglyph_canonicalized PASSED    [ 65%]
+tests/test_console_validation.py::test_fullwidth_canonicalized PASSED    [ 66%]
+tests/test_console_validation.py::test_response_echoes_canonical_session_id[standalone] PASSED [ 67%]
+tests/test_console_validation.py::test_response_echoes_canonical_session_id[plugin] PASSED [ 69%]
+tests/test_console_validation.py::test_nfkc_expansion_capped PASSED      [ 70%]
+tests/test_console_validation.py::test_plain_ascii_unchanged PASSED      [ 71%]
+tests/test_console_validation.py::test_visible_unicode_id_accepted PASSED [ 72%]
+tests/test_console_handlers.py::test_get_config_returns_fields PASSED    [ 74%]
+tests/test_console_handlers.py::test_get_config_redacts_secrets PASSED   [ 75%]
+tests/test_console_handlers.py::test_update_config_valid PASSED          [ 76%]
+tests/test_console_handlers.py::test_update_config_invalid PASSED        [ 77%]
+tests/test_console_handlers.py::test_run_scan PASSED                     [ 79%]
+tests/test_console_handlers.py::test_run_scan_with_injection PASSED      [ 80%]
+tests/test_console_handlers.py::test_get_health PASSED                   [ 81%]
+tests/test_console_handlers.py::test_get_scan_history_empty PASSED       [ 82%]
+tests/test_console_handlers.py::test_get_scan_history_after_scan PASSED  [ 83%]
+tests/test_console_handlers.py::test_get_profiles PASSED                 [ 85%]
+tests/test_console_handlers.py::test_get_about PASSED                    [ 86%]
+tests/test_console_handlers.py::test_scan_history_limit PASSED           [ 87%]
+tests/test_console_handlers.py::test_pipeline_scanner_health PASSED      [ 88%]
+tests/test_console_handlers.py::test_pipeline_list_profiles PASSED       [ 90%]
+tests/test_console_handlers.py::test_pipeline_result_to_dict PASSED      [ 91%]
+tests/test_console_handlers.py::test_config_persist_writes_yaml PASSED   [ 92%]
+tests/test_plugin_api_sse.py::test_sse_frame_format_for_fetch_reader PASSED [ 93%]
+tests/test_plugin_api_sse.py::test_sse_auth_header_passthrough PASSED    [ 95%]
+tests/test_plugin_api_sse.py::test_scan_history_polling_path PASSED      [ 96%]
+tests/test_plugin_api_sse.py::test_scan_history_populated_after_scan PASSED [ 97%]
+tests/test_plugin_api_sse.py::test_health_endpoint_for_polling PASSED    [ 98%]
+tests/test_plugin_api_sse.py::test_polling_and_sse_return_same_scan PASSED [100%]
+
+============================== warnings summary ===============================
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-85-worktree\petasos\console\server.py:271: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\AppData\Local\hermes\hermes-agent\venv\Lib\site-packages\fastapi\applications.py:4599: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================= 81 passed, 48 warnings in 0.60s =======================
+EXIT: 0
+
+$ python -m pytest
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+========== 1052 passed, 58 skipped, 1 xfailed, 48 warnings in 6.85s ===========
+EXIT: 0
+
+$ python -m ruff check .
+All checks passed!
+EXIT: 0
+
+$ python -m ruff format --check .
+95 files already formatted
+EXIT: 0
+
+$ python -m mypy --strict .
+Success: no issues found in 95 source files
+EXIT: 0

--- a/petasos/console/_validation.py
+++ b/petasos/console/_validation.py
@@ -1,0 +1,83 @@
+"""Boundary validation for caller-supplied values entering the console API."""
+
+from __future__ import annotations
+
+import unicodedata
+
+from petasos.normalize import _HOMOGLYPH_TABLE, _is_strippable
+
+_MAX_SESSION_ID_LEN = 128
+
+# Invisible/zero-width code points that str.isprintable() returns True for and
+# NFKC does not remove. Enumerated, not predicate-derived: CPython's
+# unicodedata exposes no Default_Ignorable_Code_Point accessor (only
+# category()), and the residue spans Mn/Lo/So, so no single category test
+# isolates it — contrast NORM-01 (PET-43) where category()=="Cf" WAS the
+# semantic predicate. Two groups:
+#   1. The assigned-non-Cf Default_Ignorable residue (isprintable() already
+#      rejects every Cf and unassigned-Cn Default_Ignorable, leaving only this
+#      small, slow-growing set). Source: DerivedCoreProperties.txt (Unicode 14+).
+#   2. Non-DI zero-glyph fillers Unicode chose not to mark Default_Ignorable
+#      but which still render no glyph (PET-85 round-3 finding).
+# Extend either group if a future Unicode version adds a member;
+# test_default_ignorable_rejected (independently derived) guards group 1.
+_INVISIBLE_PRINTABLE: frozenset[str] = frozenset(
+    {
+        chr(0x034F),  # COMBINING GRAPHEME JOINER (Mn)
+        chr(0x115F),  # HANGUL CHOSEONG FILLER (Lo)
+        chr(0x1160),  # HANGUL JUNGSEONG FILLER (Lo)
+        chr(0x17B4),  # KHMER VOWEL INHERENT AQ (Mn)
+        chr(0x17B5),  # KHMER VOWEL INHERENT AA (Mn)
+        chr(0x3164),  # HANGUL FILLER (Lo; NFKC → U+1160)
+        chr(0xFFA0),  # HALFWIDTH HANGUL FILLER (Lo; NFKC → U+1160)
+        chr(0x16FE4),  # KHITAN SMALL SCRIPT FILLER (Mn; non-DI zero-glyph)
+        chr(0x1BC9D),  # DUPLOYAN THICK LETTER SELECTOR (Mn; non-DI zero-glyph)
+    }
+    | {chr(c) for c in range(0x180B, 0x1810)}  # MONGOLIAN FVS1–4 (180E is Cf; harmless dup)
+    | {chr(c) for c in range(0xFE00, 0xFE10)}  # VARIATION SELECTORS 1–16 (Mn)
+    | {chr(c) for c in range(0xE0100, 0xE01F0)}  # VARIATION SELECTORS SUPPLEMENT 17–256 (Mn)
+)
+
+_COMBINING_CATEGORIES: frozenset[str] = frozenset({"Mn", "Mc", "Me"})
+
+
+class SessionIdError(ValueError):
+    """Raised when a session_id fails boundary validation."""
+
+
+def _has_invisible(s: str) -> bool:
+    """True if s contains a non-printable or invisible-but-printable char."""
+    return not s.isprintable() or any(_is_strippable(ch) or ch in _INVISIBLE_PRINTABLE for ch in s)
+
+
+def sanitize_session_id(raw: object) -> str | None:
+    """Validate and canonicalize a session_id at the console boundary.
+
+    Returns the canonical id, or None for null input. Raises
+    SessionIdError(message) for every rejection class. The canonical id —
+    not the raw one — becomes the FrequencyTracker key, the audit-event
+    field, and the ALRT-02 alert-dedup pair, so visually identical variants
+    must either be rejected (the invisible class) or collapse here (printable
+    confusables) (PET-85).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise SessionIdError("Must be a string or null")
+    sid = raw.strip()
+    if not sid:
+        raise SessionIdError("Must be non-empty")
+    if len(sid) > _MAX_SESSION_ID_LEN:
+        raise SessionIdError(f"Exceeds {_MAX_SESSION_ID_LEN} character limit")
+    if _has_invisible(sid):
+        raise SessionIdError("Contains non-printable or invisible characters")
+    canonical = unicodedata.normalize("NFKC", sid).translate(_HOMOGLYPH_TABLE).strip()
+    if not canonical:
+        raise SessionIdError("Must be non-empty")
+    if _has_invisible(canonical):
+        raise SessionIdError("Contains non-printable or invisible characters")
+    if unicodedata.category(canonical[0]) in _COMBINING_CATEGORIES:
+        raise SessionIdError("Begins with a combining mark")
+    if len(canonical) > _MAX_SESSION_ID_LEN:
+        raise SessionIdError(f"Exceeds {_MAX_SESSION_ID_LEN} character limit")
+    return canonical

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
+from petasos.console._validation import SessionIdError, sanitize_session_id
+
 logger = logging.getLogger("petasos.dashboard")
 
 router = APIRouter()
@@ -198,9 +200,10 @@ async def run_scan(request: Request) -> Any:
     if not isinstance(direction, str) or direction not in _VALID_DIRECTIONS:
         err = {"field": "direction", "message": "Must be 'inbound' or 'outbound'"}
         return JSONResponse(status_code=422, content={"detail": [err]})
-    session_id = body.get("session_id")
-    if session_id is not None and not isinstance(session_id, str):
-        err = {"field": "session_id", "message": "Must be a string or null"}
+    try:
+        session_id = sanitize_session_id(body.get("session_id"))
+    except SessionIdError as exc:
+        err = {"field": "session_id", "message": str(exc)}
         return JSONResponse(status_code=422, content={"detail": [err]})
     return await h.run_scan(text, direction=direction, session_id=session_id)
 

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -1,6 +1,13 @@
-"""FastAPI app factory and route handlers for the Petasos Console."""
+"""FastAPI app factory and route handlers for the Petasos Console.
 
-from __future__ import annotations
+No ``from __future__ import annotations`` here: build_app's nested route
+signatures (``request: Request``) must evaluate eagerly in build_app's local
+scope, where the function-local fastapi imports live. With string annotations
+FastAPI resolves against module globals, misses ``Request``, and silently
+treats the parameter as a required query param — every standalone POST/PUT
+422s (pre-existing defect surfaced by the PET-85 route-parity tests).
+TYPE_CHECKING-only names in module-level signatures are quoted instead.
+"""
 
 import hashlib
 import json
@@ -13,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from petasos.console._config_meta import generate_config_metadata
 from petasos.console._ring_buffer import RingBuffer
 from petasos.console._sse import SSEBroadcaster
+from petasos.console._validation import SessionIdError, sanitize_session_id
 from petasos.normalize import normalize
 
 if TYPE_CHECKING:
@@ -89,7 +97,7 @@ def _persist_config(validated_config: Any) -> bool:
 class ConsoleHandlers:
     """Shared route handlers used by both standalone and Hermes plugin modes."""
 
-    def __init__(self, pipeline: Pipeline) -> None:
+    def __init__(self, pipeline: "Pipeline") -> None:
         self.pipeline = pipeline
         self.scan_history = RingBuffer[dict[str, Any]](maxlen=500)
         self.sse = SSEBroadcaster()
@@ -186,6 +194,7 @@ class ConsoleHandlers:
             "result": result.to_dict(),
             "normalized_text": normalized_text,
             "scan_id": scan_id,
+            "session_id": session_id,
         }
 
     async def get_health(self) -> dict[str, Any]:
@@ -244,7 +253,7 @@ def _extract_field_from_error(msg: str, body: dict[str, Any]) -> str:
     return "unknown"
 
 
-def build_app(pipeline: Pipeline) -> FastAPI:
+def build_app(pipeline: "Pipeline") -> "FastAPI":
     """Build the complete FastAPI application."""
     import importlib.resources
 
@@ -317,9 +326,10 @@ def build_app(pipeline: Pipeline) -> FastAPI:
         if not isinstance(direction, str) or direction not in _VALID_DIRECTIONS:
             err = {"field": "direction", "message": "Must be 'inbound' or 'outbound'"}
             return JSONResponse(status_code=422, content={"detail": [err]})
-        session_id = body.get("session_id")
-        if session_id is not None and not isinstance(session_id, str):
-            err = {"field": "session_id", "message": "Must be a string or null"}
+        try:
+            session_id = sanitize_session_id(body.get("session_id"))
+        except SessionIdError as exc:
+            err = {"field": "session_id", "message": str(exc)}
             return JSONResponse(status_code=422, content={"detail": [err]})
         return await handlers.run_scan(text, direction=direction, session_id=session_id)
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -435,6 +435,7 @@
     dirToggle.appendChild(outBtn);
 
     var sessionInput = Pet.h("input", { className: "input mono", style: { width: "120px", height: "30px", fontSize: "12px" }, placeholder: "session_id" });
+    sessionInput.maxLength = 128; // mirrors _MAX_SESSION_ID_LEN; server check is authoritative (PET-85)
 
     var scanBtn = Pet.h("button", { className: "btn btn-primary btn-sm", onClick: function () {
       var text = textArea.value;

--- a/tests/test_console_validation.py
+++ b/tests/test_console_validation.py
@@ -1,0 +1,292 @@
+"""Tests for petasos.console._validation — session_id boundary sanitization (PET-85).
+
+The console scan endpoints (standalone /api/scan and Hermes plugin /scan)
+share sanitize_session_id(): degenerate ids — oversize, empty, the invisible
+character classes — are rejected with field-level 422s, and printable
+homoglyph/compatibility variants collapse to one canonical FrequencyTracker
+key and one ALRT-02 alert-dedup pair. The scan response echoes the canonical
+id (D13), so canonicalization is observable at the API layer.
+
+Every test that takes the params-based ``client`` fixture runs once per route
+flavor, so each rejection-class test IS the route-parity test (same payload →
+same status → same detail[0].field on both routes).
+"""
+
+import unicodedata
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console._validation import SessionIdError, sanitize_session_id  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+_SCAN_TEXT = "hello world this is a test"
+
+
+def _make_pipeline() -> Pipeline:
+    return Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded"),
+    )
+
+
+@pytest.fixture(params=["standalone", "plugin"])
+def client(request: pytest.FixtureRequest) -> Iterator[tuple[TestClient, str]]:
+    """Yield (test_client, scan_path) for each console route flavor.
+
+    Carries its own copy of the plugin-handler reset (pattern from
+    tests/test_plugin_api_sse.py — fixtures are not importable across
+    modules).
+    """
+    import petasos.console.hermes.plugin_api as plugin_mod
+
+    plugin_mod._handlers = None
+    if request.param == "standalone":
+        from petasos.console.server import build_app
+
+        yield TestClient(build_app(_make_pipeline())), "/api/scan"
+    else:
+        from petasos.console.hermes.plugin_api import init_handlers, router
+
+        init_handlers(_make_pipeline())
+        app = FastAPI()
+        app.include_router(router)
+        yield TestClient(app), "/scan"
+    plugin_mod._handlers = None
+
+
+# ── Null / type / emptiness / size ──────────────────────────────────────────
+
+
+def test_null_session_id_passes(client: tuple[TestClient, str]) -> None:
+    assert sanitize_session_id(None) is None
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT})
+    assert resp.status_code == 200
+    assert resp.json()["session_id"] is None
+
+
+@pytest.mark.parametrize("bad", [123, []])
+def test_non_string_rejected(client: tuple[TestClient, str], bad: object) -> None:
+    with pytest.raises(SessionIdError, match="Must be a string or null"):
+        sanitize_session_id(bad)
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": bad})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+def test_empty_string_rejected(client: tuple[TestClient, str]) -> None:
+    with pytest.raises(SessionIdError, match="Must be non-empty"):
+        sanitize_session_id("")
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": ""})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+def test_whitespace_only_rejected(client: tuple[TestClient, str]) -> None:
+    with pytest.raises(SessionIdError, match="Must be non-empty"):
+        sanitize_session_id("   ")
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": "   "})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+def test_oversize_rejected(client: tuple[TestClient, str]) -> None:
+    with pytest.raises(SessionIdError, match="Exceeds 128 character limit"):
+        sanitize_session_id("a" * 129)
+    assert sanitize_session_id("a" * 128) == "a" * 128
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": "a" * 129})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": "a" * 128})
+    assert resp.status_code == 200
+
+
+# ── Control / invisible character classes ───────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["abc\ndef", "abc\x00def"])
+def test_control_chars_rejected(client: tuple[TestClient, str], bad: str) -> None:
+    with pytest.raises(SessionIdError, match="non-printable or invisible"):
+        sanitize_session_id(bad)
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": bad})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+def test_trailing_newline_trimmed(client: tuple[TestClient, str]) -> None:
+    # Regression for PET-85: outer whitespace (incl. C0 whitespace controls) is
+    # trimmed as copy-paste forgiveness (D2); only interior controls reject.
+    assert sanitize_session_id("session\n") == "session"
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": "session\n"})
+    assert resp.status_code == 200
+    assert resp.json()["session_id"] == "session"
+
+
+@pytest.mark.parametrize("bad", ["sess​ion", "‮session"])
+def test_zero_width_rejected(client: tuple[TestClient, str], bad: str) -> None:
+    with pytest.raises(SessionIdError, match="non-printable or invisible"):
+        sanitize_session_id(bad)
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": bad})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+_INVISIBLE_SAMPLES = [
+    "⠀",  # BRAILLE PATTERN BLANK (So, via _is_strippable)
+    "ㅤ",  # HANGUL FILLER
+    "ﾠ",  # HALFWIDTH HANGUL FILLER
+    "ᅟ",  # HANGUL CHOSEONG FILLER
+    "ᅠ",  # HANGUL JUNGSEONG FILLER
+    "͏",  # COMBINING GRAPHEME JOINER
+    "᠏",  # MONGOLIAN FREE VARIATION SELECTOR FOUR (round-2 addition)
+    "឴",  # KHMER VOWEL INHERENT AQ (round-2 addition)
+    "឵",  # KHMER VOWEL INHERENT AA (round-2 addition)
+    "️",  # VARIATION SELECTOR-16
+    "\U00016fe4",  # KHITAN SMALL SCRIPT FILLER (round-3 addition, non-DI)
+    "\U0001bc9d",  # DUPLOYAN THICK LETTER SELECTOR (round-3 addition, non-DI)
+]
+
+
+@pytest.mark.parametrize(
+    "ch", _INVISIBLE_SAMPLES, ids=[f"U+{ord(c):04X}" for c in _INVISIBLE_SAMPLES]
+)
+def test_invisible_printable_rejected(client: tuple[TestClient, str], ch: str) -> None:
+    bad = f"sess{ch}ion"
+    with pytest.raises(SessionIdError, match="non-printable or invisible"):
+        sanitize_session_id(bad)
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": bad})
+    assert resp.status_code == 422
+    assert resp.json()["detail"][0]["field"] == "session_id"
+
+
+# Default_Ignorable_Code_Point ranges transcribed directly from Unicode 14.0.0
+# DerivedCoreProperties.txt — deliberately NOT derived from the production
+# _INVISIBLE_PRINTABLE set, so this sweep fails if that set ever omits an
+# assigned-non-Cf class member (the round-1 FVS4/Khmer failure mode).
+_DEFAULT_IGNORABLE_RANGES: list[tuple[int, int]] = [
+    (0x00AD, 0x00AD),  # SOFT HYPHEN (Cf)
+    (0x034F, 0x034F),  # COMBINING GRAPHEME JOINER (Mn)
+    (0x061C, 0x061C),  # ARABIC LETTER MARK (Cf)
+    (0x115F, 0x1160),  # HANGUL FILLERS (Lo)
+    (0x17B4, 0x17B5),  # KHMER VOWELS INHERENT (Mn)
+    (0x180B, 0x180D),  # MONGOLIAN FVS1-3 (Mn)
+    (0x180E, 0x180E),  # MONGOLIAN VOWEL SEPARATOR (Cf)
+    (0x180F, 0x180F),  # MONGOLIAN FVS4 (Mn)
+    (0x200B, 0x200F),  # ZWSP..RLM (Cf)
+    (0x202A, 0x202E),  # LRE..RLO (Cf)
+    (0x2060, 0x2064),  # WORD JOINER..INVISIBLE PLUS (Cf)
+    (0x2065, 0x2065),  # reserved (Cn)
+    (0x206A, 0x206F),  # deprecated format controls (Cf)
+    (0x3164, 0x3164),  # HANGUL FILLER (Lo)
+    (0xFE00, 0xFE0F),  # VARIATION SELECTORS 1-16 (Mn)
+    (0xFEFF, 0xFEFF),  # ZWNBSP/BOM (Cf)
+    (0xFFA0, 0xFFA0),  # HALFWIDTH HANGUL FILLER (Lo)
+    (0xFFF0, 0xFFF8),  # reserved (Cn)
+    (0x1BCA0, 0x1BCA3),  # SHORTHAND FORMAT controls (Cf)
+    (0x1D173, 0x1D17A),  # MUSICAL SYMBOL beams/slurs (Cf)
+    (0xE0000, 0xE0000),  # reserved (Cn)
+    (0xE0001, 0xE0001),  # LANGUAGE TAG (Cf)
+    (0xE0002, 0xE001F),  # reserved (Cn)
+    (0xE0020, 0xE007F),  # TAG characters (Cf)
+    (0xE0080, 0xE00FF),  # reserved (Cn)
+    (0xE0100, 0xE01EF),  # VARIATION SELECTORS 17-256 (Mn)
+    (0xE01F0, 0xE0FFF),  # reserved (Cn)
+]
+
+
+def test_default_ignorable_rejected() -> None:
+    """Sweep the assigned-non-Cf Default_Ignorable residue (group 1 guard)."""
+    swept = 0
+    for start, end in _DEFAULT_IGNORABLE_RANGES:
+        for cp in range(start, end + 1):
+            ch = chr(cp)
+            if unicodedata.category(ch) in ("Cf", "Cn"):
+                continue  # isprintable() rejects these; group 1 is the assigned-non-Cf residue
+            swept += 1
+            with pytest.raises(SessionIdError):
+                sanitize_session_id(f"a{ch}b")
+    # Unicode 14.0.0: CGJ(1) + Hangul fillers(2) + Khmer(2) + FVS1-4(4)
+    # + HANGUL FILLER(1) + VS1-16(16) + HALFWIDTH FILLER(1) + VS17-256(240) = 267
+    assert swept >= 267
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "¨",  # Mn: NFKC(U+00A8) → <space>+U+0308, strip → bare leading U+0308
+        "́abc",  # Mn: literal leading COMBINING ACUTE ACCENT
+        "िabc",  # Mc: leading DEVANAGARI VOWEL SIGN I
+        "⃝x",  # Me: leading COMBINING ENCLOSING CIRCLE
+    ],
+)
+def test_leading_combining_mark_rejected(bad: str) -> None:
+    with pytest.raises(SessionIdError, match="Begins with a combining mark"):
+        sanitize_session_id(bad)
+
+
+def test_spacing_accent_accepted_visibly() -> None:
+    # D9 accepted residue: NFKC(U+00A8) = <space>+combining-diaeresis; the mark
+    # anchors to the NFKC-introduced visible space, so "a¨b" is a visibly
+    # distinct key — and stays distinct from "a´b" (no homoglyph collapse).
+    out_diaeresis = sanitize_session_id("a¨b")
+    out_acute = sanitize_session_id("a´b")
+    assert out_diaeresis == "a ̈b"
+    assert out_acute == "a ́b"
+    assert out_diaeresis != out_acute
+
+
+# ── Canonicalization (printable confusables collapse) ───────────────────────
+
+
+def test_homoglyph_canonicalized() -> None:
+    # Equal canonical ids ⟺ same FrequencyTracker key and ALRT-02 dedup pair.
+    assert sanitize_session_id("bаd-actor") == sanitize_session_id("bad-actor") == "bad-actor"
+
+
+def test_fullwidth_canonicalized() -> None:
+    assert sanitize_session_id("ｈｅｒｍｅｓ－４２") == "hermes-42"
+
+
+def test_response_echoes_canonical_session_id(client: tuple[TestClient, str]) -> None:
+    # D13: canonicalization is silent (D3) but observable in the response.
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT, "session_id": "bаd-actor"})
+    assert resp.status_code == 200
+    assert resp.json()["session_id"] == "bad-actor"
+
+
+def test_nfkc_expansion_capped() -> None:
+    # 128 ﬃ ligatures pass the pre-NFKC cap, expand to 384 chars post-NFKC (D5).
+    with pytest.raises(SessionIdError, match="Exceeds 128 character limit"):
+        sanitize_session_id("ﬃ" * 128)
+
+
+def test_plain_ascii_unchanged() -> None:
+    sid = "hermes-session-42"
+    out = sanitize_session_id(sid)
+    assert out == sid
+    assert out is not None
+    assert len(out) == len(sid)
+
+
+def test_visible_unicode_id_accepted() -> None:
+    # Devanagari "namaste" — combining matras attach to visible bases, so the
+    # leading-mark check must not fire (guards against over-rejection, D3).
+    sid = "नमस्ते-42"
+    assert sanitize_session_id(sid) == sid


### PR DESCRIPTION
## Summary
- New `sanitize_session_id()` boundary validator shared by both console scan endpoints (standalone `/api/scan`, Hermes plugin `/scan`): rejects oversize/empty/invisible-character session ids with field-level 422s, canonicalizes printable homoglyph/compatibility confusables (NFKC + homoglyph fold, no casefold), and the scan response now echoes the canonical id (D13).
- Closes the ALRT-02 invisible-variant evasion via a principled predicate (D12): `str.isprintable()` ∪ `normalize._is_strippable` ∪ the assigned-non-Cf Default_Ignorable residue + known non-DI zero-glyph fillers, plus a standalone leading-combining-mark check — not an example-chasing denylist.
- Fixes a pre-existing standalone-console defect surfaced by the new route-parity tests: with `from __future__ import annotations`, FastAPI resolved the nested routes' `request: Request` annotation against module globals, missed the function-local import, and treated `request` as a required *query* param — every standalone `POST /api/scan` and `PUT /api/config` returned 422 at HEAD `5d10761`. Same defect class PET-81 fixed in `plugin_api.py`.

## Layered defense
Rules run in order: type/null gate → outer-whitespace trim (D2 copy-paste forgiveness) → pre-NFKC length cap → invisible-class rejection → NFKC + homoglyph canonicalization → full post-canonicalization re-verification (D9: non-empty, invisible recheck, leading-mark, post-NFKC cap). Equal canonical ids ⟺ same FrequencyTracker key and same `(rule_id, session_id)` ALRT-02 dedup pair; `test_response_echoes_canonical_session_id` proves it end-to-end through both routes.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_validation.py` | New — `SessionIdError`, `sanitize_session_id()`, `_INVISIBLE_PRINTABLE`, invisible predicate |
| `petasos/console/server.py` | Wires helper into `api_run_scan`; adds canonical `session_id` response echo; removes future-annotations import (pre-existing `Request`-resolution defect) |
| `petasos/console/hermes/plugin_api.py` | Wires same helper into plugin `run_scan` |
| `petasos/console/static/petasos.js` | Defensive — playground session input mirrors `maxLength = 128` (server authoritative) |
| `tests/test_console_validation.py` | New — 24 cases: params-based standalone/plugin parity fixture, Default_Ignorable sweep (independently transcribed from `DerivedCoreProperties.txt`), Mn/Mc/Me leading-mark branches |
| `docs/specs/TODO/PET-85.test-output.txt` | Test gate evidence |

## Test plan
- [x] `python -m pytest tests/test_console_validation.py tests/test_console_handlers.py tests/test_plugin_api_sse.py -v` — 81/81 pass (full output: docs/specs/TODO/PET-85.test-output.txt)
- [x] `python -m pytest` — 1052 passed, 58 skipped, 1 xfailed
- [x] `python -m ruff check .` / `python -m ruff format --check .` — clean
- [x] `python -m mypy --strict .` — clean (95 source files)
- [x] Spec: `docs/specs/TODO/PET-85.spec.md` (v4, green at review round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced session ID validation and canonicalization for console scan operations; sanitized IDs are echoed back in responses.

* **Bug Fixes**
  * Invalid session IDs now return HTTP 422 with field-level error details.
  * Enforced non-empty values, 128-character maximum, and rejection of control/invisible characters (including leading combining marks).

* **Tests**
  * Added comprehensive tests covering boundary cases, Unicode/invisible characters, normalization, and API behavior.

* **Documentation**
  * Included captured test output demonstrating successful test and lint runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->