### PR TITLE
fix(pet-100): expanduser HF_HOME in prereq probe, accept both model layouts

### DIFF
--- a/docs/specs/TODO/PET-100.test-output.txt
+++ b/docs/specs/TODO/PET-100.test-output.txt
@@ -1,0 +1,22 @@
+=== PET-100 test gate — 2026-06-12, worktree @ fix/pet-100-prereq-hf-home-expanduser (base 3ef41f3) ===
+HF_HOME deliberately UNSET for the run — the in-process pollution scenario (first PromptGuard load
+sets a literal '~/.cache/huggingface') is exercised live by TestIntegration ordering and now passes.
+2 deselects: CodeShield-only tests, upstream codeshield broken on native Windows (PET-101).
+
+--- cmd 1: scanner test file ---
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+53 passed, 2 deselected, 9 warnings in 8.71s
+exit: 0
+
+--- cmd 2: full suite ---
+  OPS: Operations Per Second, computed as 1 / Mean
+1272 passed, 2 deselected, 1 xfailed, 57 warnings in 42.45s
+exit: 0
+
+--- cmd 3: ruff check . ---
+All checks passed!
+exit: 0
+
+--- cmd 4: mypy --strict . ---
+Success: no issues found in 103 source files
+exit: 0

--- a/petasos/scanners/llama_firewall.py
+++ b/petasos/scanners/llama_firewall.py
@@ -84,12 +84,22 @@ def _prompt_guard_prereq_error(enable_prompt_guard: bool) -> str | None:
         hf_home = os.environ.get("HF_HOME", "")
         if not hf_home:
             hf_home = os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
+        # llamafirewall sets HF_HOME to a literal "~/.cache/huggingface" after
+        # its first PromptGuard load (promptguard_utils, unexpanded), so every
+        # later probe in the process would isdir() a literal "~" path and
+        # false-negative. Expand to survive that in-process pollution (PET-100).
+        hf_home = os.path.expanduser(hf_home)
 
         model_id = "meta-llama/Llama-Prompt-Guard-2-86M"
         model_dir_name = model_id.replace("/", "--")
-        model_path = os.path.join(hf_home, "hub", f"models--{model_dir_name}")
+        # Two cache layouts satisfy the prerequisite: the HF hub cache
+        # (hub/models--…, written by snapshot_download/from_pretrained) and
+        # llamafirewall's own save_pretrained dir (HF_HOME/meta-llama--…, the
+        # path it actually loads from) (PET-100).
+        hub_path = os.path.join(hf_home, "hub", f"models--{model_dir_name}")
+        local_path = os.path.join(hf_home, model_dir_name)
 
-        if os.path.isdir(model_path):
+        if os.path.isdir(hub_path) or os.path.isdir(local_path):
             return None
 
         token = os.environ.get("HF_TOKEN", "").strip()

