### PR TITLE
fix(pet-108): bounded weakref-load retry + honest scanner health

### DIFF
--- a/docs/specs/TODO/PET-108.test-output.txt
+++ b/docs/specs/TODO/PET-108.test-output.txt
@@ -1,0 +1,61 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-108-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 50 items
+
+tests/test_llm_guard_wrapper.py::TestSlotsWriterRejectsWeakref::test_slots_writer_rejects_weakref PASSED [  2%]
+tests/test_llm_guard_wrapper.py::TestProxySupportsWeakref::test_proxy_supports_weakref PASSED [  4%]
+tests/test_llm_guard_wrapper.py::TestProxyDelegation::test_proxy_write_delegates_to_current_stdout PASSED [  6%]
+tests/test_llm_guard_wrapper.py::TestProxyNoneStdout::test_proxy_handles_none_stdout PASSED [  8%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_scan_with_wrapped_stdout SKIPPED [ 10%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_wrapped_stdout_restored_after_init SKIPPED [ 12%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_no_weakref_requirement_on_stdio SKIPPED [ 14%]
+tests/test_llm_guard_wrapper.py::TestIntegrationWrappedStdio::test_no_weakref_error_during_scanner_construction SKIPPED [ 16%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_weakref_load_failure_retryable PASSED [ 18%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_weakref_retry_capped_rotating_wrapper PASSED [ 20%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_cap_not_reset_by_success PASSED [ 22%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_cap_decoupled_from_missing_package PASSED [ 24%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_reset_clears_cap PASSED [ 26%]
+tests/test_llm_guard_wrapper.py::TestWeakrefRetryClassification::test_non_weakref_breakage_stays_fail_once PASSED [ 28%]
+tests/test_llm_guard_wrapper.py::TestScanSyncEmptyGuard::test_scan_sync_empty_scanners_returns_error_not_silent PASSED [ 30%]
+tests/test_console_handlers.py::test_get_config_returns_fields PASSED    [ 32%]
+tests/test_console_handlers.py::test_metadata_endpoint_carries_help_plain PASSED [ 34%]
+tests/test_console_handlers.py::test_get_config_redacts_secrets PASSED   [ 36%]
+tests/test_console_handlers.py::test_update_config_valid PASSED          [ 38%]
+tests/test_console_handlers.py::test_update_config_invalid PASSED        [ 40%]
+tests/test_console_handlers.py::test_run_scan PASSED                     [ 42%]
+tests/test_console_handlers.py::test_run_scan_with_injection PASSED      [ 44%]
+tests/test_console_handlers.py::test_get_health PASSED                   [ 46%]
+tests/test_console_handlers.py::test_get_scan_history_empty PASSED       [ 48%]
+tests/test_console_handlers.py::test_get_scan_history_after_scan PASSED  [ 50%]
+tests/test_console_handlers.py::test_get_profiles PASSED                 [ 52%]
+tests/test_console_handlers.py::test_get_about PASSED                    [ 54%]
+tests/test_console_handlers.py::test_scan_history_limit PASSED           [ 56%]
+tests/test_console_handlers.py::test_pipeline_scanner_health PASSED      [ 58%]
+tests/test_console_handlers.py::test_pipeline_list_profiles PASSED       [ 60%]
+tests/test_console_handlers.py::test_pipeline_result_to_dict PASSED      [ 62%]
+tests/test_console_handlers.py::test_config_persist_writes_yaml PASSED   [ 64%]
+tests/test_console_handlers.py::test_health_surfaces_scan_errors PASSED  [ 66%]
+tests/test_console_handlers.py::test_health_unavailable_status PASSED    [ 68%]
+tests/test_console_handlers.py::test_health_recovery_to_healthy PASSED   [ 70%]
+tests/test_console_handlers.py::test_health_unavailable_wins_over_breaker PASSED [ 72%]
+tests/test_console_handlers.py::test_minimal_never_unavailable PASSED    [ 74%]
+tests/test_console_handlers.py::test_health_has_last_error_field PASSED  [ 76%]
+tests/test_console_handlers.py::test_idle_recovery_transition PASSED     [ 78%]
+tests/test_console_handlers.py::test_health_load_failed_distinct_from_unavailable PASSED [ 80%]
+tests/test_console_handlers.py::test_health_unavailable_means_absent PASSED [ 82%]
+tests/test_console_handlers.py::test_health_unavailable_legacy_2tuple PASSED [ 84%]
+tests/test_console_handlers.py::test_health_retryable_load_failure_is_degraded PASSED [ 86%]
+tests/test_console_handlers.py::test_health_error_last_error_is_crash_reason PASSED [ 88%]
+tests/test_console_handlers.py::test_availability_returns_cause_discriminator PASSED [ 90%]
+tests/test_console_handlers.py::test_health_not_healthy_under_pending_weakref_failure PASSED [ 92%]
+tests/test_console_handlers.py::test_health_returns_healthy_after_recovery PASSED [ 94%]
+tests/test_console_handlers.py::test_scanner_health_no_attributeerror_on_sibling_ml PASSED [ 96%]
+tests/test_console_handlers.py::test_scan_summary_carries_tile_contract PASSED [ 98%]
+tests/test_console_handlers.py::test_scan_summary_session_id_present_when_omitted PASSED [100%]
+
+======================== 46 passed, 4 skipped in 0.31s ========================

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import logging
 import os
@@ -341,8 +342,6 @@ class Pipeline:
             probe_reason: str | None = None
             probe_cause: str | None = None
             if probe_fn is not None:
-                import contextlib
-
                 # PET-103 D4: arity-tolerant, fail-safe extraction. ``probe_result``
                 # is ``Any`` (``availability()`` is duck-typed) and MUST stay ``Any``
                 # — annotating it as a fixed-arity tuple makes the ``len`` guards
@@ -357,6 +356,22 @@ class Pipeline:
                     probe_reason = probe_result[1] if len(probe_result) > 1 else None
                     probe_cause = probe_result[2] if len(probe_result) > 2 else None
 
+            # PET-108 (D5/D10): consult load_health() defensively for llm_guard's
+            # retryable/pending load state, which availability() does not cover.
+            # getattr-guarded (siblings lack it), arity-tolerant, exception-
+            # suppressed — a missing/malformed/raising load_health leaves
+            # ``load_failed`` False → the scanner reports ``healthy``, not
+            # ``degraded`` (mirrors the availability() idiom above; the only
+            # in-tree implementer returns a guaranteed 2-tuple).
+            load_failed = False
+            load_error: str | None = None
+            lh = getattr(s, "load_health", None)
+            if lh is not None:
+                with contextlib.suppress(Exception):
+                    lh_result = lh()
+                    load_failed = bool(lh_result[0])
+                    load_error = lh_result[1] if len(lh_result) > 1 else None
+
             if not probe_ok:
                 if probe_cause == AVAILABILITY_CAUSE_LOAD_FAILED:
                     status = _HEALTH_STATUS_ERROR
@@ -367,6 +382,15 @@ class Pipeline:
                 # ``scan_err``. ``is not None`` (not ``or``) preserves an
                 # explicitly-empty crash reason. (PET-103)
                 last_error = probe_reason if probe_reason is not None else scan_err
+            elif load_failed:
+                # PET-108 D10: retryable/pending load failure → degraded. Ordered
+                # AFTER the terminal ``not probe_ok`` check so a cap-exhausted load
+                # (availability() → load_failed → probe_ok False) still wins
+                # ``error``; the two states partition cleanly by availability().
+                # ``is not None`` (not ``or``) preserves an explicitly-empty
+                # reason, matching the ``error`` branch's provenance rule.
+                status = _HEALTH_STATUS_DEGRADED
+                last_error = load_error if load_error is not None else scan_err
             elif open_until > _time.monotonic():
                 status = _HEALTH_STATUS_CIRCUIT_OPEN
                 last_error = scan_err

--- a/petasos/scanners/llm_guard.py
+++ b/petasos/scanners/llm_guard.py
@@ -21,9 +21,25 @@ from petasos._types import (
 
 _REQUIRED_PACKAGES: tuple[str, ...] = ("llm_guard",)
 
+# D9 (PET-108): hard per-process cap on weakref-shaped load attempts. One initial
+# attempt + two retries. Never reset by success — only reset() clears the counter.
+_MAX_LOAD_ATTEMPTS = 3
+
 _INSTALL_HINT = "llm_guard not installed. pip install petasos[llm-guard]"
 
 _logger = logging.getLogger(__name__)
+
+
+def _is_weakref_shaped(exc: BaseException) -> bool:
+    """True when ``exc`` is the stdio-weakref load failure carved out by PET-108.
+
+    The live signature is ``cannot create weak reference to '_SafeWriter'
+    object`` — a TypeError whose message mentions a weak reference. This failure
+    class is stdio-state-transient (the host can rebind a weakref-able stdout),
+    so it is reclassified retryable; everything else stays fail-once (D1/D4).
+    """
+    return isinstance(exc, TypeError) and "weak reference" in str(exc).lower()
+
 
 # Serializes the logging-shield's stdio snapshot/restore window across scanner
 # instances: self._lock is per-instance, but sys.stdout/sys.stderr are
@@ -92,6 +108,8 @@ class LlmGuardScanner:
         self._loaded: bool = False
         self._load_error: str | None = None
         self._load_error_retryable: bool = False
+        self._load_attempts: int = 0  # D2: weakref-shaped attempts (hard per-process cap)
+        self._load_health_error: str | None = None  # D6: health backing; success-only clear
         self._lock: threading.Lock = threading.Lock()
         self._scanners: list[tuple[str, str, Severity, Any]] = []
 
@@ -120,6 +138,20 @@ class LlmGuardScanner:
             if spec is None or spec.origin is None:
                 return (False, _INSTALL_HINT, AVAILABILITY_CAUSE_ABSENT)
         return (True, None, None)
+
+    def load_health(self) -> tuple[bool, str | None]:
+        """Return ``(failed, last_error)`` for the console dashboard (PET-108).
+
+        Lock-free (mirrors ``availability()``): ``_load_health_error`` is cleared
+        only on a confirmed load success and in ``reset()`` — never at the
+        retry-clear site — so a reader sees only a failed state (retryable,
+        pending, or terminal) or a post-success not-failed state, never a torn
+        intermediate (D6). The clear is sequenced before ``_loaded`` is published
+        on the success path so a composite health read cannot report a stale
+        ``degraded`` after the load already succeeded.
+        """
+        err = self._load_health_error
+        return (err is not None, err)
 
     def _ensure_loaded(self) -> None:
         if self._loaded:
@@ -260,7 +292,8 @@ class LlmGuardScanner:
                     )
                 )
 
-            self._loaded = True
+            self._load_health_error = None  # D6: success-only clear, sequenced BEFORE
+            self._loaded = True  # ........... publishing success (avoids a stale degraded read)
         except Exception as exc:
             from petasos.scanners import _is_missing_package
 
@@ -271,10 +304,15 @@ class LlmGuardScanner:
                 avail, avail_reason, _cause = self.availability()
                 if avail:
                     self._load_error = str(exc)
-                    self._load_error_retryable = False
+                    if _is_weakref_shaped(exc):  # D1: stdio-weakref carve-out
+                        self._load_attempts += 1  # D2: count weakref attempts only
+                        self._load_error_retryable = self._load_attempts < _MAX_LOAD_ATTEMPTS
+                    else:
+                        self._load_error_retryable = False  # D4: non-weakref stays fail-once
                 else:
                     self._load_error = avail_reason or str(exc)
                     self._load_error_retryable = True
+            self._load_health_error = self._load_error  # D6: set on every failure path
 
     def reset(self) -> None:
         """Clear cached load error to allow re-attempt (e.g., after pip install).
@@ -290,6 +328,8 @@ class LlmGuardScanner:
             self._load_error_retryable = False
             self._loaded = False
             self._scanners = []
+            self._load_health_error = None  # D6: cleared only here and on confirmed success
+            self._load_attempts = 0  # D2: the only place the weakref cap counter resets
 
     async def scan(
         self,
@@ -335,9 +375,24 @@ class LlmGuardScanner:
             )
 
     def _scan_sync(self, text: str) -> tuple[list[ScanFinding], list[str]]:
+        # D8 (PET-108): bind self._scanners to a local once at entry, then guard
+        # on empty. Every clear site (_do_load, _ensure_loaded's retry-clear,
+        # reset()) *rebinds* self._scanners = [] (never mutates in place), so this
+        # local is a safe read-once alias — not a copy. If any clear site is ever
+        # changed to in-place mutation (.clear() / del [:]), this MUST become
+        # `scanners = list(self._scanners)` or a concurrent mutation tears the loop.
+        scanners = self._scanners
+        if not scanners:
+            # A concurrent clear (reset()/retry) emptied _scanners after scan()'s
+            # pre-checks passed (loaded, _load_error is None). Return an explicit
+            # error so fail-mode 'degraded' blocks, instead of the silent
+            # false-negative (findings=(), error=None) an unguarded loop would
+            # yield. A successfully-loaded llm_guard always has >=1 scanner (the
+            # injection scanner is unconditional), so this is never the normal path.
+            return [], ["llm_guard: scanners cleared mid-scan (load reset in flight)"]
         findings: list[ScanFinding] = []
         errors: list[str] = []
-        for rule_id, finding_type, severity, sub_scanner in self._scanners:
+        for rule_id, finding_type, severity, sub_scanner in scanners:
             try:
                 _sanitized, is_valid, risk_score = sub_scanner.scan(text)
                 if not is_valid:

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -541,6 +541,101 @@ async def test_availability_returns_cause_discriminator(
 
 
 # ---------------------------------------------------------------------------
+# PET-108: honest health under a retryable/pending weakref load failure. The
+# scanner stubs expose the exact availability()/load_health() return shapes of
+# each truth-table row rather than suspending a real _do_load mid-flight —
+# deterministic and extras-free, consistent with the PET-103 stubs above.
+# ---------------------------------------------------------------------------
+
+
+class _PendingWeakrefLoadScanner(_StubScanner):
+    """Failed/pending weakref load: availability() truthy (the required modules
+    are present — that is the precondition that produced the weakref failure),
+    load_health() reports failed with a reason (PET-108 truth-table rows 2-3)."""
+
+    def __init__(self, name: str, *, reason: str | None) -> None:
+        super().__init__(name)
+        self._reason = reason
+
+    def availability(self) -> tuple[bool, str | None, str | None]:
+        return (True, None, None)
+
+    def load_health(self) -> tuple[bool, str | None]:
+        return (True, self._reason)
+
+
+class _RecoveredLoadScanner(_StubScanner):
+    """Recovered-after-retry row: availability() truthy and load_health() not
+    failed — the deterministic 'healthy' truth-table row (PET-108)."""
+
+    def availability(self) -> tuple[bool, str | None, str | None]:
+        return (True, None, None)
+
+    def load_health(self) -> tuple[bool, str | None]:
+        return (False, None)
+
+
+async def test_health_not_healthy_under_pending_weakref_failure() -> None:
+    """PET-108 (B/D6/D10): a failed/pending weakref load reports 'degraded',
+    never 'healthy', driven solely by load_health() — no scan error is seeded,
+    so this exercises the poll interleaved with the retry window."""
+    stub = _PendingWeakrefLoadScanner("test_ml", reason="weakref load failed; retry pending")
+    pipe = Pipeline(
+        scanners=[MinimalScanner(), stub],
+        config=PetasosConfig(fail_mode="open"),
+    )
+    health = pipe.scanner_health()
+    ml_entry = [h for h in health if h["name"] == "test_ml"][0]
+    assert ml_entry["status"] == "degraded"
+    assert ml_entry["status"] != "healthy"
+    assert ml_entry["last_error"] == "weakref load failed; retry pending"
+
+    # Empty-string crash reason is preserved (not replaced by a stale scan_err),
+    # pinning the `load_error is not None` provenance on the new branch the way
+    # test_health_error_last_error_is_crash_reason pins it on the 'error' branch.
+    empty_stub = _PendingWeakrefLoadScanner("test_ml2", reason="")
+    pipe2 = Pipeline(
+        scanners=[MinimalScanner(), empty_stub],
+        config=PetasosConfig(fail_mode="open"),
+    )
+    pipe2._last_scan_errors["test_ml2"] = "stale run-time scan error from before"
+    health2 = pipe2.scanner_health()
+    ml_entry2 = [h for h in health2 if h["name"] == "test_ml2"][0]
+    assert ml_entry2["status"] == "degraded"
+    assert ml_entry2["last_error"] == ""
+
+
+async def test_health_returns_healthy_after_recovery() -> None:
+    """PET-108: after recovery (load_health() -> (False, None), availability()
+    truthy), the scanner reports 'healthy' with no stale last_error. Stub-based,
+    so it cannot flake on the success-path store window (D6)."""
+    stub = _RecoveredLoadScanner("test_ml")
+    pipe = Pipeline(
+        scanners=[MinimalScanner(), stub],
+        config=PetasosConfig(fail_mode="open"),
+    )
+    health = pipe.scanner_health()
+    ml_entry = [h for h in health if h["name"] == "test_ml"][0]
+    assert ml_entry["status"] == "healthy"
+    assert ml_entry["last_error"] is None
+
+
+async def test_scanner_health_no_attributeerror_on_sibling_ml() -> None:
+    """PET-108 D5: scanner_health() does not raise when an _ml_scanners member
+    lacks load_health() (a stub with availability() but no load_health, mirroring
+    Presidio/LlamaFirewall); its entry is computed normally."""
+    stub = _AvailableScanner("sibling_ml", error=None)  # availability() but NO load_health
+    pipe = Pipeline(
+        scanners=[MinimalScanner(), stub],
+        config=PetasosConfig(fail_mode="open"),
+    )
+    health = pipe.scanner_health()  # must not raise AttributeError
+    ml_entry = [h for h in health if h["name"] == "sibling_ml"][0]
+    assert ml_entry["status"] == "healthy"
+    assert ml_entry["last_error"] is None
+
+
+# ---------------------------------------------------------------------------
 # PET-102: run_scan summary carries the field set the Observability tiles read
 # ---------------------------------------------------------------------------
 

--- a/tests/test_llm_guard_wrapper.py
+++ b/tests/test_llm_guard_wrapper.py
@@ -14,10 +14,16 @@ import io
 import sys
 import weakref
 from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from petasos.scanners.llm_guard import LlmGuardScanner, _WeakrefableStdout
+from petasos._types import AVAILABILITY_CAUSE_LOAD_FAILED, Severity
+from petasos.scanners.llm_guard import (
+    _MAX_LOAD_ATTEMPTS,
+    LlmGuardScanner,
+    _WeakrefableStdout,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -292,3 +298,237 @@ class TestIntegrationWrappedStdio:
         result = await scanner.scan(_INJECTION_TEXT)
         assert result.error is None
         assert any(f.rule_id == "petasos.llmguard.injection" for f in result.findings)
+
+
+# ---------------------------------------------------------------------------
+# PET-108: weakref-shaped load failures are retryable, bounded by a hard cap;
+# honest health backing; _scan_sync empty-guard. All extras-free (no skipif).
+#
+# Injection convention (per PET-104 round-1 edge guidance): swap the
+# `llm_guard.input_scanners` module for a MagicMock whose `PromptInjection`
+# drives the chosen `_do_load` failure. The fake modules are *present* (non-None)
+# in sys.modules, so `availability()` probes truthy on its own — the unit reaches
+# the installed-but-broken classifier without the real extra.
+# ---------------------------------------------------------------------------
+
+_WEAKREF_EXC_MSG = "cannot create weak reference to '_SafeWriter' object"
+
+
+def _fake_modules(mock_module: MagicMock) -> dict[str, MagicMock]:
+    """Present (non-None) llm_guard modules so ``availability()`` probes truthy,
+    with ``input_scanners`` swapped for ``mock_module`` (mirrors the helper in
+    tests/test_llm_guard_scanner.py)."""
+    return {
+        "llm_guard": MagicMock(),
+        "llm_guard.util": MagicMock(),
+        "llm_guard.input_scanners": mock_module,
+    }
+
+
+def _weakref_failing_module() -> MagicMock:
+    """``input_scanners`` mock whose ``PromptInjection()`` raises the live weakref
+    ``TypeError`` (``cannot create weak reference to '_SafeWriter' object``)."""
+    mock_module = MagicMock()
+    mock_module.PromptInjection.side_effect = TypeError(_WEAKREF_EXC_MSG)
+    mock_module.InvisibleText = MagicMock()
+    return mock_module
+
+
+def _succeeding_module() -> MagicMock:
+    """``input_scanners`` mock whose scanners construct and scan cleanly."""
+    mock_sub = MagicMock()
+    mock_sub.scan.return_value = ("clean", True, 0.0)
+    mock_module = MagicMock()
+    mock_module.PromptInjection = MagicMock(return_value=mock_sub)
+    mock_module.InvisibleText = MagicMock(return_value=mock_sub)
+    return mock_module
+
+
+def _rearm_for_reload(scanner: LlmGuardScanner) -> None:
+    """Re-arm load state exactly as ``_ensure_loaded``'s involuntary retry-clear
+    does (NO ``reset()``): clears the per-attempt state but leaves ``_load_attempts``
+    untouched, so a direct ``_do_load()`` re-runs while the lifetime cap persists.
+    """
+    scanner._loaded = False
+    scanner._load_error = None
+    scanner._load_error_retryable = False
+    scanner._scanners = []
+
+
+class TestWeakrefRetryClassification:
+    """PET-108 D1/D2/D4: weakref-shaped failures retry under a hard cap; everything
+    else stays fail-once."""
+
+    async def test_weakref_load_failure_retryable(self) -> None:
+        # Regression for PET-108 D1: a weakref-shaped load failure is reclassified
+        # retryable, and a subsequent scan re-attempts the load (the attempt
+        # counter increments) — unlike the pre-PET-108 fail-once behavior.
+        scanner = LlmGuardScanner()
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            r1 = await scanner.scan("first")
+            assert r1.error is not None
+            assert scanner._load_error_retryable is True
+            assert scanner._load_attempts == 1
+
+            r2 = await scanner.scan("second")
+            assert r2.error is not None
+            assert scanner._load_attempts == 2  # re-attempted, not short-circuited
+
+    async def test_weakref_retry_capped_rotating_wrapper(self) -> None:
+        # Regression for PET-108 D2: a persistently/rotating-failing weakref
+        # wrapper does NOT cause a per-scan reload storm — total weakref _do_load
+        # attempts are bounded by _MAX_LOAD_ATTEMPTS, after which the scanner is
+        # terminal (availability() -> load_failed).
+        scanner = LlmGuardScanner()
+        mock_module = _weakref_failing_module()
+        with patch.dict("sys.modules", _fake_modules(mock_module)):
+            for _ in range(10):
+                await scanner.scan("rotating wrapper keeps failing")
+            # Each _do_load attempt calls PromptInjection exactly once before it
+            # raises, so its call_count IS the attempt count: capped at the cap
+            # despite 10 scans.
+            assert mock_module.PromptInjection.call_count == _MAX_LOAD_ATTEMPTS
+        assert scanner._load_attempts == _MAX_LOAD_ATTEMPTS
+        assert scanner._load_error_retryable is False
+        ok, _reason, cause = scanner.availability()
+        assert ok is False
+        assert cause == AVAILABILITY_CAUSE_LOAD_FAILED
+
+    async def test_cap_not_reset_by_success(self) -> None:
+        # Regression for PET-108 D2: a successful load between weakref failures
+        # does NOT reset the cap counter (the only bound that holds under a
+        # rotating / id-reused wrapper). Also pins the health-field flap: cleared
+        # on confirmed success, set again on the next failure.
+        scanner = LlmGuardScanner()
+
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            scanner._do_load()
+        assert scanner._load_attempts == 1
+        assert scanner._load_health_error is not None
+
+        # A successful load in between — must not reset _load_attempts.
+        _rearm_for_reload(scanner)
+        success_module = _succeeding_module()
+        with patch.dict("sys.modules", _fake_modules(success_module)):
+            scanner._do_load()
+        assert scanner._loaded is True
+        assert success_module.PromptInjection.called  # proves _do_load actually ran
+        assert scanner._load_attempts == 1  # success did NOT reset the cap
+        assert scanner._load_health_error is None  # cleared on confirmed success
+
+        # A further weakref failure advances the hard lifetime bound to 2.
+        _rearm_for_reload(scanner)
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            scanner._do_load()
+        assert scanner._load_attempts == 2
+        assert scanner._load_health_error is not None
+
+    async def test_cap_decoupled_from_missing_package(self) -> None:
+        # Regression for PET-108 D2 / Out-of-scope: a missing-package retryable
+        # failure does NOT increment the weakref cap; only weakref-shaped failures
+        # do. availability() is truthy via _fake_modules, so the classifier path
+        # is reached white-box (the only way to exercise the decoupling).
+        scanner = LlmGuardScanner()
+
+        missing_module = MagicMock()
+        missing_module.PromptInjection.side_effect = ImportError(
+            "No module named 'llm_guard'", name="llm_guard"
+        )
+        missing_module.InvisibleText = MagicMock()
+        with patch.dict("sys.modules", _fake_modules(missing_module)):
+            scanner._do_load()
+        assert scanner._load_error_retryable is True  # missing-package stays retryable
+        assert scanner._load_attempts == 0  # but did NOT touch the weakref cap
+
+        _rearm_for_reload(scanner)
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            scanner._do_load()
+        assert scanner._load_attempts == 1  # only the weakref failure incremented
+
+    async def test_reset_clears_cap(self) -> None:
+        # Regression for PET-108 D2: reset() zeroes the attempt counter and clears
+        # the health backing field; a subsequent weakref failure is retryable again.
+        scanner = LlmGuardScanner()
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            for _ in range(_MAX_LOAD_ATTEMPTS):
+                await scanner.scan("fail")
+        assert scanner._load_attempts == _MAX_LOAD_ATTEMPTS
+        assert scanner._load_error_retryable is False
+        assert scanner._load_health_error is not None
+
+        scanner.reset()
+        assert scanner._load_attempts == 0
+        assert scanner._load_health_error is None
+
+        with patch.dict("sys.modules", _fake_modules(_weakref_failing_module())):
+            await scanner.scan("fail again")
+        assert scanner._load_attempts == 1
+        assert scanner._load_error_retryable is True
+
+    async def test_non_weakref_breakage_stays_fail_once(self) -> None:
+        # Regression for PET-108 D4: a non-weakref installed-but-broken failure
+        # (here a TypeError WITHOUT "weak reference") stays fail-once — retryable
+        # False, the weakref cap untouched, and a subsequent scan does not
+        # re-attempt the load.
+        scanner = LlmGuardScanner()
+        mock_module = MagicMock()
+        mock_module.PromptInjection.side_effect = TypeError("unexpected keyword argument")
+        mock_module.InvisibleText = MagicMock()
+        with patch.dict("sys.modules", _fake_modules(mock_module)):
+            r1 = await scanner.scan("first")
+            assert r1.error is not None
+            assert scanner._load_error_retryable is False
+            assert scanner._load_attempts == 0
+
+            r2 = await scanner.scan("second")
+            assert r2.error is not None
+            # No re-attempt: _ensure_loaded short-circuits on a non-retryable error.
+            assert mock_module.PromptInjection.call_count == 1
+            assert scanner._load_attempts == 0
+
+
+class TestScanSyncEmptyGuard:
+    """PET-108 D8: _scan_sync returns an explicit error (not a silent
+    false-negative) when a concurrent clear empties _scanners mid-flight."""
+
+    async def test_scan_sync_empty_scanners_returns_error_not_silent(self) -> None:
+        # Regression for PET-108 D8 (fix-discriminating): a concurrent reset()/
+        # clear can land in the asyncio.to_thread dispatch gap, after scan()'s
+        # pre-checks pass, leaving _scanners == []. The unguarded loop returned
+        # (findings=(), error=None) — a silent false-negative (content passes with
+        # no ML scan). The guard converts it to an explicit blocking error.
+        scanner = LlmGuardScanner()
+        scanner._loaded = True
+        scanner._load_error = None
+        scanner._scanners = []
+        result = await scanner.scan("content that must not silently pass unscanned")
+        assert result.error is not None
+        assert "cleared mid-scan" in result.error
+        assert result.findings == ()  # explicit error, not a silent empty pass
+
+        # Characterization (Python iterator-protocol guarantee, NOT a fix guard):
+        # an in-loop *rebind* of self._scanners installs a NEW list object and
+        # leaves the live iterator intact, so every captured sub-scanner still
+        # runs. Documents why the bare snapshot is not the load-bearing half of D8.
+        scanner2 = LlmGuardScanner()
+        calls: list[str] = []
+
+        def _make_sub(tag: str) -> MagicMock:
+            sub = MagicMock()
+
+            def _scan(_text: str) -> tuple[str, bool, float]:
+                calls.append(tag)
+                scanner2._scanners = []  # concurrent rebind mid-iteration
+                return ("clean", True, 0.0)
+
+            sub.scan.side_effect = _scan
+            return sub
+
+        scanner2._scanners = [
+            ("petasos.llmguard.injection", "injection", Severity.HIGH, _make_sub("a")),
+            ("petasos.llmguard.invisible-text", "encoding", Severity.MEDIUM, _make_sub("b")),
+        ]
+        findings, errors = scanner2._scan_sync("text")
+        assert calls == ["a", "b"]  # iteration completed over the captured list
+        assert findings == []
+        assert errors == []


### PR DESCRIPTION
## Summary
- Reclassifies a **weakref-shaped** `LlmGuardScanner` load failure (the `cannot create weak reference to '_SafeWriter' object` `TypeError`) as **retryable**, bounded by a hard per-process cap (`_MAX_LOAD_ATTEMPTS=3`) that no success resets — only `reset()` clears it. Non-weakref breakage stays fail-once; the cap counter is decoupled from the missing-package path.
- Adds a lock-free `load_health()` accessor (success-only clear, sequenced **before** publishing `_loaded`) consulted defensively by `Pipeline.scanner_health()`, so a failed/pending load reports `degraded` instead of `healthy`.
- Binds `_scanners` to a local in `_scan_sync` and **returns an explicit error when empty**, converting a silent empty-findings false-negative (under a concurrent `reset()`/retry clear) into a blocking scanner error under fail-mode `degraded`.
- Defense-in-depth: PET-92's shield works (PET-104 Step-0 proved it), so the scanner does not currently fail — this hardens a *latent* mode.

## Two-check interaction (why ordering is load-bearing)
`scanner_health()` reads `availability()` **and** `load_health()`. The new `elif load_failed` branch is placed **after** the terminal `not probe_ok` check (D10): the two states partition cleanly by `availability()` — a retryable/pending load keeps the required modules in `sys.modules` so `probe_ok=True` → reaches `degraded`; a cap-exhausted (terminal) load makes `availability()` return `load_failed` → `probe_ok=False` → PET-103's `error` branch wins and is **not** masked. `load_error is not None` (not `or`) preserves an explicitly-empty crash reason.

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/llm_guard.py` | Adds `_MAX_LOAD_ATTEMPTS`, `_is_weakref_shaped()`, `_load_attempts`/`_load_health_error` fields, weakref carve-out + cap in `_do_load`'s classifier, success-only `_load_health_error` clear (sequenced before `_loaded`), `load_health()`, `_scan_sync` snapshot + empty-guard, `reset()` clears the two new fields |
| `petasos/pipeline.py` | Hoists `import contextlib` to module level (removes nested import); `scanner_health()` consults `load_health()` defensively (getattr-guarded, arity-tolerant, exception-suppressed) + new `elif load_failed` → `degraded` branch |
| `tests/test_llm_guard_wrapper.py` | 7 scanner-level regression tests (retry, rotating-cap, cap-not-reset-by-success, cap-decoupled-from-missing-package, reset-clears-cap, non-weakref-fail-once, `_scan_sync` empty-guard) |
| `tests/test_console_handlers.py` | 3 pipeline-level `scanner_health()` tests (degraded under pending/empty-reason weakref load, healthy after recovery, no `AttributeError` on siblings lacking `load_health`) |

## Test plan
- [x] `C:\python310\python.exe -m pytest tests/test_llm_guard_wrapper.py tests/test_console_handlers.py -v` — 46 passed, 4 skipped (real-`llm-guard` integration rows) — full output: `docs/specs/TODO/PET-108.test-output.txt`
- [x] All 10 new PET-108 tests pass; existing PET-103 `scanner_health` suite unchanged/green (no regressions)
- [x] `ruff check .` — clean · `ruff format --check .` — clean · `mypy --strict .` — clean (103 files)
- [x] Full `C:\python310\python.exe -m pytest` — 1275 passed, 36 skipped, 1 xfailed. One **pre-existing, unrelated** failure: `test_console_validation.py::test_default_ignorable_rejected` asserts `swept >= 267` (Unicode 14.0.0), but local Python 3.10.6 ships Unicode 13.0.0 (sweeps 266). Fails identically on unmodified `master`; passes on CI's Python 3.11+ (Unicode 14.0+). Not touched (out of scope).

> **Note on D12 / base-CI collection:** the 3 `scanner_health` tests live in `tests/test_console_handlers.py`, which top-level `pytest.importorskip("fastapi")`. `fastapi` is in the `console` extra, **not** `[dev]`, so the base `ci.yml` `test` job (`pip install -e .[dev]`) import-skips that module — the 3 console tests do **not** actually run there (the 7 wrapper tests do). This is a pre-existing condition (PET-103's `scanner_health` suite already lives behind the same guard), not introduced here; flagging so the spec's D12 "collects all ten" claim can be reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scanner health status reporting with improved load failure detection and clearer error messaging for degraded or unavailable scanners.

* **Bug Fixes**
  * Improved handling of specific load failure patterns with configurable retry limits and recovery detection.

* **Tests**
  * Added comprehensive test coverage for scanner health status scenarios, load failure edge cases, and concurrent state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->