### PR TITLE
fix(pet-96): hermetic _blocked_import — staged axes beat real venv state

### DIFF
--- a/.github/workflows/extras-llamafirewall.yml
+++ b/.github/workflows/extras-llamafirewall.yml
@@ -1,0 +1,19 @@
+# PET-96: weekly lane with the real llamafirewall extra installed, so
+# "real package present" stops being a local-only configuration.
+# TestIntegration self-skips via _skip_integration (no HF token/model in CI).
+name: extras-llamafirewall
+on:
+  schedule:
+    - cron: "23 6 * * 1" # Mondays 06:23 UTC — off-peak, off-minute
+  workflow_dispatch:
+jobs:
+  scanner-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[llamafirewall,dev]"
+      - run: pytest tests/test_llama_firewall_scanner.py -v --tb=short

--- a/docs/specs/TODO/PET-96.test-output.txt
+++ b/docs/specs/TODO/PET-96.test-output.txt
@@ -1,0 +1,12 @@
+.........................................                                [100%]
+41 passed, 12 deselected in 0.15s
+--- ruff check ---
+All checks passed!
+--- ruff format --check ---
+102 files already formatted
+--- mypy --strict ---
+Success: no issues found in 102 source files
+--- full suite (reduced deviation set: TestIntegration only, was 8 now 7) ---
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1239 passed, 4 skipped, 12 deselected, 1 xfailed, 55 warnings in 28.15s

--- a/tests/test_llama_firewall_scanner.py
+++ b/tests/test_llama_firewall_scanner.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import asyncio
 import builtins
 import enum
+import importlib.util
 import os
+import shutil
 import sys
+import tempfile
 import time
 import types
 from contextlib import contextmanager