--- a/tests/test_llama_firewall_scanner.py
+++ b/tests/test_llama_firewall_scanner.py
@@ -51,6 +51,10 @@ _skip_integration = pytest.mark.skipif(
 # _prompt_guard_prereq_error probes (llama_firewall.py model_dir_name).
 _PROMPT_GUARD_MODEL_DIR = "models--meta-llama--Llama-Prompt-Guard-2-86M"
 
+# llamafirewall's own save_pretrained layout (directly under HF_HOME, no
+# hub/, no models-- prefix) — the dir it actually loads from (PET-100).
+_PROMPT_GUARD_LOCAL_DIR = "meta-llama--Llama-Prompt-Guard-2-86M"
+
 
 def _find(result: ScanResult, rule_id: str) -> bool:
     return any(f.rule_id == rule_id for f in result.findings)
@@ -444,6 +448,39 @@ class TestPromptGuardPrereqPredicate:
         monkeypatch.delenv("HF_TOKEN_PATH", raising=False)
         result = _prompt_guard_prereq_error(True)
         assert result is not None
+
+    def test_polluted_tilde_hf_home_expanded(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression for PET-100: llamafirewall sets HF_HOME to a literal
+        # unexpanded "~/.cache/huggingface" after its first PromptGuard load;
+        # the probe must expanduser or every later in-process scanner
+        # construction false-negatives despite the model being cached.
+        monkeypatch.setenv("HOME", str(tmp_path))  # posixpath expanduser
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))  # ntpath expanduser
+        model_dir = os.path.join(
+            str(tmp_path), ".cache", "huggingface", "hub", _PROMPT_GUARD_MODEL_DIR
+        )
+        os.makedirs(model_dir)
+        monkeypatch.setenv("HF_HOME", "~/.cache/huggingface")  # the polluted literal
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+        monkeypatch.delenv("HF_TOKEN_PATH", raising=False)
+        assert _prompt_guard_prereq_error(True) is None
+
+    def test_save_pretrained_layout_returns_none(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression for PET-100: llamafirewall loads from its own
+        # save_pretrained dir (HF_HOME/meta-llama--…, no hub/ segment) — a
+        # machine with only that layout has the model and must pass the probe.
+        hf_home = str(tmp_path / "hf")
+        os.makedirs(os.path.join(hf_home, _PROMPT_GUARD_LOCAL_DIR))
+        monkeypatch.setenv("HF_HOME", hf_home)
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+        monkeypatch.delenv("HF_TOKEN_PATH", raising=False)
+        assert _prompt_guard_prereq_error(True) is None
 
 
 class TestFailFast:


### PR DESCRIPTION
## Summary
- Fixes a cross-platform false-negative in `_prompt_guard_prereq_error`: llamafirewall pollutes `os.environ["HF_HOME"]` with a literal unexpanded `~/.cache/huggingface` after its first PromptGuard load (`promptguard_utils.py`), and the probe joined paths against that literal string — `isdir("~/...")` is False on every OS — so every *subsequent* `LlamaFirewallScanner` constructed in the process fail-fasted with "PromptGuard model unavailable" despite a fully cached model and token. The probe now `expanduser()`s `HF_HOME` (idempotent on already-expanded values).
- The probe also recognizes llamafirewall's actual load layout: its `save_pretrained` dir at `HF_HOME/meta-llama--Llama-Prompt-Guard-2-86M` (no `hub/` segment, no `models--` prefix), in addition to the HF hub cache layout. A machine with only the save_pretrained dir has the model and must pass.
- Discovered 2026-06-12 during HF gated-model verification: first TestIntegration test passed (loads model, pollutes env), the remaining ones died at ~0.1 ms with the prereq error. Full diagnosis on PET-100.

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/llama_firewall.py` | Fixes: `expanduser` on `HF_HOME`; dual-layout model check (`hub_path` or `local_path`) |
| `tests/test_llama_firewall_scanner.py` | Adds `test_polluted_tilde_hf_home_expanded` (HOME/USERPROFILE redirected to `tmp_path` for hermetic expansion) and `test_save_pretrained_layout_returns_none`; new `_PROMPT_GUARD_LOCAL_DIR` constant |

## Test plan
- [x] `python -m pytest tests/test_llama_firewall_scanner.py -q` — 53/53 pass **with `HF_HOME` unset**, exercising the live pollution scenario (previously only the first TestIntegration test survived it)
- [x] `python -m pytest -q` — 1272 pass, 1 xfail (full output: docs/specs/TODO/PET-100.test-output.txt); 2 deselects are the CodeShield-only tests blocked by upstream codeshield on native Windows (PET-101, unrelated)
- [x] `ruff check .` — clean
- [x] `mypy --strict .` — clean, 103 files

Known residue (documented on PET-100, deliberately not changed here): a hub-cache hit with *no* token still passes the probe but llamafirewall would prompt at load time — tightening that arm is a behavior change beyond this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PromptGuard prerequisite detection to avoid false-negative checks caused by unexpanded environment path values.

* **Tests**
  * Added regression tests covering PromptGuard model detection with various HF_HOME/layout scenarios.

* **Documentation**
  * Added a recorded PET-100 test run showing all test suites and code quality checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->