### PR TITLE
fix(pet-104): close llm_guard weakref test-coverage gap with non-skipping lane

### DIFF
--- a/.github/workflows/extras-llm-guard.yml
+++ b/.github/workflows/extras-llm-guard.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "petasos/scanners/llm_guard.py"
       - "tests/test_llm_guard_wrapper.py"
+      - "tests/conftest.py" # home of the fail-loud collection guard this lane arms
   schedule:
     - cron: "47 5 * * 1" # Mondays 05:47 UTC — off-peak, off-minute, distinct from extras-llamafirewall
   workflow_dispatch:

--- a/.github/workflows/extras-llm-guard.yml
+++ b/.github/workflows/extras-llm-guard.yml
@@ -1,0 +1,29 @@
+# PET-104: non-skipping lane with the real llm-guard extra installed, so the
+# "loads under a non-weakref-able host stdio wrapper" path (PET-92 shield) is
+# exercised by passing CI instead of silently self-skipping. Runs on the
+# shipping PR (path-filtered) — not cron-only — so a future shield change can't
+# merge green without running the path (spec D2). PETASOS_REQUIRE_LLM_GUARD=1
+# arms the collection-time fail-loud guard in tests/conftest.py (spec D3): with
+# the extra present, TestIntegrationWrappedStdio must run, never skip.
+name: extras-llm-guard
+on:
+  pull_request:
+    paths:
+      - "petasos/scanners/llm_guard.py"
+      - "tests/test_llm_guard_wrapper.py"
+  schedule:
+    - cron: "47 5 * * 1" # Mondays 05:47 UTC — off-peak, off-minute, distinct from extras-llamafirewall
+  workflow_dispatch:
+jobs:
+  scanner-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PETASOS_REQUIRE_LLM_GUARD: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[llm-guard,dev]"
+      - run: pytest tests/test_llm_guard_wrapper.py -v --tb=short