@@ -43,6 +46,10 @@ _skip_integration = pytest.mark.skipif(
 
 
 # ---- Helpers ----
+
+# HF hub cache directory name for the PromptGuard model — the exact path
+# _prompt_guard_prereq_error probes (llama_firewall.py model_dir_name).
+_PROMPT_GUARD_MODEL_DIR = "models--meta-llama--Llama-Prompt-Guard-2-86M"
 
 
 def _find(result: ScanResult, rule_id: str) -> bool:
@@ -149,27 +156,56 @@ def _injected_mock(
 
 @contextmanager
 def _blocked_import() -> Iterator[None]:
+    """Simulate 'backend not installed' authoritatively: blocks __import__,
+    blanks find_spec, and neutralizes PromptGuard prereq env reads so real
+    venv/cache state cannot leak past the staged axis (PET-96)."""
+    # Fallible setup (mkdtemp) runs before any process-global mutation, so a
+    # failure here leaves sys.modules and the patches untouched.
+    hermetic_home = tempfile.mkdtemp(prefix="petasos-hermetic-hf-")
+    saved_env: dict[str, str | None] = {
+        k: os.environ.get(k)
+        for k in ("HF_HOME", "HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_TOKEN_PATH")
+    }
+
     saved: dict[str, types.ModuleType] = {}
     for key in list(sys.modules):
         if key == "llamafirewall" or key.startswith("llamafirewall."):
             saved[key] = sys.modules.pop(key)
 
     real_import = builtins.__import__
+    real_find_spec = importlib.util.find_spec
 
     def blocking(name: str, *args: Any, **kwargs: Any) -> Any:
         if name == "llamafirewall" or name.startswith("llamafirewall."):
-            raise ImportError(f"blocked: {name}")
+            raise ImportError(f"blocked: {name}", name=name)
         return real_import(name, *args, **kwargs)
 
+    def blank_find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "llamafirewall" or name.startswith("llamafirewall."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    os.environ["HF_HOME"] = hermetic_home
+    for k in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_TOKEN_PATH"):
+        os.environ.pop(k, None)
+
     builtins.__import__ = blocking
+    importlib.util.find_spec = blank_find_spec
     try:
         yield
     finally:
         builtins.__import__ = real_import
+        importlib.util.find_spec = real_find_spec
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
         for key in list(sys.modules):
             if key == "llamafirewall" or key.startswith("llamafirewall."):
                 del sys.modules[key]
         sys.modules.update(saved)
+        shutil.rmtree(hermetic_home, ignore_errors=True)
 
 
 # ==============================================================
@@ -298,7 +334,8 @@ class TestUnit:
 
 
 # ==============================================================
-# PET-87: availability, prereq predicate, stdin tripwire, recovery
+# PET-87 / PET-96: availability, prereq predicate, stdin tripwire,
+# recovery, probe isolation
 # ==============================================================
 
 
@@ -328,6 +365,28 @@ class TestAvailabilityProbe:
         assert reason == "GPU corrupted"
 
 
+class TestProbeIsolation:
+    async def test_probe_isolation_hermetic(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression for PET-96: fixture-controlled probe verdicts beat real
+        # venv/cache state. Fabricate the worst-case leak-bait environment
+        # (model dir cached + token set), then assert the blocked axis wins.
+        bait_home = str(tmp_path)
+        os.makedirs(os.path.join(bait_home, "hub", _PROMPT_GUARD_MODEL_DIR))
+        monkeypatch.setenv("HF_HOME", bait_home)
+        monkeypatch.setenv("HF_TOKEN", "hf_fake_token")
+
+        with _blocked_import():
+            scanner = LlamaFirewallScanner()
+            avail, reason = scanner.availability()
+            assert avail is False
+            assert reason is not None and "pip install" in reason
+            r = await scanner.scan("probe")
+            assert r.error is not None
+            assert scanner._load_error_retryable is True
+
+
 class TestPromptGuardPrereqPredicate:
     def test_disabled_returns_none(self) -> None:
         assert _prompt_guard_prereq_error(False) is None
@@ -336,7 +395,7 @@ class TestPromptGuardPrereqPredicate:
         self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         hf_home = str(tmp_path / "hf")
-        model_dir = os.path.join(hf_home, "hub", "models--meta-llama--Llama-Prompt-Guard-2-86M")
+        model_dir = os.path.join(hf_home, "hub", _PROMPT_GUARD_MODEL_DIR)
         os.makedirs(model_dir)
         monkeypatch.setenv("HF_HOME", hf_home)
         monkeypatch.delenv("HF_TOKEN", raising=False)
@@ -564,9 +623,7 @@ class TestCrossAxisRecovery:
         assert "PromptGuard model unavailable" in r2.error
         assert scanner._load_error_retryable is True
 
-        model_dir = os.path.join(
-            str(tmp_path), "hub", "models--meta-llama--Llama-Prompt-Guard-2-86M"
-        )
+        model_dir = os.path.join(str(tmp_path), "hub", _PROMPT_GUARD_MODEL_DIR)
         os.makedirs(model_dir)
         monkeypatch.setenv("HF_TOKEN", "hf_fake_token")
 


### PR DESCRIPTION
## Summary
- Fixes `TestCrossAxisRecovery::test_blocked_to_prereq_to_healthy` failing with a real `llamafirewall` install (PET-87 residual, CI-invisible). Root cause classified **(a) test-isolation defect** with traceback evidence on the ticket: `_blocked_import` patched `builtins.__import__` only, so `availability()`'s `find_spec` probe and the PromptGuard prereq's cache/token reads saw **real environment state** — the partial PromptGuard model dir now in the local HF cache flipped the prereq verdict, and PET-87's classifier honestly concluded "package present + prereqs OK + import exploded = in-process breakage" (non-retryable) instead of the staged availability-blocked axis.
- **No production change** — the scanner's classification is PET-87-correct; the fixture now makes the staged axis authoritative: blanks `importlib.util.find_spec` for `llamafirewall*`, raises a name-carrying `ImportError` (faithful missing-package shape for `_is_missing_package`), neutralizes `HF_HOME`/token env reads, full save/restore including temp-dir cleanup.
- Adds a weekly + on-demand CI lane installing the real extra, so "real package present" stops being a local-only configuration.

## Two-environment proof
The fixed test and the new regression test pass **both** with the real package (hermes venv — the bug-definition environment) and without it (per-PR CI, mock-only). `TestProbeIsolation::test_probe_isolation_hermetic` fabricates the worst-case leak-bait state (fake cached model dir + fake `HF_TOKEN`) and asserts the blocked axis still wins — a faithful reproduction of the PET-96 failure on the pre-fix fixture.

## Files changed

| File | Change |
|------|--------|
| `tests/test_llama_firewall_scanner.py` | Hermetic `_blocked_import` (find_spec blank + name-carrying ImportError + env neutralization + rmtree); new `TestProbeIsolation` regression class; `_PROMPT_GUARD_MODEL_DIR` constant deduped across 3 sites; section banner widened PET-87/PET-96 |
| `.github/workflows/extras-llamafirewall.yml` | New — weekly (Mon 06:23 UTC) + `workflow_dispatch` lane, `timeout-minutes: 30`, installs `.[llamafirewall,dev]`, runs the scanner file; `TestIntegration` self-skips via `_skip_integration` (no HF token/model in CI) |

## Test plan
- [x] `python -m pytest tests/test_llama_firewall_scanner.py -q --deselect ...::TestIntegration` (pinned hermes venv, **real llamafirewall installed**) — 41/41 pass incl. the previously-failing cross-axis test (full output: docs/specs/TODO/PET-96.test-output.txt)
- [x] `python -m ruff check .` / `format --check` — clean
- [x] `python -m mypy --strict .` — clean, 102 files (no `type: ignore` needed on the find_spec assignments)
- [x] Full suite with the **reduced** deviation set (TestIntegration only — the cross-axis deselect is dropped by this fix): 1239 passed, 0 failed. Known deviations shrink 8 → 7.
- [ ] Post-merge: first green `workflow_dispatch` run of the extras lane, recorded on PET-96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation for the scanner to ensure hermetic behavior and reliable cleanup
  * Added new coverage validating isolation and retryable load error handling

* **Chores**
  * Configured scheduled CI job to run scanner tests weekly with manual trigger option

* **Documentation**
  * Added recorded test-run summary to project docs for verification and auditing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->