--- a/docs/specs/TODO/PET-104.test-output.txt
+++ b/docs/specs/TODO/PET-104.test-output.txt
@@ -1,0 +1,51 @@
+PET-104 — local test gate (interpreter: C:\python310\python.exe, Python 3.10.6)
+NOTE: llm-guard extra is NOT installed locally, so the 4 TestIntegrationWrappedStdio
+rows (incl. the new test_no_weakref_error_during_scanner_construction) self-skip here.
+Authoritative verification of those rows is the extras-llm-guard CI lane on this PR
+(pip install -e .[llm-guard,dev] + PETASOS_REQUIRE_LLM_GUARD=1 arms the fail-loud guard).
+
+===================================================================================
+$ pytest tests/test_llm_guard_wrapper.py -v --tb=short
+===================================================================================
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-104-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 8 items
+
+tests/test_llm_guard_wrapper.py::TestSlotsWriterRejectsWeakref::test_slots_writer_rejects_weakref PASSED [ 12%]
+tests/test_llm_guard_wrapper.py::TestProxySupportsWeakref::test_proxy_supports_weakref PASSED [ 25%]
+tests/test_llm_guard_wrapper.py::TestProxyDelegation::test_proxy_write_delegates_to_current_stdout PASSED [ 37%]
+tests/test_llm_guard_wrapper.py::TestProxyNoneStdout::test_proxy_handles_none_stdout PASSED [ 50%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_scan_with_wrapped_stdout SKIPPED [ 62%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_wrapped_stdout_restored_after_init SKIPPED [ 75%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_no_weakref_requirement_on_stdio SKIPPED [ 87%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_no_weakref_error_during_scanner_construction SKIPPED [100%]
+
+======================== 4 passed, 4 skipped in 0.04s =========================
+
+===================================================================================
+$ PETASOS_REQUIRE_LLM_GUARD=1 pytest tests/test_llm_guard_wrapper.py --collect-only  (guard fail-loud evidence; llm-guard absent locally -> ERROR by design)
+===================================================================================
+ERROR: extras-llm-guard lane requires the real llm-guard extra, but importing `llm_guard.input_scanners` (the symbol LlmGuardScanner._do_load loads) failed: No module named 'llm_guard'. Install with: pip install -e ".[llm-guard,dev]".
+(exit 4 = pytest UsageError raised by the conftest collection guard)
+
+===================================================================================
+$ pytest   (full suite)
+===================================================================================
+........................................................................ [ 95%]
+.....................................................                    [100%]
+1162 passed, 45 skipped, 1 xfailed in 22.17s
+
+===================================================================================
+$ ruff check .
+===================================================================================
+All checks passed!
+
+===================================================================================
+$ mypy --strict .
+===================================================================================
+Success: no issues found in 103 source files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+import os
 import pathlib
 from datetime import datetime, timedelta, timezone
 
@@ -48,3 +50,64 @@ def expired_token() -> str:
 @pytest.fixture()
 def valid_key() -> str:
     return _make_token()
+
+
+def _item_class_name(item: pytest.Item) -> str | None:
+    """Return the name of the test class owning ``item``, or None for module-level
+    functions. ``cls`` is a ``pytest.Function`` attribute, absent on bare items."""
+    cls = getattr(item, "cls", None)
+    if cls is None:
+        return None
+    name: str = cls.__name__
+    return name
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """PET-104 C — collection-time fail-loud guard for the extras-llm-guard lane.
+
+    When ``PETASOS_REQUIRE_LLM_GUARD=1`` (set only in the extras-llm-guard job's
+    ``env`` block), assert the real backend is importable via the same symbol
+    ``LlmGuardScanner._do_load`` loads — ``llm_guard.input_scanners``, not a
+    top-level ``find_spec`` — and that ``TestIntegrationWrappedStdio`` is
+    collected unskipped. Otherwise fail collection loudly, naming the lane and
+    the missing import. A no-op when the env var is unset, so the default
+    ``ci.yml`` lane and local dev keep the existing ``@_skip_no_llm_guard``
+    self-skip unchanged (spec D3).
+
+    Controller-gated: under ``pytest-xdist`` only the controller (which lacks a
+    ``workerinput`` attribute) runs this, so the message is emitted once and
+    stays stable.
+    """
+    if os.environ.get("PETASOS_REQUIRE_LLM_GUARD") != "1":
+        return
+    if hasattr(config, "workerinput"):
+        return
+
+    lane = "extras-llm-guard"
+    try:
+        importlib.import_module("llm_guard.input_scanners")
+    except ImportError as exc:
+        raise pytest.UsageError(
+            f"{lane} lane requires the real llm-guard extra, but importing "
+            f"`llm_guard.input_scanners` (the symbol LlmGuardScanner._do_load "
+            f'loads) failed: {exc}. Install with: pip install -e ".[llm-guard,dev]".'
+        ) from exc
+
+    target = "TestIntegrationWrappedStdio"
+    in_class = [item for item in items if _item_class_name(item) == target]
+    if not in_class:
+        raise pytest.UsageError(
+            f"{lane} lane: {target} (tests/test_llm_guard_wrapper.py) was not "
+            f"collected. The non-weakref-able stdio path must run, not vanish."
+        )
+    would_skip = [
+        item
+        for item in in_class
+        if any(mark.args and mark.args[0] for mark in item.iter_markers(name="skipif"))
+    ]
+    if would_skip:
+        raise pytest.UsageError(
+            f"{lane} lane: {target} is collected but {len(would_skip)} item(s) "
+            f"would skip despite llm-guard being importable. The lane must "
+            f"exercise the shield, not skip it."
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,11 +100,16 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             f"{lane} lane: {target} (tests/test_llm_guard_wrapper.py) was not "
             f"collected. The non-weakref-able stdio path must run, not vanish."
         )
-    would_skip = [
-        item
-        for item in in_class
-        if any(mark.args and mark.args[0] for mark in item.iter_markers(name="skipif"))
-    ]
+
+    def _would_skip(item: pytest.Item) -> bool:
+        # A plain @pytest.mark.skip (unconditional) is not a skipif and would
+        # otherwise sail past the guard, skipping the class despite llm-guard
+        # being importable — exactly what this lane must catch.
+        if item.get_closest_marker("skip") is not None:
+            return True
+        return any(mark.args and bool(mark.args[0]) for mark in item.iter_markers(name="skipif"))
+
+    would_skip = [item for item in in_class if _would_skip(item)]
     if would_skip:
         raise pytest.UsageError(
             f"{lane} lane: {target} is collected but {len(would_skip)} item(s) "

--- a/tests/test_llm_guard_wrapper.py
+++ b/tests/test_llm_guard_wrapper.py
@@ -175,6 +175,57 @@ def hostile_stdio(
         _restore()
 
 
+@pytest.fixture
+def hostile_stdio_unconfigured(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[_SlotsOnlyWriter, _SlotsOnlyWriter]]:
+    """Like ``hostile_stdio`` but **without** the pre-scan ``configure_logger``.
+
+    PET-104 D4: ``hostile_stdio`` calls ``configure_logger(stream=sys.stdout)``
+    in setup, so structlog's first emission happens at fixture time — that path
+    passes even if the construction window were unshielded. This fixture installs
+    the slots-only wrappers and stops, so the first structlog emission lands
+    *during scanner construction* (inside ``_do_load``), with the raw
+    non-weakref-able wrapper live as ``sys.stdout``. That is the true
+    construction-window path Step 0 reproduced.
+
+    Restoration is registered *before* any global mutation so a setup failure
+    (including the tripwire below) still restores stdio for downstream tests.
+    """
+    saved_out, saved_err = sys.stdout, sys.stderr
+
+    def _restore() -> None:
+        sys.stdout, sys.stderr = saved_out, saved_err
+
+    request.addfinalizer(_restore)
+
+    out_wrapper = _SlotsOnlyWriter(io.StringIO())
+    err_wrapper = _SlotsOnlyWriter(io.StringIO())
+    sys.stdout = cast("TextIO", out_wrapper)
+    sys.stderr = cast("TextIO", err_wrapper)
+
+    # Loud tripwire: the wrapper must be non-weakref-able, or the guard is moot.
+    with pytest.raises(TypeError):
+        weakref.ref(sys.stdout)
+
+    # Intentionally NO configure_logger here (the whole point — see docstring).
+    yield out_wrapper, err_wrapper
+
+    # Teardown: restore real streams, then re-bind structlog to a weakref-able
+    # stream. The scan's _do_load points structlog at the shield proxy, but a
+    # scan that errored before that point could leave it elsewhere; re-bind
+    # defensively so no downstream test inherits the slots-only writer (mirrors
+    # hostile_stdio). The re-bind is swap-triggering on Windows — the final
+    # restore must survive it.
+    _restore()
+    from llm_guard.util import configure_logger
+
+    try:
+        configure_logger(stream=sys.stdout)
+    finally:
+        _restore()
+
+
 @_skip_no_llm_guard
 class TestIntegrationWrappedStdio:
     """Tests 5-7: scans survive non-weakref-able stdio wrappers (PET-92).
@@ -224,3 +275,20 @@ class TestIntegrationWrappedStdio:
         result = await scanner.scan("clean everyday text about the weather")
         assert result.error is None
         assert "weak reference" not in (result.error or "")
+
+    async def test_no_weakref_error_during_scanner_construction(
+        self,
+        hostile_stdio_unconfigured: tuple[_SlotsOnlyWriter, _SlotsOnlyWriter],
+    ) -> None:
+        # Regression for PET-104: the construction-window path. Unlike
+        # test_scan_with_wrapped_stdout (which pre-binds structlog via
+        # hostile_stdio's configure_logger call), this test does NOT
+        # pre-configure — so the first structlog emission lands during scanner
+        # construction inside _do_load, with the raw non-weakref-able wrapper
+        # live as sys.stdout. This mirrors the Step-0 reproduction: it passes
+        # under the PET-92 shield and would have been RED against pre-PET-92
+        # code, which is exactly the coverage gap PET-104 closes.
+        scanner = LlmGuardScanner()
+        result = await scanner.scan(_INJECTION_TEXT)
+        assert result.error is None
+        assert any(f.rule_id == "petasos.llmguard.injection" for f in result.findings)


### PR DESCRIPTION
## Summary
- Closes the PET-104 test-coverage gap: the PET-92 stdio weakref shield was only exercised by `@skipif`-gated integration tests that **skip silently** wherever the `llm-guard` extra is absent, so the green gate never proved the shield works under a non-weakref-able host stdio wrapper.
- **Test + CI only — no `petasos/` runtime change.** Step 0 (recorded in the spec) verified the shield is correct and the live failure was a stale process; the bounded-retry/honest-health hardening moved to PET-108.
- Adds the missing construction-window regression test, a collection-time fail-loud guard, and a dedicated `extras-llm-guard` lane that runs the real backend on the shipping PR and cannot silently skip.

## Layered defense
1. **Construction-window test** — the existing `test_scan_with_wrapped_stdout` pre-binds structlog via `hostile_stdio`'s `configure_logger` call, so its first emission is at fixture setup and it would pass even if the construction window were unshielded (spec D4). The new `hostile_stdio_unconfigured` fixture omits that call, so the first structlog emission lands *during scanner construction inside `_do_load`* with the raw slots-only wrapper live — the true path Step 0 reproduced. RED against pre-PET-92 code.
2. **Fail-loud guard** — a `pytest_collection_modifyitems` hook armed only by `PETASOS_REQUIRE_LLM_GUARD=1` asserts `llm_guard.input_scanners` imports (the symbol `_do_load` loads, not a top-level `find_spec`) and that `TestIntegrationWrappedStdio` is collected unskipped; otherwise collection fails with a lane-naming message. Controller-gated no-op by default (local dev + `ci.yml` keep the `@_skip_no_llm_guard` self-skip).
3. **CI lane** — `extras-llm-guard.yml` sets the guard env var, installs `.[llm-guard,dev]`, and runs the wrapper suite. Triggering on path-filtered `pull_request` (not cron-only) means a future shield change cannot merge green without running the path (spec D2).

## Files changed

| File | Change |
|------|--------|
| `tests/test_llm_guard_wrapper.py` | Adds `hostile_stdio_unconfigured` fixture + `test_no_weakref_error_during_scanner_construction` (construction-window regression) |
| `tests/conftest.py` | Adds `pytest_collection_modifyitems` fail-loud guard (+ `_item_class_name` helper), armed by `PETASOS_REQUIRE_LLM_GUARD=1` |
| `.github/workflows/extras-llm-guard.yml` | New non-skipping extras lane mirroring `extras-llamafirewall.yml`; `pull_request` (path-filtered) + weekly cron + `workflow_dispatch` |
| `docs/specs/TODO/PET-104.test-output.txt` | Local test-gate audit trail |

## Test plan
- [x] `pytest tests/test_llm_guard_wrapper.py -v --tb=short` — 4 passed, 4 skipped locally (integration rows self-skip without the extra; new test collects). Full output: `docs/specs/TODO/PET-104.test-output.txt`
- [x] `pytest` (full suite) — 1162 passed, 45 skipped, 1 xfailed
- [x] `ruff check .` — clean · `ruff format --check` — clean · `mypy --strict .` — clean (103 files)
- [x] Conftest guard proven fail-loud locally: `PETASOS_REQUIRE_LLM_GUARD=1 pytest … --collect-only` exits 4 with `ERROR: extras-llm-guard lane requires the real llm-guard extra …`
- [ ] **Authoritative gate:** the `extras-llm-guard` lane on this PR runs `TestIntegrationWrappedStdio` (incl. the new test) **unskipped + green** with the real extra (path-filtered trigger fires — `tests/test_llm_guard_wrapper.py` is in the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test to confirm scanner initialization succeeds without weakref-related errors when standard output/error are constrained.
  * Enhanced pytest collection/setup to ensure required LLM Guard components are importable when the feature is enabled, and to fail if expected integration tests would be skipped.

* **Chores**
  * Added a dedicated CI workflow for LLM Guard-related tests, including pull-request scoping and scheduled execution.
  * Updated local test output documentation for the latest PET-104 run details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->