### PR TITLE
feat(pet-107): sub-agent lineage escalation + delegation fan-out gate

### DIFF
--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -180,7 +180,37 @@ hooks:
   - pre_tool_call
   - post_tool_call
   - on_session_start
+  # PET-107: sub-agent (delegate_task) session lineage. Optional — registered
+  # defensively; if the host build does not emit them, lineage-linked
+  # escalation (A) no-ops and only the delegation fan-out gate (C) runs.
+  - subagent_start
+  - subagent_stop
 ```
+
+### Sub-agent (delegate_task) session intelligence — PET-107
+
+A Hermes `delegate_task` spawns a child agent with its own fresh
+`session_id`, so without extra wiring a session escalating toward tier 2/3
+could launder its frequency state through a clean child, and a parent's
+tier-3 termination would never reach its children. Petasos closes this with
+two independently-shippable halves:
+
+- **A — lineage-linked escalation.** On `subagent_start` the plugin records
+  a host-asserted `child → parent` edge in a `LineageRegistry`; the guard
+  then derives a child's tier as `max(own, parent-chain)` read live at
+  evaluation time. A parent reaching tier 3 forces its children to tier 3 on
+  their *next* guarded tool call (the hook model cannot interrupt an
+  in-flight call). `subagent_stop` drops the edge. A non-terminated tier-1/2
+  parent with a live child is pinned against eviction so the child can still
+  read its tier, bounded by an edge TTL and a hard `2×max_sessions` ceiling.
+- **C — delegation fan-out gate.** An escalation-tied budget on
+  `delegate_task` spawns (configurable via `delegate_max_fanout_per_window` /
+  `delegate_fanout_window_seconds` / `delegate_tool_names`) so a
+  high-frequency session cannot spray sub-agents. This needs only
+  `pre_tool_call`, so it runs even when the sub-agent hooks are unavailable.
+
+Both default on. If the host does not emit `subagent_start`/`subagent_stop`,
+A no-ops and only C is active (logged once at startup).
 
 ### `__init__.py`
 

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -36,6 +36,17 @@ _initialized = False
 _init_error: str | None = None
 _session_ids: dict[int, str] = {}
 
+# PET-107: sub-agent lineage (Option A). The registry is constructed in
+# _deferred_init (it shares the tracker's clock + lock discipline), but the
+# subagent_start/subagent_stop hooks are registered earlier in register(). The
+# handlers therefore reference the registry lazily through this module global —
+# a hook firing before init completes (registry None) is a safe no-op.
+_lineage_registry = None
+# True iff BOTH subagent hooks registered. A is wired only when both are present
+# (an edge store created but never dropped-on-stop would leak edges); otherwise
+# A degrades fully to C (lineage=None). Set in register(), read in _deferred_init.
+_subagent_hooks_available = False
+
 # Dedicated event loop for async Petasos calls (evaluate is async,
 # but Hermes invoke_hook is sync).
 _async_loop: asyncio.AbstractEventLoop | None = None
@@ -286,10 +297,33 @@ def _deferred_init() -> None:
                     "PETASOS_LICENSE_KEY not set — all features available (license is optional)"
                 )
 
-            from petasos import FrequencyTracker
+            from petasos import FrequencyTracker, LineageRegistry
 
-            tracker = FrequencyTracker(config)
-            _guard = ToolCallGuard(_pipeline, tracker, config)
+            global _lineage_registry
+            if _subagent_hooks_available:
+                # A + C: construct ONE registry before the tracker, wire the
+                # tracker's pin/unpin callbacks to it, and hand it to the guard.
+                # Hooks carry raw session_ids; the registry keys on raw ids
+                # (matching is_terminated); the guard mints per-ancestor tokens
+                # for get_state.
+                registry = LineageRegistry(config)
+                _lineage_registry = registry
+                tracker = FrequencyTracker(
+                    config,
+                    is_pinned=registry.is_pinned,
+                    on_terminate=registry.unregister,
+                )
+                _guard = ToolCallGuard(_pipeline, tracker, config, lineage=registry)
+                logger.info("Petasos sub-agent lineage (A) + delegation fan-out gate (C) active")
+            else:
+                # C only: no sub-agent hooks, so lineage no-ops (no chain walk,
+                # no pinning). The fan-out gate still rate-limits delegate spawns.
+                tracker = FrequencyTracker(config)
+                _guard = ToolCallGuard(_pipeline, tracker, config, lineage=None)
+                logger.info(
+                    "Petasos delegation fan-out gate (C) active; sub-agent lineage (A) "
+                    "inactive (sub-agent hooks unavailable)"
+                )
 
             scanner_names = [s.name for s in scanners]
             logger.info(
@@ -486,13 +520,55 @@ def _on_session_start(**kwargs) -> None:
     logger.info("PETASOS_SESSION_START — Petasos content security active")
 
 
+def _subagent_start(parent_session_id: str = "", child_session_id: str = "", **kwargs) -> None:
+    """Host-asserted lineage edge: child spawned by parent (PET-107 D2).
+
+    Only the host's hook calls register(); the child agent never registers its
+    own edge and does not choose its parent_session_id (Hermes assigns it from
+    the spawning parent). The untrusted surface is the child's tool *content*
+    (already scanned), not this edge.
+    """
+    reg = _lineage_registry
+    if reg is None:
+        return
+    if not child_session_id or not parent_session_id:
+        logger.debug("subagent_start missing parent/child id — ignoring edge")
+        return
+    reg.register(child_session_id, parent_session_id)
+
+
+def _subagent_stop(child_session_id: str = "", **kwargs) -> None:
+    """Drop the child's lineage edge on stop (idempotent)."""
+    reg = _lineage_registry
+    if reg is None:
+        return
+    if child_session_id:
+        reg.unregister(child_session_id)
+
+
+def _try_register_hook(ctx, name: str, handler) -> bool:
+    """Register an optional hook, tolerating a host that rejects the name.
+
+    subagent_start/subagent_stop are a Hermes-side assumption (brief
+    delegate_tool.py:1213) that must be verified against the live build. If the
+    host's plugin loader rejects the name, log a warning and report False so the
+    caller can degrade A → C rather than crash.
+    """
+    try:
+        ctx.register_hook(name, handler)
+        return True
+    except Exception as exc:
+        logger.warning("register_hook(%s) rejected by host — skipping: %s", name, exc)
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Plugin registration — called by Hermes plugin loader
 # ---------------------------------------------------------------------------
 
 
 def register(ctx) -> None:
-    global _config
+    global _config, _subagent_hooks_available
 
     try:
         _config = _load_config()
@@ -503,6 +579,24 @@ def register(ctx) -> None:
     ctx.register_hook("pre_tool_call", _pre_tool_call)
     ctx.register_hook("post_tool_call", _post_tool_call)
     ctx.register_hook("on_session_start", _on_session_start)
+
+    # PET-107: sub-agent lineage hooks (Option A). Registered defensively — both
+    # must be accepted, else A degrades fully to C (an edge store that never sees
+    # subagent_stop would leak edges to the TTL/on_terminate backstop only).
+    start_ok = _try_register_hook(ctx, "subagent_start", _subagent_start)
+    stop_ok = _try_register_hook(ctx, "subagent_stop", _subagent_stop)
+    _subagent_hooks_available = start_ok and stop_ok
+    if not _subagent_hooks_available:
+        rejected = [
+            name
+            for name, ok in (("subagent_start", start_ok), ("subagent_stop", stop_ok))
+            if not ok
+        ]
+        logger.warning(
+            "Petasos sub-agent lineage (A) inactive — hook(s) unavailable: %s. "
+            "Delegation fan-out gate (C) remains active.",
+            ", ".join(rejected),
+        )
 
     init_thread = threading.Thread(
         target=_deferred_init,

--- a/docs/deployment/reference_plugin/plugin.yaml
+++ b/docs/deployment/reference_plugin/plugin.yaml
@@ -5,3 +5,8 @@ hooks:
   - pre_tool_call
   - post_tool_call
   - on_session_start
+  # PET-107: sub-agent (delegate_task) lineage. Registered defensively — if the
+  # host build does not emit these, Petasos degrades to the fan-out gate (C)
+  # only; lineage-linked escalation (A) no-ops.
+  - subagent_start
+  - subagent_stop

--- a/docs/specs/TODO/PET-107.test-output.txt
+++ b/docs/specs/TODO/PET-107.test-output.txt
@@ -1,0 +1,337 @@
+# PET-107 test gate — captured 2026-06-14T02:15:49Z
+# Interpreter: Python 3.10.6 at C:\python310\python.exe
+# NOTE: tests/test_console_validation.py::test_default_ignorable_rejected is a PRE-EXISTING
+#       failure on clean master (verified) — a Unicode sweep expecting Unicode 14.0.0, but this
+#       interpreter (CPython 3.10.6) ships Unicode 13.0.0 (swept=266 vs expected>=267). The repo
+#       targets Python 3.11+ (Unicode 14). Unrelated to PET-107; not touched by this change.
+
+=================================================================
+## 1) python -m pytest tests/test_lineage.py tests/test_guard.py tests/test_frequency.py -v
+=================================================================
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-107-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 120 items
+
+tests/test_lineage.py::TestMaxTier::test_returns_highest_rank PASSED     [  0%]
+tests/test_lineage.py::TestMaxTier::test_no_args_is_none PASSED          [  1%]
+tests/test_lineage.py::TestMaxTier::test_raises_on_unknown PASSED        [  2%]
+tests/test_lineage.py::TestRegisterUnregister::test_basic_edge_and_ancestors PASSED [  3%]
+tests/test_lineage.py::TestRegisterUnregister::test_unregister_drops_edge_and_is_idempotent PASSED [  4%]
+tests/test_lineage.py::TestRegisterUnregister::test_self_edge_rejected PASSED [  5%]
+tests/test_lineage.py::TestRegisterUnregister::test_empty_ids_rejected PASSED [  5%]
+tests/test_lineage.py::TestRegisterUnregister::test_register_is_idempotent_same_parent PASSED [  6%]
+tests/test_lineage.py::TestReparent::test_last_writer_wins PASSED        [  7%]
+tests/test_lineage.py::TestReparent::test_reparent_in_place_does_not_evict_unrelated_edge_at_cap PASSED [  8%]
+tests/test_lineage.py::TestAncestorsWalk::test_multi_hop_nearest_first PASSED [  9%]
+tests/test_lineage.py::TestAncestorsWalk::test_bounded_by_max_depth PASSED [ 10%]
+tests/test_lineage.py::TestAncestorsWalk::test_cycle_is_safe PASSED      [ 10%]
+tests/test_lineage.py::TestAncestorsWalk::test_no_edge_returns_empty PASSED [ 11%]
+tests/test_lineage.py::TestTtlAndCap::test_expired_edge_skipped_in_walk PASSED [ 12%]
+tests/test_lineage.py::TestTtlAndCap::test_max_edges_evicts_oldest PASSED [ 13%]
+tests/test_lineage.py::TestIsPinned::test_parent_of_live_edge_is_pinned PASSED [ 14%]
+tests/test_lineage.py::TestIsPinned::test_unregister_unpins_parent PASSED [ 15%]
+tests/test_lineage.py::TestIsPinned::test_expired_edge_does_not_pin PASSED [ 15%]
+tests/test_guard.py::TestFeatureGate::test_feature_disabled_returns_allowed PASSED [ 16%]
+tests/test_guard.py::TestFeatureGate::test_feature_disabled_is_singleton PASSED [ 17%]
+tests/test_guard.py::TestFeatureGate::test_feature_enabled_does_not_skip PASSED [ 18%]
+tests/test_guard.py::TestToolNameNormalization::test_case_folding PASSED [ 19%]
+tests/test_guard.py::TestToolNameNormalization::test_mcp_namespace_stripping PASSED [ 20%]
+tests/test_guard.py::TestToolNameNormalization::test_hermes_namespace_stripping PASSED [ 20%]
+tests/test_guard.py::TestToolNameNormalization::test_no_double_strip PASSED [ 21%]
+tests/test_guard.py::TestToolNameNormalization::test_alias_mapping_bash PASSED [ 22%]
+tests/test_guard.py::TestToolNameNormalization::test_alias_mapping_file_read PASSED [ 23%]
+tests/test_guard.py::TestToolNameNormalization::test_alias_mapping_web_fetch PASSED [ 24%]
+tests/test_guard.py::TestToolNameNormalization::test_whitespace_stripped PASSED [ 25%]
+tests/test_guard.py::TestToolNameNormalization::test_default_alias_map_coverage PASSED [ 25%]
+tests/test_guard.py::TestToolNameNormalization::test_namespace_prefix_with_numbers PASSED [ 26%]
+tests/test_guard.py::TestToolNameNormalization::test_profile_alias_extends_defaults PASSED [ 27%]
+tests/test_guard.py::TestToolNameNormalization::test_casefold_not_just_lower PASSED [ 28%]
+tests/test_guard.py::TestToolNameNormalization::test_namespace_prefix_with_cyrillic PASSED [ 29%]
+tests/test_guard.py::TestToolNameNormalization::test_plain_ascii_no_regression PASSED [ 30%]
+tests/test_guard.py::TestToolNameNormalization::test_empty_string_normalizes PASSED [ 30%]
+tests/test_guard.py::TestToolNameNormalization::test_whitespace_only_normalizes PASSED [ 31%]
+tests/test_guard.py::TestToolNameNormalization::test_empty_after_normalization_blocks PASSED [ 32%]
+tests/test_guard.py::TestTierDerivation::test_unknown_session_is_none PASSED [ 33%]
+tests/test_guard.py::TestTierDerivation::test_profile_tier_thresholds_used PASSED [ 34%]
+tests/test_guard.py::TestTierDerivation::test_terminated_session_is_tier3 PASSED [ 35%]
+tests/test_guard.py::TestTierBlocking::test_tier3_blocks_unconditionally PASSED [ 35%]
+tests/test_guard.py::TestTierBlocking::test_tier2_blocks_non_exempt PASSED [ 36%]
+tests/test_guard.py::TestTierBlocking::test_tier2_allows_exempt_tool PASSED [ 37%]
+tests/test_guard.py::TestTierBlocking::test_tier1_allows_with_warning PASSED [ 38%]
+tests/test_guard.py::TestParamScanning::test_empty_params_shortcircuit PASSED [ 39%]
+tests/test_guard.py::TestParamScanning::test_none_valued_params_skipped PASSED [ 40%]
+tests/test_guard.py::TestParamScanning::test_non_string_params_serialized PASSED [ 40%]
+tests/test_guard.py::TestParamScanning::test_malicious_param_detected PASSED [ 41%]
+tests/test_guard.py::TestParamScanning::test_exempt_tool_scans_params_by_default PASSED [ 42%]
+tests/test_guard.py::TestParamScanning::test_tier3_shortcircuits_before_scanning PASSED [ 43%]
+tests/test_guard.py::TestGuard03AliasExempt::test_default_alias_onto_exempt_still_allowed PASSED [ 44%]
+tests/test_guard.py::TestGuard03AliasExempt::test_default_aliases_not_in_builtin_exempt PASSED [ 45%]
+tests/test_guard.py::TestGuard03AliasExempt::test_valid_alias_still_works PASSED [ 45%]
+tests/test_guard.py::TestSessionTokenGuard::test_guard_derive_tier_with_session_secret PASSED [ 46%]
+tests/test_guard.py::TestGuardResult::test_frozen PASSED                 [ 47%]
+tests/test_guard.py::TestGuardResult::test_to_dict PASSED                [ 48%]
+tests/test_guard.py::TestGuardResult::test_to_dict_with_findings PASSED  [ 49%]
+tests/test_guard.py::TestGuardNoProfile::test_guard_works_without_profile PASSED [ 50%]
+tests/test_guard.py::TestGuardNoProfile::test_guard_tier_derivation_without_profile PASSED [ 50%]
+tests/test_guard.py::TestConcurrency::test_concurrent_evaluate_calls PASSED [ 51%]
+tests/test_guard.py::TestNamespaceRegex::test_mcp_prefix PASSED          [ 52%]
+tests/test_guard.py::TestNamespaceRegex::test_hermes_prefix PASSED       [ 53%]
+tests/test_guard.py::TestNamespaceRegex::test_no_prefix PASSED           [ 54%]
+tests/test_guard.py::TestNamespaceRegex::test_mcp_with_numbers PASSED    [ 55%]
+tests/test_guard.py::TestFullEscalationFlow::test_tier1_to_tier2_to_tier3 PASSED [ 55%]
+tests/test_guard.py::TestScanParamsCatchAll::test_scan_params_exception_returns_unsafe PASSED [ 56%]
+tests/test_guard.py::TestLineageInheritance::test_subagent_inherits_parent_tier PASSED [ 57%]
+tests/test_guard.py::TestLineageInheritance::test_parent_tier3_blocks_child_tools PASSED [ 58%]
+tests/test_guard.py::TestLineageInheritance::test_lineage_with_session_token PASSED [ 59%]
+tests/test_guard.py::TestLineageInheritance::test_child_cannot_register_arbitrary_parent PASSED [ 60%]
+tests/test_guard.py::TestLineageInheritance::test_laundering_closed_under_eviction PASSED [ 60%]
+tests/test_guard.py::TestDelegationFanout::test_tier2_blocks_delegate_task PASSED [ 61%]
+tests/test_guard.py::TestDelegationFanout::test_delegate_not_exempt_rejected_at_construction PASSED [ 62%]
+tests/test_guard.py::TestDelegationFanout::test_delegate_fanout_budget_enforced PASSED [ 63%]
+tests/test_guard.py::TestDelegationFanout::test_fanout_tier1_cap_halved PASSED [ 64%]
+tests/test_guard.py::TestDelegationFanout::test_fanout_concurrent_atomic PASSED [ 65%]
+tests/test_guard.py::TestConcurrentChildren::test_concurrent_children_threadsafe PASSED [ 65%]
+tests/test_guard.py::TestFeatureDisabledNoop::test_lineage_none_no_inheritance PASSED [ 66%]
+tests/test_guard.py::TestFeatureDisabledNoop::test_lineage_flag_off_no_inheritance PASSED [ 67%]
+tests/test_guard.py::TestFeatureDisabledNoop::test_fanout_flag_off_not_gated PASSED [ 68%]
+tests/test_frequency.py::TestDecayMath::test_score_halves_after_one_half_life PASSED [ 69%]
+tests/test_frequency.py::TestDecayMath::test_score_decays_to_near_zero_after_many_half_lives PASSED [ 70%]
+tests/test_frequency.py::TestDecayMath::test_zero_elapsed_no_decay PASSED [ 70%]
+tests/test_frequency.py::TestDecayMath::test_decay_with_zero_initial_score PASSED [ 71%]
+tests/test_frequency.py::TestDecayMath::test_multiple_updates_produce_reference_sequence PASSED [ 72%]
+tests/test_frequency.py::TestWeightMatching::test_exact_match_takes_priority_over_glob PASSED [ 73%]
+tests/test_frequency.py::TestWeightMatching::test_glob_match_longest_prefix_wins PASSED [ 74%]
+tests/test_frequency.py::TestWeightMatching::test_no_match_returns_zero PASSED [ 75%]
+tests/test_frequency.py::TestWeightMatching::test_multiple_rule_ids_weights_summed PASSED [ 75%]
+tests/test_frequency.py::TestWeightMatching::test_empty_rule_ids_only_decays PASSED [ 76%]
+tests/test_frequency.py::TestRollingWindow::test_findings_within_window_counted PASSED [ 77%]
+tests/test_frequency.py::TestRollingWindow::test_findings_outside_window_pruned PASSED [ 78%]
+tests/test_frequency.py::TestRollingWindow::test_rolling_threshold_promotes_to_tier1 PASSED [ 79%]
+tests/test_frequency.py::TestRollingWindow::test_empty_rolling_window_after_expiry PASSED [ 80%]
+tests/test_frequency.py::TestSessionEviction::test_ttl_eviction_removes_stale_sessions PASSED [ 80%]
+tests/test_frequency.py::TestSessionEviction::test_max_sessions_evicts_oldest_prefers_terminated PASSED [ 81%]
+tests/test_frequency.py::TestSessionEviction::test_eviction_never_removes_current_session PASSED [ 82%]
+tests/test_frequency.py::TestSessionEviction::test_over_1000_sessions_no_crash PASSED [ 83%]
+tests/test_frequency.py::TestRateLimiting::test_new_session_rejected_at_capacity PASSED [ 84%]
+tests/test_frequency.py::TestRateLimiting::test_new_session_accepted_under_capacity PASSED [ 85%]
+tests/test_frequency.py::TestRateLimiting::test_rate_limit_window_rolls_forward PASSED [ 85%]
+tests/test_frequency.py::TestEdgeCases::test_terminated_session_returns_immediately PASSED [ 86%]
+tests/test_frequency.py::TestEdgeCases::test_get_state_unknown_session_returns_none PASSED [ 87%]
+tests/test_frequency.py::TestEdgeCases::test_reset_removes_session PASSED [ 88%]
+tests/test_frequency.py::TestEdgeCases::test_clear_removes_all_sessions_and_timestamps PASSED [ 89%]
+tests/test_frequency.py::TestStaticResults::test_disabled_result_is_frozen PASSED [ 90%]
+tests/test_frequency.py::TestStaticResults::test_rate_limited_result_is_frozen PASSED [ 90%]
+tests/test_frequency.py::TestWeightValidation::test_glob_key_with_non_terminal_star_raises PASSED [ 91%]
+tests/test_frequency.py::TestWeightValidation::test_default_weights_used_when_none PASSED [ 92%]
+tests/test_frequency.py::TestSessionToken::test_backward_compat_no_secret PASSED [ 93%]
+tests/test_frequency.py::TestSessionToken::test_valid_token_accepted PASSED [ 94%]
+tests/test_frequency.py::TestSessionToken::test_mint_token_without_secret_raises PASSED [ 95%]
+tests/test_frequency.py::TestSessionToken::test_mint_token_rejects_null_bytes PASSED [ 95%]
+tests/test_frequency.py::TestLineagePinning::test_terminated_child_unpins_parent PASSED [ 96%]
+tests/test_frequency.py::TestLineagePinning::test_passive_eviction_retries_after_unpin PASSED [ 97%]
+tests/test_frequency.py::TestLineagePinning::test_terminated_parent_ttl_evicted_unpins PASSED [ 98%]
+tests/test_frequency.py::TestLineagePinning::test_pinning_hard_ceiling PASSED [ 99%]
+tests/test_frequency.py::TestLineagePinning::test_feature_off_eviction_is_unchanged PASSED [100%]
+
+============================= 120 passed in 0.21s =============================
+exit=0
+
+=================================================================
+## 2) python -m pytest   (full suite)
+=================================================================
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-107-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1353 items
+
+tests\adversarial\config\test_bool_coercion.py ......................... [  1%]
+....                                                                     [  2%]
+tests\adversarial\config\test_config_poisoning.py ............           [  3%]
+tests\adversarial\escalation\test_derive_tier.py ......                  [  3%]
+tests\adversarial\escalation\test_standalone_tier3.py .....              [  3%]
+tests\adversarial\escalation\test_tier3_floor_inline.py ..               [  3%]
+tests\adversarial\frequency\test_rate_limited_sentinel.py ....           [  4%]
+tests\adversarial\frequency\test_session_spoofing.py .....               [  4%]
+tests\adversarial\frequency\test_terminated_state_loss.py .........      [  5%]
+tests\adversarial\frequency\test_ttl_eviction.py ....                    [  5%]
+tests\adversarial\guard\test_tool_smuggling.py ................          [  6%]
+tests\adversarial\license\test_jwt_attacks.py ...                        [  7%]
+tests\adversarial\license\test_license_hardening.py .................... [  8%]
+...                                                                      [  8%]
+tests\adversarial\normalization\test_unicode_bypass.py ................. [  9%]
+.....                                                                    [ 10%]
+tests\adversarial\pipeline\test_callback_isolation.py ...............    [ 11%]
+tests\adversarial\pipeline\test_cancel_mid_gather.py ......              [ 11%]
+tests\adversarial\pipeline\test_cancel_scan_residual.py .                [ 11%]
+tests\adversarial\pipeline\test_degraded_fail_open.py .................. [ 13%]
+......                                                                   [ 13%]
+tests\adversarial\pipeline\test_env_license_trust.py ...                 [ 13%]
+tests\adversarial\pipeline\test_rt075_chain.py x....                     [ 14%]
+tests\adversarial\pipeline\test_scanner_timeout_breaker.py ............. [ 15%]
+.....                                                                    [ 15%]
+tests\adversarial\profiles\test_suppress_bypass.py .....                 [ 16%]
+tests\adversarial\scanner\test_confidence_clamp.py ......                [ 16%]
+tests\adversarial\syntactic\test_binary_nul.py .                         [ 16%]
+tests\adversarial\syntactic\test_injection_evasion.py .................. [ 17%]
+.....................................                                    [ 20%]
+tests\adversarial\syntactic\test_json_depth_strings.py .                 [ 20%]
+tests\adversarial\types\test_type_validation.py ...................      [ 22%]
+tests\test_alerting.py ................................................. [ 25%]
+..................                                                       [ 27%]
+tests\test_audit.py ..................................                   [ 29%]
+tests\test_benchmarks.py ssssss                                          [ 30%]
+tests\test_config.py .........................................           [ 33%]
+tests\test_config_meta.py .............                                  [ 33%]
+tests\test_console_handlers.py ................................          [ 36%]
+tests\test_console_validation.py ....................................... [ 39%]
+........F............                                                    [ 40%]
+tests\test_escalation.py ...............                                 [ 41%]
+tests\test_finding_merge.py ............                                 [ 42%]
+tests\test_formatting.py ....................                            [ 44%]
+tests\test_frequency.py ......................................           [ 47%]
+tests\test_frequency_tombstone.py .................                      [ 48%]
+tests\test_guard.py .................................................... [ 52%]
+...........                                                              [ 52%]
+tests\test_hardening.py ..............                                   [ 54%]
+tests\test_hermes_integration_defaults.py .................              [ 55%]
+tests\test_hermes_smoke.py ssss..                                        [ 55%]
+tests\test_integration_e2e.py ..................                         [ 57%]
+tests\test_license.py ....................                               [ 58%]
+tests\test_lineage.py ...................                                [ 59%]
+tests\test_llama_firewall_scanner.py ................................... [ 62%]
+........ssssssssssss                                                     [ 64%]
+tests\test_llm_guard_scanner.py .......................ssssssssss        [ 66%]
+tests\test_llm_guard_wrapper.py ....ssss                                 [ 67%]
+tests\test_minimal_scanner.py .......................................... [ 70%]
+.......................                                                  [ 71%]
+tests\test_normalize.py ................................................ [ 75%]
+........                                                                 [ 75%]
+tests\test_pipeline.py ................................................. [ 79%]
+......                                                                   [ 80%]
+tests\test_plugin_api_paths.py .......................................   [ 82%]
+tests\test_plugin_api_sse.py ......                                      [ 83%]
+tests\test_plugin_init_logging.py ....                                   [ 83%]
+tests\test_presidio_scanner.py ......................................... [ 86%]
+.............                                                            [ 87%]
+tests\test_profiles.py ......................................            [ 90%]
+tests\test_profiles_retained_ref.py ...                                  [ 90%]
+tests\test_profiles_suppress.py .......                                  [ 91%]
+tests\test_ring_buffer.py ........                                       [ 91%]
+tests\test_safe_json.py .........                                        [ 92%]
+tests\test_scanner_init.py ...........                                   [ 93%]
+tests\test_session_integration.py ...................................... [ 96%]
+...........                                                              [ 96%]
+tests\test_sse.py .......                                                [ 97%]
+tests\test_subagent_plugin_wiring.py .......                             [ 97%]
+tests\test_types.py ................                                     [ 99%]
+tests\test_verify.py ............                                        [100%]
+
+================================== FAILURES ===================================
+_______________________ test_default_ignorable_rejected _______________________
+
+    def test_default_ignorable_rejected() -> None:
+        """Sweep the assigned-non-Cf Default_Ignorable residue (group 1 guard)."""
+        swept = 0
+        for start, end in _DEFAULT_IGNORABLE_RANGES:
+            for cp in range(start, end + 1):
+                ch = chr(cp)
+                if unicodedata.category(ch) in ("Cf", "Cn"):
+                    continue  # isprintable() rejects these; group 1 is the assigned-non-Cf residue
+                swept += 1
+                with pytest.raises(SessionIdError):
+                    sanitize_session_id(f"a{ch}b")
+        # Unicode 14.0.0: CGJ(1) + Hangul fillers(2) + Khmer(2) + FVS1-4(4)
+        # + HANGUL FILLER(1) + VS1-16(16) + HALFWIDTH FILLER(1) + VS17-256(240) = 267
+>       assert swept >= 267
+E       assert 266 >= 267
+
+tests\test_console_validation.py:240: AssertionError
+============================== warnings summary ===============================
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-107-worktree\petasos\console\server.py:273: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ===========================
+FAILED tests/test_console_validation.py::test_default_ignorable_rejected - as...
+===== 1 failed, 1315 passed, 36 skipped, 1 xfailed, 48 warnings in 20.97s =====
+full-suite exit=1
+
+=================================================================
+## 2b) full suite minus the pre-existing Unicode-version failure
+=================================================================
+........................................................................ [  5%]
+........................................................................ [ 10%]
+.............................................x.......................... [ 15%]
+........................................................................ [ 21%]
+........................................................................ [ 26%]
+........................................ssssss.......................... [ 31%]
+........................................................................ [ 37%]
+........................................................................ [ 42%]
+........................................................................ [ 47%]
+........................................................................ [ 53%]
+...........................ssss......................................... [ 58%]
+.............................................................sssssssssss [ 63%]
+s.......................ssssssssss....ssss.............................. [ 69%]
+........................................................................ [ 74%]
+........................................................................ [ 79%]
+........................................................................ [ 85%]
+........................................................................ [ 90%]
+........................................................................ [ 95%]
+........................................................                 [100%]
+============================== warnings summary ===============================
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-107-worktree\petasos\console\server.py:273: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1315 passed, 36 skipped, 1 deselected, 1 xfailed, 48 warnings in 20.78s
+deselected exit=0
+
+=================================================================
+## 3) ruff check .
+=================================================================
+All checks passed!
+ruff exit=0
+
+=================================================================
+## 4) mypy --strict .
+=================================================================
+Success: no issues found in 106 source files
+mypy exit=0

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -16,6 +16,7 @@ from petasos.pipeline import Pipeline
 from petasos.scanners.minimal import RULE_TAXONOMY, MinimalScanner
 from petasos.session.alerting import AlertManager
 from petasos.session.audit import AuditEmitter
+from petasos.session.escalation import max_tier
 from petasos.session.formatting import (
     format_block_message,
     format_pipeline_block_message,
@@ -42,6 +43,7 @@ __all__ = [
     "LicenseState",
     "LicenseValidator",
     "LineageRegistry",
+    "max_tier",
     "MinimalScanner",
     "NormalizedText",
     "PetasosConfig",

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -24,6 +24,7 @@ from petasos.session.formatting import (
 from petasos.session.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
 from petasos.session.guard import GuardResult, ToolCallGuard
 from petasos.session.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
+from petasos.session.lineage import LineageRegistry
 from petasos.session.profiles import ProfileResolver, ResolvedProfile, TierThresholds
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     "LicenseClaims",
     "LicenseState",
     "LicenseValidator",
+    "LineageRegistry",
     "MinimalScanner",
     "NormalizedText",
     "PetasosConfig",

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -285,8 +285,22 @@ class PetasosConfig:
             )
         # delegate_tool_names stored raw; coerce list→tuple in lockstep with
         # pii_entities so a to_dict/from_dict round-trip preserves the tuple type.
+        # Reject a bare string first: tuple("delegate_task") would explode into
+        # per-character entries that each pass the non-empty-string check below,
+        # silently emptying the delegate match set and bypassing the spawn gate.
+        if isinstance(self.delegate_tool_names, str):
+            raise ValueError(
+                "delegate_tool_names must be an iterable of tool names, not a string, "
+                f"got {self.delegate_tool_names!r}"
+            )
         if not isinstance(self.delegate_tool_names, tuple):
-            object.__setattr__(self, "delegate_tool_names", tuple(self.delegate_tool_names))
+            try:
+                object.__setattr__(self, "delegate_tool_names", tuple(self.delegate_tool_names))
+            except TypeError as exc:
+                raise ValueError(
+                    f"delegate_tool_names must be an iterable of non-empty strings, "
+                    f"got {self.delegate_tool_names!r}"
+                ) from exc
         for tool_name in self.delegate_tool_names:
             if not isinstance(tool_name, str) or not tool_name:
                 raise ValueError(

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -25,6 +25,8 @@ _BOOL_FIELDS: frozenset[str] = frozenset(
         "tool_guard_enabled",
         "audit_enabled",
         "alert_enabled",
+        "subagent_lineage_enabled",
+        "delegate_fanout_enabled",
     }
 )
 
@@ -119,6 +121,28 @@ class PetasosConfig:
 
     # Session token binding (FREQ-03 defense)
     session_secret: bytes | None = None
+
+    # Sub-agent (delegate_task) session intelligence (PET-107).
+    # A — lineage-linked escalation: a child's tier is max(own, parent-chain).
+    # C — delegation fan-out gate: an escalation-tied budget on delegate spawns.
+    # Both default on (PET-78 posture); A additionally needs the host's
+    # subagent_start/subagent_stop hooks (degrades to C-only if unavailable).
+    subagent_lineage_enabled: bool = True
+    delegate_fanout_enabled: bool = True
+    # Lineage chain walk + edge store bounds. depth 8 gives headroom over the
+    # Hermes default delegation depth (<=1); edges/ttl parallel max_sessions /
+    # session_ttl_seconds.
+    lineage_max_depth: int = 8
+    lineage_max_edges: int = 10_000
+    lineage_edge_ttl_seconds: float = 3600.0
+    # Fan-out budget: base spawns per rolling window at tier none. Default 3
+    # mirrors Hermes's 3-concurrent delegate default; tier1 halves it, tier2
+    # caps at 1, tier3 is already fully blocked by the tier ladder.
+    delegate_max_fanout_per_window: int = 3
+    delegate_fanout_window_seconds: float = 60.0
+    # Tool names treated as delegation spawns. Stored RAW here; the guard
+    # normalizes them through its own _normalize_tool_name at construction.
+    delegate_tool_names: tuple[str, ...] = ("delegate_task",)
 
     def __post_init__(self) -> None:
         for fname in _BOOL_FIELDS:
@@ -220,6 +244,54 @@ class PetasosConfig:
             raise ValueError(
                 f"session_secret must be bytes or None, got {type(self.session_secret).__name__}"
             )
+
+        # Sub-agent session intelligence validation (PET-107)
+        if (
+            not isinstance(self.lineage_max_depth, int)
+            or isinstance(self.lineage_max_depth, bool)
+            or self.lineage_max_depth <= 0
+        ):
+            raise ValueError(
+                f"lineage_max_depth must be a positive integer, got {self.lineage_max_depth!r}"
+            )
+        if (
+            not isinstance(self.lineage_max_edges, int)
+            or isinstance(self.lineage_max_edges, bool)
+            or self.lineage_max_edges <= 0
+        ):
+            raise ValueError(
+                f"lineage_max_edges must be a positive integer, got {self.lineage_max_edges!r}"
+            )
+        if self.lineage_edge_ttl_seconds <= 0 or not math.isfinite(self.lineage_edge_ttl_seconds):
+            raise ValueError(
+                f"lineage_edge_ttl_seconds must be positive and finite, "
+                f"got {self.lineage_edge_ttl_seconds!r}"
+            )
+        if (
+            not isinstance(self.delegate_max_fanout_per_window, int)
+            or isinstance(self.delegate_max_fanout_per_window, bool)
+            or self.delegate_max_fanout_per_window <= 0
+        ):
+            raise ValueError(
+                f"delegate_max_fanout_per_window must be a positive integer, "
+                f"got {self.delegate_max_fanout_per_window!r}"
+            )
+        if self.delegate_fanout_window_seconds <= 0 or not math.isfinite(
+            self.delegate_fanout_window_seconds
+        ):
+            raise ValueError(
+                f"delegate_fanout_window_seconds must be positive and finite, "
+                f"got {self.delegate_fanout_window_seconds!r}"
+            )
+        # delegate_tool_names stored raw; coerce list→tuple in lockstep with
+        # pii_entities so a to_dict/from_dict round-trip preserves the tuple type.
+        if not isinstance(self.delegate_tool_names, tuple):
+            object.__setattr__(self, "delegate_tool_names", tuple(self.delegate_tool_names))
+        for tool_name in self.delegate_tool_names:
+            if not isinstance(tool_name, str) or not tool_name:
+                raise ValueError(
+                    f"delegate_tool_names entries must be non-empty strings, got {tool_name!r}"
+                )
         if self.frequency_weights is not None:
             for k, v in self.frequency_weights.items():
                 if not isinstance(k, str) or not k:
@@ -399,6 +471,8 @@ class PetasosConfig:
         filtered = {k: v for k, v in data.items() if k in known}
         if "pii_entities" in filtered and isinstance(filtered["pii_entities"], list):
             filtered["pii_entities"] = tuple(filtered["pii_entities"])
+        if "delegate_tool_names" in filtered and isinstance(filtered["delegate_tool_names"], list):
+            filtered["delegate_tool_names"] = tuple(filtered["delegate_tool_names"])
         if "session_secret" in filtered and isinstance(filtered["session_secret"], str):
             import base64
 

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -497,6 +497,84 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "section": "session",
         "constraints": {"min": 1},
     },
+    "subagent_lineage_enabled": {
+        "description": "Inherit a parent's escalation tier into its delegated sub-agents.",
+        "help_plain": (
+            "When a conversation spawns a helper sub-agent, this makes the helper start at"
+            " least as restricted as the conversation that launched it — so a flagged session"
+            " can't wash its record clean by handing work to a fresh child. Needs the host to"
+            " report sub-agent start/stop; if it doesn't, this quietly does nothing."
+        ),
+        "section": "tool_guard",
+    },
+    "delegate_fanout_enabled": {
+        "description": "Rate-limit how many sub-agents a session may spawn.",
+        "help_plain": (
+            "Caps how fast one conversation can spin up helper sub-agents, so a noisy or"
+            " hostile session can't flood the system by spraying delegated tasks. The cap"
+            " tightens automatically as the session's risk level rises."
+        ),
+        "section": "tool_guard",
+    },
+    "lineage_max_depth": {
+        "description": "Maximum ancestor chain walked when inheriting a sub-agent's tier.",
+        "help_plain": (
+            "How many levels up the family tree to look when deciding an inherited"
+            " restriction level for a sub-agent. Sub-agents are normally shallow, so the"
+            " default leaves plenty of headroom while keeping the lookup fast."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 1},
+    },
+    "lineage_max_edges": {
+        "description": "Maximum parent↔child links tracked at once.",
+        "help_plain": (
+            "How many active sub-agent relationships to remember at a time. Once full, the"
+            " oldest link is dropped to make room — a safety ceiling so the bookkeeping can't"
+            " grow without bound under a flood of helpers."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 1},
+    },
+    "lineage_edge_ttl_seconds": {
+        "description": "How long a parent↔child link stays valid (seconds).",
+        "help_plain": (
+            "How long to keep a sub-agent's link to its parent before treating it as stale."
+            " Set this comfortably longer than a realistic helper's lifetime so the parent"
+            " stays remembered for as long as the child might still be running."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 0.01},
+    },
+    "delegate_max_fanout_per_window": {
+        "description": "Base number of sub-agent spawns allowed per time window.",
+        "help_plain": (
+            "How many helper sub-agents a calm conversation may launch within the time"
+            " window below. The allowance is cut in half once the session looks risky, and"
+            " down to one when it's flagged — a terminated session can't spawn at all."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 1},
+    },
+    "delegate_fanout_window_seconds": {
+        "description": "Rolling window for the sub-agent spawn budget (seconds).",
+        "help_plain": (
+            "The span of time the spawn allowance above is measured over. A shorter window"
+            " forgives bursts sooner; a longer one keeps a tighter lid on sustained"
+            " sub-agent spawning."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 0.01},
+    },
+    "delegate_tool_names": {
+        "description": "Tool names treated as sub-agent spawns for the fan-out budget.",
+        "help_plain": (
+            "The list of tool names that count as launching a helper sub-agent (by default,"
+            ' just "delegate_task"). Anything named here is subject to the spawn rate limit;'
+            " add your host's own delegation tool names if they differ."
+        ),
+        "section": "tool_guard",
+    },
 }
 
 _EXCLUDED_FIELDS = frozenset({"session_secret"})

--- a/petasos/session/__init__.py
+++ b/petasos/session/__init__.py
@@ -7,6 +7,7 @@ from petasos.session.escalation import (
     derive_tier,
     evaluate_escalation,
     evaluate_tier,
+    max_tier,
 )
 from petasos.session.formatting import (
     format_block_message,
@@ -16,6 +17,7 @@ from petasos.session.formatting import (
 from petasos.session.frequency import FrequencyTracker, FrequencyUpdateResult, SessionToken
 from petasos.session.guard import GuardResult, ToolCallGuard
 from petasos.session.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
+from petasos.session.lineage import LineageRegistry
 from petasos.session.profiles import (
     ProfileResolver,
     ResolvedProfile,
@@ -32,6 +34,8 @@ __all__ = [
     "derive_tier",
     "FrequencyUpdateResult",
     "GuardResult",
+    "LineageRegistry",
+    "max_tier",
     "format_block_message",
     "format_pipeline_block_message",
     "LicenseClaims",

--- a/petasos/session/escalation.py
+++ b/petasos/session/escalation.py
@@ -19,6 +19,33 @@ _TIER_ACTIONS: dict[str, str] = {
     "tier3": "terminate",
 }
 
+# PET-107: single ordering source for tier comparison across the codebase.
+_TIER_RANK: dict[str, int] = {"none": 0, "tier1": 1, "tier2": 2, "tier3": 3}
+
+
+def max_tier(*tiers: str) -> str:
+    """Return the highest-ranked tier among the inputs (``"none"`` if none given).
+
+    The single ordering source for combining already-derived tier strings
+    (e.g. an own tier with a parent-chain of ancestor tiers, PET-107 Option A).
+    It is a *combinator*, not a re-derivation: it never re-evaluates a score and
+    never re-applies the tier-3 floor (that stays inline in ``derive_tier``).
+
+    Raises ``ValueError`` on any string not in ``_TIER_RANK``. The inputs are
+    produced internally, so an unknown value is a bug — ranking it silently as
+    ``"none"`` would be a fail-open in a security max, which is never acceptable.
+    """
+    best = "none"
+    best_rank = 0
+    for tier in tiers:
+        rank = _TIER_RANK.get(tier)
+        if rank is None:
+            raise ValueError(f"unknown tier: {tier!r}")
+        if rank > best_rank:
+            best_rank = rank
+            best = tier
+    return best
+
 
 @dataclass(frozen=True)
 class EscalationResult:

--- a/petasos/session/frequency.py
+++ b/petasos/session/frequency.py
@@ -189,10 +189,10 @@ class FrequencyTracker:
                     self._terminated_ids[sid] = None
                     self._enforce_tombstone_cap()
                 del self._sessions[sid]
-                if state_ev.terminated:
-                    # Tombstone path (1/4): a terminated session reaped on TTL
-                    # must unpin its own parent.
-                    self._fire_on_terminate(sid)
+                # Any session removed here is gone, terminated or not: drop its
+                # OWN outgoing lineage edge so it stops pinning its parent. A
+                # terminated session was additionally tombstoned above.
+                self._fire_on_terminate(sid)
 
             # Step 1b: Deque compaction
             if len(self._ttl_deque) > 2 * self._max_sessions:
@@ -327,19 +327,28 @@ class FrequencyTracker:
     def reset(self, session: str | SessionToken) -> None:
         with self._lock:
             session_id = self._resolve_session_id(session)
-            self._sessions.pop(session_id, None)
+            if self._sessions.pop(session_id, None) is not None:
+                # Removed session drops its own outgoing lineage edge.
+                self._fire_on_terminate(session_id)
 
     def force_reset(self, session_id: str) -> None:
         with self._lock:
-            self._sessions.pop(session_id, None)
+            removed = self._sessions.pop(session_id, None)
             self._terminated_ids.pop(session_id, None)
+            if removed is not None:
+                # Removed session drops its own outgoing lineage edge.
+                self._fire_on_terminate(session_id)
 
     def clear(self) -> None:
         with self._lock:
+            removed_ids = tuple(self._sessions)
             self._sessions.clear()
             self._creation_timestamps.clear()
             self._terminated_ids.clear()
             self._ttl_deque.clear()
+            # Every removed session drops its own outgoing lineage edge.
+            for session_id in removed_ids:
+                self._fire_on_terminate(session_id)
 
     @property
     def size(self) -> int:
@@ -427,9 +436,13 @@ class FrequencyTracker:
             # Tombstone path (4/4): an evicted terminated session unpins its parent.
             self._fire_on_terminate(sid)
         elif oldest_candidate is not None:
-            # Plain LRU eviction of a non-terminated session — NOT a tombstone,
-            # so on_terminate does not fire here.
-            del self._sessions[oldest_candidate[0]]
+            # Plain LRU eviction of a non-terminated session: not a tombstone,
+            # but the evicted session is gone, so it must still drop its own
+            # outgoing edge (mirrors _force_evict_pinned) rather than leave its
+            # parent pinned by a session that no longer exists.
+            sid = oldest_candidate[0]
+            del self._sessions[sid]
+            self._fire_on_terminate(sid)
 
     def _force_evict_pinned(self, protect_id: str) -> None:
         """Hard-ceiling overflow: force-evict the smallest-last_update pinned session.

--- a/petasos/session/frequency.py
+++ b/petasos/session/frequency.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import hmac as _hmac
+import logging
 import math
+import threading
 import time
 from collections import OrderedDict, deque
 from dataclasses import dataclass, field
@@ -11,9 +13,11 @@ from typing import TYPE_CHECKING
 from petasos.session.escalation import evaluate_tier
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from petasos.config import PetasosConfig
+
+_logger = logging.getLogger(__name__)
 
 DEFAULT_FREQUENCY_WEIGHTS: dict[str, float] = {
     "petasos.syntactic.injection.*": 10.0,
@@ -57,7 +61,13 @@ RATE_LIMITED_RESULT = FrequencyUpdateResult(
 
 
 class FrequencyTracker:
-    def __init__(self, config: PetasosConfig) -> None:
+    def __init__(
+        self,
+        config: PetasosConfig,
+        *,
+        is_pinned: Callable[[str], bool] | None = None,
+        on_terminate: Callable[[str], None] | None = None,
+    ) -> None:
         self._half_life = config.frequency_half_life_seconds
         self._rolling_window = config.rolling_window_seconds
         self._rolling_threshold = config.rolling_threshold
@@ -66,6 +76,20 @@ class FrequencyTracker:
         self._max_new_per_minute = config.max_new_sessions_per_minute
         self._config = config
         self._session_secret: bytes | None = config.session_secret
+
+        # PET-107: cross-thread access from concurrent delegated children. The
+        # RLock guards ALL mutable state (sessions, tombstones, deques). Internal
+        # helpers assume it is held (RLock tolerates re-entry).
+        self._lock = threading.RLock()
+        # PET-107 D6: lineage pinning + termination unpin. Both run INSIDE this
+        # tracker's critical section during eviction/tombstoning — by contract
+        # they are O(1), non-blocking, must not acquire this lock or call any
+        # FrequencyTracker method, and only touch the lineage registry. The
+        # shipped wiring (registry.is_pinned / registry.unregister) satisfies
+        # this, and the registry never calls back into the tracker, so the only
+        # nesting is tracker -> registry (no deadlock cycle, spec D10).
+        self._is_pinned = is_pinned
+        self._on_terminate = on_terminate
 
         raw_weights = (
             config.frequency_weights
@@ -138,160 +162,194 @@ class FrequencyTracker:
     def update(
         self, session: str | SessionToken, rule_ids: Sequence[str]
     ) -> FrequencyUpdateResult:
-        session_id = self._resolve_session_id(session)
-        now = time.monotonic()
+        with self._lock:
+            session_id = self._resolve_session_id(session)
+            now = time.monotonic()
 
-        # Step 1: Passive TTL eviction (O(k) amortized via sorted deque)
-        while self._ttl_deque and self._ttl_deque[0][0] <= now:
-            _, sid = self._ttl_deque.popleft()
-            if sid not in self._sessions:
-                continue
-            state_ev = self._sessions[sid]
-            if state_ev.last_update + self._session_ttl > now:
-                continue
-            if state_ev.terminated and sid not in self._terminated_ids:
-                self._terminated_ids[sid] = None
-                self._enforce_tombstone_cap()
-            del self._sessions[sid]
+            # Step 1: Passive TTL eviction (O(n) amortized via sorted deque).
+            # Bounded to a snapshot of the deque length so a re-appended
+            # (still-pinned) entry is never re-examined within the same call.
+            n = len(self._ttl_deque)
+            while n > 0 and self._ttl_deque and self._ttl_deque[0][0] <= now:
+                n -= 1
+                _expiry, sid = self._ttl_deque.popleft()
+                if sid not in self._sessions:
+                    continue
+                state_ev = self._sessions[sid]
+                if state_ev.last_update + self._session_ttl > now:
+                    continue
+                # D6: a pinned session is retained (a live child still
+                # references its tier). Re-queue it with its real expiry key so
+                # a later update() reaps it once it unpins; the snapshot bound n
+                # guarantees this re-appended entry is not revisited this call.
+                if self._is_pinned is not None and self._is_pinned(sid):
+                    self._ttl_deque.append((state_ev.last_update + self._session_ttl, sid))
+                    continue
+                if state_ev.terminated and sid not in self._terminated_ids:
+                    self._terminated_ids[sid] = None
+                    self._enforce_tombstone_cap()
+                del self._sessions[sid]
+                if state_ev.terminated:
+                    # Tombstone path (1/4): a terminated session reaped on TTL
+                    # must unpin its own parent.
+                    self._fire_on_terminate(sid)
 
-        # Step 1b: Deque compaction
-        if len(self._ttl_deque) > 2 * self._max_sessions:
-            self._compact_ttl_deque(now)
+            # Step 1b: Deque compaction
+            if len(self._ttl_deque) > 2 * self._max_sessions:
+                self._compact_ttl_deque(now)
 
-        # Step 1.5: Tombstone early-return
-        if session_id not in self._sessions and session_id in self._terminated_ids:
-            sentinel = self._config.tier3_threshold
-            return FrequencyUpdateResult(
-                previous_score=sentinel,
-                current_score=sentinel,
-                tier="tier3",
-                terminated=True,
-            )
+            # Step 1.5: Tombstone early-return
+            if session_id not in self._sessions and session_id in self._terminated_ids:
+                sentinel = self._config.tier3_threshold
+                return FrequencyUpdateResult(
+                    previous_score=sentinel,
+                    current_score=sentinel,
+                    tier="tier3",
+                    terminated=True,
+                )
 
-        # Step 2: Get or create session
-        is_new = session_id not in self._sessions
-        if is_new:
+            # Step 2: Get or create session
+            is_new = session_id not in self._sessions
+            if is_new:
+                while (
+                    self._creation_timestamps
+                    and (now - self._creation_timestamps[0]) > _RATE_LIMIT_WINDOW_SECONDS
+                ):
+                    self._creation_timestamps.popleft()
+
+                if (
+                    len(self._sessions) >= self._max_sessions
+                    and len(self._creation_timestamps) >= self._max_new_per_minute
+                ):
+                    return RATE_LIMITED_RESULT
+
+                self._sessions[session_id] = SessionState(
+                    last_score=0.0, last_update=now, rolling_findings=deque()
+                )
+                self._creation_timestamps.append(now)
+
+            state = self._sessions[session_id]
+
+            # Step 3: Enforce max-sessions cap. _evict_one skips pinned sessions
+            # (D6); if pins prevent eviction and the table has grown to the hard
+            # 2x ceiling, force-evict the smallest-last_update pinned session.
+            if is_new and len(self._sessions) > self._max_sessions:
+                self._evict_one(session_id)
+                if self._is_pinned is not None and len(self._sessions) > 2 * self._max_sessions:
+                    self._force_evict_pinned(session_id)
+
+            # Step 4: Terminated sessions
+            if state.terminated:
+                return FrequencyUpdateResult(
+                    previous_score=state.last_score,
+                    current_score=state.last_score,
+                    tier="tier3",
+                    terminated=True,
+                )
+
+            # Step 5: Compute weight
+            total_weight = 0.0
+            for rid in rule_ids:
+                total_weight += self._match_weight(rid)
+
+            # Step 6: Decay previous score
+            elapsed = max(0.0, now - state.last_update)
+            if elapsed > 0 and state.last_score > 0:
+                decayed = state.last_score * math.exp((-elapsed * math.log(2)) / self._half_life)
+            else:
+                decayed = state.last_score
+
+            # Step 7: Update score
+            previous_score = decayed
+            current_score = decayed + total_weight
+
+            # Step 8: Update rolling window
             while (
-                self._creation_timestamps
-                and (now - self._creation_timestamps[0]) > _RATE_LIMIT_WINDOW_SECONDS
+                state.rolling_findings and (now - state.rolling_findings[0]) > self._rolling_window
             ):
-                self._creation_timestamps.popleft()
+                state.rolling_findings.popleft()
+            if rule_ids:
+                state.rolling_findings.append(now)
 
-            if (
-                len(self._sessions) >= self._max_sessions
-                and len(self._creation_timestamps) >= self._max_new_per_minute
-            ):
-                return RATE_LIMITED_RESULT
+            # Step 9: Evaluate tier
+            tier = evaluate_tier(current_score, self._config)
+            if tier == "none" and len(state.rolling_findings) >= self._rolling_threshold:
+                tier = "tier1"
 
-            self._sessions[session_id] = SessionState(
-                last_score=0.0, last_update=now, rolling_findings=deque()
-            )
-            self._creation_timestamps.append(now)
+            # Step 10: Update state
+            state.last_score = current_score
+            state.last_update = now
+            self._ttl_deque.append((now + self._session_ttl, session_id))
+            if tier == "tier3":
+                state.terminated = True
+                self._add_tombstone(session_id)
+                # Tombstone path (2/4): newly terminated session unpins its parent.
+                self._fire_on_terminate(session_id)
 
-        state = self._sessions[session_id]
-
-        # Step 3: Enforce max-sessions cap
-        if is_new and len(self._sessions) > self._max_sessions:
-            self._evict_one(session_id)
-
-        # Step 4: Terminated sessions
-        if state.terminated:
+            # Step 11: Return
             return FrequencyUpdateResult(
-                previous_score=state.last_score,
-                current_score=state.last_score,
-                tier="tier3",
-                terminated=True,
+                previous_score=previous_score,
+                current_score=current_score,
+                tier=tier,
+                terminated=state.terminated,
             )
-
-        # Step 5: Compute weight
-        total_weight = 0.0
-        for rid in rule_ids:
-            total_weight += self._match_weight(rid)
-
-        # Step 6: Decay previous score
-        elapsed = max(0.0, now - state.last_update)
-        if elapsed > 0 and state.last_score > 0:
-            decayed = state.last_score * math.exp((-elapsed * math.log(2)) / self._half_life)
-        else:
-            decayed = state.last_score
-
-        # Step 7: Update score
-        previous_score = decayed
-        current_score = decayed + total_weight
-
-        # Step 8: Update rolling window
-        while state.rolling_findings and (now - state.rolling_findings[0]) > self._rolling_window:
-            state.rolling_findings.popleft()
-        if rule_ids:
-            state.rolling_findings.append(now)
-
-        # Step 9: Evaluate tier
-        tier = evaluate_tier(current_score, self._config)
-        if tier == "none" and len(state.rolling_findings) >= self._rolling_threshold:
-            tier = "tier1"
-
-        # Step 10: Update state
-        state.last_score = current_score
-        state.last_update = now
-        self._ttl_deque.append((now + self._session_ttl, session_id))
-        if tier == "tier3":
-            state.terminated = True
-            self._add_tombstone(session_id)
-
-        # Step 11: Return
-        return FrequencyUpdateResult(
-            previous_score=previous_score,
-            current_score=current_score,
-            tier=tier,
-            terminated=state.terminated,
-        )
 
     def get_state(self, session: str | SessionToken) -> SessionState | None:
-        session_id = self._resolve_session_id(session)
-        state = self._sessions.get(session_id)
-        if state is None:
-            return None
-        return SessionState(
-            last_score=state.last_score,
-            last_update=state.last_update,
-            rolling_findings=deque(state.rolling_findings),
-            terminated=state.terminated,
-        )
+        with self._lock:
+            session_id = self._resolve_session_id(session)
+            state = self._sessions.get(session_id)
+            if state is None:
+                return None
+            return SessionState(
+                last_score=state.last_score,
+                last_update=state.last_update,
+                rolling_findings=deque(state.rolling_findings),
+                terminated=state.terminated,
+            )
 
     def is_terminated(self, session_id: str) -> bool:
-        state = self._sessions.get(session_id)
-        if state is not None:
-            return state.terminated
-        return session_id in self._terminated_ids
+        with self._lock:
+            state = self._sessions.get(session_id)
+            if state is not None:
+                return state.terminated
+            return session_id in self._terminated_ids
 
     def terminate_session(self, session: str | SessionToken) -> None:
-        session_id = self._resolve_session_id(session)
-        state = self._sessions.get(session_id)
-        if state is not None:
-            state.terminated = True
-        self._add_tombstone(session_id)
+        with self._lock:
+            session_id = self._resolve_session_id(session)
+            state = self._sessions.get(session_id)
+            if state is not None:
+                state.terminated = True
+            self._add_tombstone(session_id)
+            # Tombstone path (3/4): explicit termination unpins the parent.
+            self._fire_on_terminate(session_id)
 
     def reset(self, session: str | SessionToken) -> None:
-        session_id = self._resolve_session_id(session)
-        self._sessions.pop(session_id, None)
+        with self._lock:
+            session_id = self._resolve_session_id(session)
+            self._sessions.pop(session_id, None)
 
     def force_reset(self, session_id: str) -> None:
-        self._sessions.pop(session_id, None)
-        self._terminated_ids.pop(session_id, None)
+        with self._lock:
+            self._sessions.pop(session_id, None)
+            self._terminated_ids.pop(session_id, None)
 
     def clear(self) -> None:
-        self._sessions.clear()
-        self._creation_timestamps.clear()
-        self._terminated_ids.clear()
-        self._ttl_deque.clear()
+        with self._lock:
+            self._sessions.clear()
+            self._creation_timestamps.clear()
+            self._terminated_ids.clear()
+            self._ttl_deque.clear()
 
     @property
     def size(self) -> int:
-        return len(self._sessions)
+        with self._lock:
+            return len(self._sessions)
 
     @property
     def tombstone_count(self) -> int:
-        return len(self._terminated_ids)
+        with self._lock:
+            return len(self._terminated_ids)
 
     def _compact_ttl_deque(self, now: float) -> None:
         entries: list[tuple[float, str]] = []
@@ -311,6 +369,22 @@ class FrequencyTracker:
                 return weight
         return 0.0
 
+    def _fire_on_terminate(self, session_id: str) -> None:
+        """Notify the lineage registry that ``session_id`` is gone.
+
+        Runs inside the tracker's critical section; by contract the callback is
+        O(1), non-blocking, touches only the lineage registry, and never calls
+        back into this tracker (preserving the PET-30/34 direct-write tombstone
+        discipline — it must not touch ``_terminated_ids``). Wrapped so a buggy
+        callback cannot break tombstoning.
+        """
+        if self._on_terminate is None:
+            return
+        try:
+            self._on_terminate(session_id)
+        except Exception:
+            _logger.exception("on_terminate callback failed for session %s", session_id)
+
     def _add_tombstone(self, session_id: str) -> None:
         if session_id in self._terminated_ids:
             self._terminated_ids.move_to_end(session_id)
@@ -329,6 +403,11 @@ class FrequencyTracker:
         for sid, state in self._sessions.items():
             if sid == protect_id:
                 continue
+            # D6: never evict a pinned session on the normal path — a live child
+            # still references its tier. The hard ceiling handles the all-pinned
+            # overflow case separately.
+            if self._is_pinned is not None and self._is_pinned(sid):
+                continue
             if state.terminated and (
                 terminated_candidate is None or state.last_update < terminated_candidate[1]
             ):
@@ -345,5 +424,41 @@ class FrequencyTracker:
                 self._terminated_ids[sid] = None
                 self._enforce_tombstone_cap()
             del self._sessions[sid]
+            # Tombstone path (4/4): an evicted terminated session unpins its parent.
+            self._fire_on_terminate(sid)
         elif oldest_candidate is not None:
+            # Plain LRU eviction of a non-terminated session — NOT a tombstone,
+            # so on_terminate does not fire here.
             del self._sessions[oldest_candidate[0]]
+
+    def _force_evict_pinned(self, protect_id: str) -> None:
+        """Hard-ceiling overflow: force-evict the smallest-last_update pinned session.
+
+        Reached only when every eligible session is pinned and the table has
+        grown beyond ``2 * max_sessions``. Bounding memory under a spray takes
+        precedence over tier-1/2 inheritance: the sacrificed parent is dropped
+        (it is non-terminated, so it is NOT tombstoned) and its sub-tree degrades
+        to own-tier — a *terminated* ancestor's tombstone survives ``del``, so
+        the tier-3 floor (D4) is unaffected. Logs once at WARNING; never raises.
+        """
+        victim: tuple[str, float] | None = None
+        for sid, state in self._sessions.items():
+            if sid == protect_id:
+                continue
+            if victim is None or state.last_update < victim[1]:
+                victim = (sid, state.last_update)
+        if victim is None:
+            return
+        sid = victim[0]
+        del self._sessions[sid]
+        _logger.warning(
+            "FrequencyTracker hard ceiling hit (>2x max_sessions=%d): force-evicted "
+            "pinned session %s (smallest last_update); its sub-tree degrades to own-tier "
+            "per the overflow policy (tier-3 termination is unaffected)",
+            self._max_sessions,
+            sid,
+        )
+        # Non-terminated force-evict: fire on_terminate so the evicted session's
+        # OWN outgoing edge drops (unpinning ITS parent). The children's inbound
+        # edges remain; they read get_state=None -> "none" (own-tier).
+        self._fire_on_terminate(sid)

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -79,18 +79,32 @@ class SpawnBudget:
     all in one critical section so the read-check-append is atomic (closes the
     concurrent-spawn TOCTOU two children racing against a budget of 1).
 
-    The per-session deque is dropped once its window empties, so memory is bound
-    by the count of sessions that have spawned within ``window_seconds``.
+    The consumed session's deque is dropped once its window empties; an amortized
+    global sweep (at most once per ``window_seconds``) drops the deques of
+    sessions that delegated once and were never touched again. Together these
+    bound memory by the count of sessions that spawned within roughly the last
+    window, not by every distinct session ever seen.
     """
 
     def __init__(self, window_seconds: float) -> None:
         self._window = window_seconds
         self._lock = threading.Lock()
         self._events: dict[str, deque[float]] = {}
+        self._last_sweep = 0.0
 
     def try_consume(self, session_id: str, cap: int, now: float) -> bool:
         with self._lock:
             cutoff = now - self._window
+            # Amortized global sweep (<= once per window): drop any session whose
+            # entire window has expired. The per-session prune below only fires
+            # when THAT session is consumed again, so without this a one-shot
+            # delegate would leave a stale deque in _events forever and the map
+            # would grow with distinct session IDs instead of active windows.
+            if now - self._last_sweep >= self._window:
+                stale = [sid for sid, ev in self._events.items() if not ev or ev[-1] <= cutoff]
+                for sid in stale:
+                    del self._events[sid]
+                self._last_sweep = now
             dq = self._events.get(session_id)
             if dq is not None:
                 while dq and dq[0] <= cutoff:

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
+import time
 import unicodedata
+from collections import deque
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from petasos.normalize import _HOMOGLYPH_TABLE
 from petasos.session._safe_json import safe_json_dumps
-from petasos.session.escalation import derive_tier, evaluate_tier
+from petasos.session.escalation import derive_tier, evaluate_tier, max_tier
 
 _logger = logging.getLogger(__name__)
 
@@ -17,7 +20,8 @@ if TYPE_CHECKING:
     from petasos._types import ScanFinding
     from petasos.config import PetasosConfig
     from petasos.pipeline import Pipeline
-    from petasos.session.frequency import FrequencyTracker
+    from petasos.session.frequency import FrequencyTracker, SessionState
+    from petasos.session.lineage import LineageRegistry
     from petasos.session.profiles import ResolvedProfile
 
 DEFAULT_TOOL_ALIASES: MappingProxyType[str, str] = MappingProxyType(
@@ -67,6 +71,43 @@ _FEATURE_DISABLED = GuardResult(
 )
 
 
+class SpawnBudget:
+    """Per-session rolling-window spawn counter for the delegation fan-out gate.
+
+    PET-107 Option C. ``try_consume`` prunes the session's window, compares the
+    live count to the (tier-adjusted) cap, and on pass appends the timestamp —
+    all in one critical section so the read-check-append is atomic (closes the
+    concurrent-spawn TOCTOU two children racing against a budget of 1).
+
+    The per-session deque is dropped once its window empties, so memory is bound
+    by the count of sessions that have spawned within ``window_seconds``.
+    """
+
+    def __init__(self, window_seconds: float) -> None:
+        self._window = window_seconds
+        self._lock = threading.Lock()
+        self._events: dict[str, deque[float]] = {}
+
+    def try_consume(self, session_id: str, cap: int, now: float) -> bool:
+        with self._lock:
+            cutoff = now - self._window
+            dq = self._events.get(session_id)
+            if dq is not None:
+                while dq and dq[0] <= cutoff:
+                    dq.popleft()
+                if not dq:
+                    del self._events[session_id]
+                    dq = None
+            count = len(dq) if dq is not None else 0
+            if count >= cap:
+                return False
+            if dq is None:
+                dq = deque()
+                self._events[session_id] = dq
+            dq.append(now)
+            return True
+
+
 class ToolCallGuard:
     def __init__(
         self,
@@ -76,12 +117,39 @@ class ToolCallGuard:
         profile: ResolvedProfile | None = None,
         *,
         exempt_param_scan: bool = True,
+        lineage: LineageRegistry | None = None,
     ) -> None:
         self._pipeline = pipeline
         self._frequency_tracker = frequency_tracker
         self._config = config
         self._profile = profile
         self._exempt_param_scan = exempt_param_scan
+        # PET-107 A: lineage edge store (None → chain walk + pinning disabled,
+        # behavior is byte-for-byte today's).
+        self._lineage = lineage
+
+        # PET-107 C: delegate tool names are stored RAW in config; normalize
+        # them once here through the guard's OWN _normalize_tool_name (never a
+        # parallel normalizer) so recognition at Step 3.5 matches the same
+        # casefold/homoglyph/alias/namespace handling applied to every tool.
+        self._delegate_tool_names: frozenset[str] = frozenset(
+            n for n in (self._normalize_tool_name(raw) for raw in config.delegate_tool_names) if n
+        )
+        # D8: a delegate must never be exempt — an exempt delegate would skip the
+        # tier ladder, defeating the spray ceiling on the normal path.
+        if self._profile is not None:
+            exempt_overlap = self._delegate_tool_names & self._profile.tool_exempt_list
+            if exempt_overlap:
+                raise ValueError(
+                    f"delegate tool name(s) {sorted(exempt_overlap)} appear in the profile "
+                    f"exempt list; a delegate must not be exempt (it would skip the tier ladder)"
+                )
+        if config.delegate_fanout_enabled and not self._delegate_tool_names:
+            _logger.warning(
+                "delegate_fanout_enabled but delegate_tool_names is empty (or all normalized "
+                "away) — the delegation fan-out gate is inert"
+            )
+        self._spawn_budget = SpawnBudget(config.delegate_fanout_window_seconds)
 
     async def evaluate(
         self,
@@ -116,6 +184,24 @@ class ToolCallGuard:
                 tier="tier3",
                 param_scan_unsafe=False,
             )
+
+        # Step 3.5: Delegation fan-out gate (PET-107 C). Runs AFTER the tier-3
+        # block and BEFORE the Step-4 exempt check so the budget applies
+        # regardless of exempt status (D8 guarantees a delegate is never exempt,
+        # so this governs spawn-attempt accounting, not an exempt bypass). The
+        # budget counts ATTEMPTS — a spawn later blocked by param-scan-unsafe
+        # still consumed budget, since a session spamming delegate_task is
+        # exactly the spray to rate-limit regardless of per-call content outcome.
+        if self._config.delegate_fanout_enabled and normalized_name in self._delegate_tool_names:
+            cap = self._fanout_cap(tier)
+            if not self._spawn_budget.try_consume(session_id, cap, time.monotonic()):
+                return GuardResult(
+                    allowed=False,
+                    reason="delegate fan-out budget exceeded",
+                    findings=(),
+                    tier=tier,
+                    param_scan_unsafe=False,
+                )
 
         # Step 4: Exempt check
         if self._profile and normalized_name in self._profile.tool_exempt_list:
@@ -196,20 +282,66 @@ class ToolCallGuard:
             resolved = pre_alias
         return resolved.strip().casefold()
 
-    def _derive_tier(self, session_id: str) -> str:
-        if self._frequency_tracker.is_terminated(session_id):
-            return "tier3"
-        if self._config.session_secret is not None:
-            token = self._frequency_tracker.mint_token(session_id, self._pipeline.host_id)
-            state = self._frequency_tracker.get_state(token)
-        else:
-            state = self._frequency_tracker.get_state(session_id)
+    def _fanout_cap(self, tier: str) -> int:
+        """Tier-adjusted fan-out cap. tier3 is already blocked at Step 3, so it
+        never reaches here; tier2 is tightest (1) and is also blocked at Step 6,
+        so Step 3.5 only accounts the attempt for a tier-2 delegate."""
+        base = self._config.delegate_max_fanout_per_window
+        if tier == "tier1":
+            return max(1, base // 2)
+        if tier == "tier2":
+            return 1
+        return base  # none / below-threshold
+
+    def _state_to_tier(self, state: SessionState | None) -> str:
         if state is None:
             return "none"
         if self._profile and self._profile.tier_thresholds:
             t = self._profile.tier_thresholds
             return derive_tier(state.last_score, t.tier1, t.tier2, t.tier3)
         return evaluate_tier(state.last_score, self._config)
+
+    def _read_state(self, session_id: str) -> SessionState | None:
+        # Mirror the own-session path: with a session_secret set, get_state is
+        # keyed by a per-id minted token, not the raw id (PET-31).
+        if self._config.session_secret is not None:
+            token = self._frequency_tracker.mint_token(session_id, self._pipeline.host_id)
+            return self._frequency_tracker.get_state(token)
+        return self._frequency_tracker.get_state(session_id)
+
+    def _derive_own_tier(self, session_id: str) -> str:
+        if self._frequency_tracker.is_terminated(session_id):
+            return "tier3"
+        return self._state_to_tier(self._read_state(session_id))
+
+    def _derive_tier(self, session_id: str) -> str:
+        # Step 1: own tier (today's logic). Computed outside the fail-secure
+        # wrapper so its existing error behavior is preserved.
+        own = self._derive_own_tier(session_id)
+        # Step 2: lineage off / disabled → own only (byte-for-byte today's).
+        if self._lineage is None or not self._config.subagent_lineage_enabled:
+            return own
+        # Steps 3-4: a child's tier is max(own, worst ancestor) read LIVE at
+        # evaluation time (D5). The whole chain walk is wrapped fail-SECURE — an
+        # internal error (including a max_tier ValueError on an unexpected tier
+        # string) logs and returns tier3, mirroring evaluate_tier; it must never
+        # escape into the reference plugin's fail-OPEN evaluate catch.
+        try:
+            anc_tiers: list[str] = []
+            for aid in self._lineage.ancestors(session_id):
+                if self._frequency_tracker.is_terminated(aid):
+                    # Tombstone-backed: a terminated ancestor forces tier3 even
+                    # post-eviction (closes orphaned termination).
+                    anc_tiers.append("tier3")
+                else:
+                    anc_tiers.append(self._state_to_tier(self._read_state(aid)))
+            return max_tier(own, *anc_tiers)
+        except Exception:
+            _logger.exception(
+                "lineage tier derivation failed for session=%s — returning tier3 fail-secure",
+                session_id,
+            )
+            return "tier3"
 
     async def _scan_params(
         self,

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -315,18 +315,20 @@ class ToolCallGuard:
         return self._state_to_tier(self._read_state(session_id))
 
     def _derive_tier(self, session_id: str) -> str:
-        # Step 1: own tier (today's logic). Computed outside the fail-secure
-        # wrapper so its existing error behavior is preserved.
-        own = self._derive_own_tier(session_id)
-        # Step 2: lineage off / disabled → own only (byte-for-byte today's).
-        if self._lineage is None or not self._config.subagent_lineage_enabled:
-            return own
-        # Steps 3-4: a child's tier is max(own, worst ancestor) read LIVE at
-        # evaluation time (D5). The whole chain walk is wrapped fail-SECURE — an
-        # internal error (including a max_tier ValueError on an unexpected tier
-        # string) logs and returns tier3, mirroring evaluate_tier; it must never
-        # escape into the reference plugin's fail-OPEN evaluate catch.
+        # The whole derivation is wrapped fail-SECURE: any internal error — the
+        # own-tier read (_read_state → mint_token can raise on a malformed
+        # session_id or unset host_id when session_secret is set), a terminated
+        # ancestor lookup, or a max_tier ValueError on an unexpected tier string
+        # — logs and returns tier3, mirroring evaluate_tier. It must never escape
+        # into the reference plugin's fail-OPEN evaluate catch.
         try:
+            # Step 1: own tier (today's logic).
+            own = self._derive_own_tier(session_id)
+            # Step 2: lineage off / disabled → own only (byte-for-byte today's).
+            if self._lineage is None or not self._config.subagent_lineage_enabled:
+                return own
+            # Steps 3-4: a child's tier is max(own, worst ancestor) read LIVE at
+            # evaluation time (D5).
             anc_tiers: list[str] = []
             for aid in self._lineage.ancestors(session_id):
                 if self._frequency_tracker.is_terminated(aid):

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -324,18 +324,24 @@ class ToolCallGuard:
         try:
             # Step 1: own tier (today's logic).
             own = self._derive_own_tier(session_id)
-            # Step 2: lineage off / disabled → own only (byte-for-byte today's).
-            if self._lineage is None or not self._config.subagent_lineage_enabled:
+            # Step 2: no lineage data wired (host sub-agent hooks absent) → own
+            # only. This is the graceful-degradation branch (lineage is None).
+            if self._lineage is None:
                 return own
             # Steps 3-4: a child's tier is max(own, worst ancestor) read LIVE at
-            # evaluation time (D5).
+            # evaluation time (D5). subagent_lineage_enabled gates the OPTIONAL
+            # tier-1/2 inheritance, but a terminated ancestor's tier-3 floor (D4)
+            # has NO config override — "Tier 3 escalation cannot be disabled" — so
+            # the chain is still walked for tombstones even when the flag is off.
+            inherit_full = self._config.subagent_lineage_enabled
             anc_tiers: list[str] = []
             for aid in self._lineage.ancestors(session_id):
                 if self._frequency_tracker.is_terminated(aid):
                     # Tombstone-backed: a terminated ancestor forces tier3 even
-                    # post-eviction (closes orphaned termination).
+                    # post-eviction (closes orphaned termination) and even when
+                    # full inheritance is config-disabled (D4 floor, no override).
                     anc_tiers.append("tier3")
-                else:
+                elif inherit_full:
                     anc_tiers.append(self._state_to_tier(self._read_state(aid)))
             return max_tier(own, *anc_tiers)
         except Exception:

--- a/petasos/session/lineage.py
+++ b/petasos/session/lineage.py
@@ -1,0 +1,129 @@
+"""Sub-agent delegation lineage registry (PET-107, Option A).
+
+A thread-safe ``child_session_id -> parent_session_id`` edge store that lets the
+``ToolCallGuard`` derive a child's tier as ``max(own, parent-chain)``. Edges are
+asserted by the *host* (Hermes) on its ``subagent_start``/``subagent_stop``
+hooks; the child agent never registers its own edge and never chooses its parent
+(see spec D2 — the untrusted surface is the child's tool *content*, already
+scanned, not the lineage edge).
+
+Invariant (load-bearing): **no method here ever calls into ``FrequencyTracker``.**
+The lock order across the two structures is always tracker → registry (the only
+nested case is eviction calling ``is_pinned``/``on_terminate``); because the
+registry never reaches back into the tracker, no opposite-order nesting exists
+and no deadlock cycle is possible (spec D10).
+
+The clock is ``time.monotonic()`` — the *same* clock ``FrequencyTracker`` uses —
+so edge-TTL comparisons here and session-TTL comparisons there agree.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from petasos.config import PetasosConfig
+
+_logger = logging.getLogger(__name__)
+
+
+class LineageRegistry:
+    """Thread-safe store of ``child -> (parent, registered_monotonic)`` edges."""
+
+    def __init__(self, config: PetasosConfig) -> None:
+        self._max_depth = config.lineage_max_depth
+        self._max_edges = config.lineage_max_edges
+        self._edge_ttl = config.lineage_edge_ttl_seconds
+        self._lock = threading.Lock()
+        self._edges: dict[str, tuple[str, float]] = {}
+
+    def register(self, child: str, parent: str) -> None:
+        """Record (or re-parent) the ``child -> parent`` edge.
+
+        Rejects empty ids and a self-edge (``child == parent``). If ``child``
+        already has an edge it is updated **in place** (last-writer-wins, so a
+        re-parented child points at its newest parent and a stale clean parent
+        cannot mask an escalating one) — an in-place update is *not* a new
+        insertion, so it never evicts an unrelated oldest edge. A genuinely new
+        ``child`` key enforces ``lineage_max_edges`` by evicting the oldest edge
+        by timestamp. Expired edges are opportunistically pruned first.
+        """
+        if not child or not parent:
+            _logger.warning(
+                "lineage.register rejected empty id (child=%r parent=%r)", child, parent
+            )
+            return
+        if child == parent:
+            _logger.warning("lineage.register rejected self-edge (id=%r)", child)
+            return
+        now = time.monotonic()
+        with self._lock:
+            self._prune_expired_locked(now)
+            if child in self._edges:
+                # Re-parent in place — last-writer-wins, no eviction.
+                self._edges[child] = (parent, now)
+                return
+            if len(self._edges) >= self._max_edges:
+                oldest = min(self._edges, key=lambda c: self._edges[c][1])
+                del self._edges[oldest]
+            self._edges[child] = (parent, now)
+
+    def unregister(self, child: str) -> None:
+        """Drop ``child``'s edge. Idempotent — a missed/duplicate stop is a no-op."""
+        with self._lock:
+            self._edges.pop(child, None)
+
+    def ancestors(self, session_id: str) -> list[str]:
+        """Return a **snapshot** list of ancestor ids, nearest-first.
+
+        Built entirely under the lock and returned by value (the lock is
+        released on return — the guard then reads the tracker per ancestor with
+        no registry lock held, keeping the two locks strictly sequential).
+        Bounded by ``lineage_max_depth`` and a ``visited`` set (cycle-safe), and
+        stops at the first edge older than ``lineage_edge_ttl_seconds``.
+        """
+        now = time.monotonic()
+        result: list[str] = []
+        with self._lock:
+            visited: set[str] = {session_id}
+            current = session_id
+            while len(result) < self._max_depth:
+                edge = self._edges.get(current)
+                if edge is None:
+                    break
+                parent, registered = edge
+                if now - registered > self._edge_ttl:
+                    break
+                if parent in visited:
+                    break  # cycle guard
+                result.append(parent)
+                visited.add(parent)
+                current = parent
+        return result
+
+    def is_pinned(self, session_id: str) -> bool:
+        """True iff ``session_id`` is the parent of >=1 *live* edge.
+
+        "Live" = non-expired (monotonic TTL) and the child still registered
+        (an unregistered child has no entry in ``_edges``). Cheap; takes only
+        the registry lock. Shares ``time.monotonic()`` with ``FrequencyTracker``
+        so the pin window and the session-TTL window agree.
+
+        This is the predicate ``FrequencyTracker`` consults to keep a tier-1/2
+        parent alive while a child references it. It MUST stay O(small) and
+        non-blocking, and must never call back into the tracker.
+        """
+        now = time.monotonic()
+        with self._lock:
+            for parent, registered in self._edges.values():
+                if parent == session_id and (now - registered) <= self._edge_ttl:
+                    return True
+        return False
+
+    def _prune_expired_locked(self, now: float) -> None:
+        expired = [child for child, (_p, ts) in self._edges.items() if (now - ts) > self._edge_ttl]
+        for child in expired:
+            del self._edges[child]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,6 +94,19 @@ class TestConfigSerialization:
         d = cfg.to_dict()
         assert isinstance(d["pii_entities"], list)
 
+    def test_config_roundtrip_preserves_delegate_tool_names_tuple(self) -> None:
+        # PET-107: delegate_tool_names is stored raw as a tuple; a to_dict (→
+        # list) / from_dict (→ tuple) round-trip — as the Console persist path
+        # and copy() perform — must preserve the tuple type and value.
+        cfg = PetasosConfig(delegate_tool_names=("delegate_task", "spawn_agent"))
+        d = cfg.to_dict()
+        assert isinstance(d["delegate_tool_names"], list)  # serialized as JSON list
+        restored = PetasosConfig.from_dict(d)
+        assert isinstance(restored.delegate_tool_names, tuple)
+        assert restored.delegate_tool_names == ("delegate_task", "spawn_agent")
+        assert restored == cfg
+        assert isinstance(cfg.copy().delegate_tool_names, tuple)
+
     def test_from_dict_partial_fills_defaults(self) -> None:
         cfg = PetasosConfig.from_dict({"direction": "outbound"})
         assert cfg.direction == "outbound"

--- a/tests/test_frequency.py
+++ b/tests/test_frequency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -10,7 +11,9 @@ from petasos.session.frequency import (
     DISABLED_RESULT,
     RATE_LIMITED_RESULT,
     FrequencyTracker,
+    SessionState,
 )
+from petasos.session.lineage import LineageRegistry
 
 
 def _cfg(**overrides: object) -> PetasosConfig:
@@ -539,3 +542,107 @@ class TestSessionToken:
             tracker.mint_token("\x00abc", "host")
         with pytest.raises(ValueError, match="null bytes"):
             tracker.mint_token("s1", "host\x00evil")
+
+
+# ---------------------------------------------------------------------------
+# PET-107 D6: lineage pinning, hard ceiling, termination unpin
+# ---------------------------------------------------------------------------
+
+
+def _pinned_tracker(cfg: PetasosConfig) -> tuple[FrequencyTracker, LineageRegistry]:
+    registry = LineageRegistry(cfg)
+    tracker = FrequencyTracker(cfg, is_pinned=registry.is_pinned, on_terminate=registry.unregister)
+    return tracker, registry
+
+
+class TestLineagePinning:
+    def test_terminated_child_unpins_parent(self) -> None:
+        # D6: tombstoning a child fires on_terminate → its edge drops → the
+        # parent is no longer pinned.
+        tracker, registry = _pinned_tracker(_cfg())
+        registry.register("child", "parent")
+        assert registry.is_pinned("parent") is True
+        tracker.terminate_session("child")
+        assert registry.is_pinned("parent") is False
+
+    def test_passive_eviction_retries_after_unpin(self) -> None:
+        # D6: a pinned session is skipped (and re-appended, no spin) by passive
+        # TTL eviction, then reaped once it unpins on a later update().
+        cfg = _cfg(session_ttl_seconds=10.0)
+        tracker, registry = _pinned_tracker(cfg)
+        clock = {"t": 0.0}
+
+        def _now() -> float:
+            return clock["t"]
+
+        with patch("petasos.session.frequency.time.monotonic", _now):
+            tracker.update("parent", [])  # created at t=0
+            registry.register("child", "parent")  # parent pinned
+            clock["t"] = 100.0  # past session_ttl
+            tracker.update("trigger", [])  # step-1: parent expired but pinned → skip
+            assert tracker.get_state("parent") is not None  # retained, no spin
+            registry.unregister("child")  # unpin
+            clock["t"] = 200.0
+            tracker.update("trigger2", [])  # step-1: parent now reaped
+            assert tracker.get_state("parent") is None
+
+    def test_terminated_parent_ttl_evicted_unpins(self) -> None:
+        # D6 (4th tombstone path): a terminated session reaped on the step-1 TTL
+        # path fires on_terminate → drops its outgoing edge → unpins its parent.
+        cfg = _cfg(session_ttl_seconds=10.0)
+        tracker, registry = _pinned_tracker(cfg)
+        clock = {"t": 0.0}
+
+        def _now() -> float:
+            return clock["t"]
+
+        with patch("petasos.session.frequency.time.monotonic", _now):
+            # Directly mark terminated to bypass the on_terminate-firing paths,
+            # isolating the TTL reap path with a still-live outgoing edge.
+            tracker._sessions["parent"] = SessionState(
+                last_score=0.0, last_update=0.0, terminated=True
+            )
+            tracker._ttl_deque.append((10.0, "parent"))
+            registry.register("parent", "grandparent")  # grandparent pinned
+            assert registry.is_pinned("grandparent") is True
+            clock["t"] = 100.0
+            tracker.update("trigger", [])  # step-1 reaps the terminated parent
+            assert tracker.get_state("parent") is None
+            assert registry.is_pinned("grandparent") is False  # edge dropped on reap
+
+    def test_pinning_hard_ceiling(self, caplog: pytest.LogCaptureFixture) -> None:
+        # D6: under an all-pinned spray, _sessions never exceeds 2×max_sessions;
+        # the smallest-last_update pinned session is force-evicted (logged, no
+        # raise) and degrades to OWN-tier (non-tombstoned), while a *terminated*
+        # ancestor's tombstone still survives (tier-3 floor unaffected, D4).
+        cfg = _cfg(max_sessions=2)
+        tracker, registry = _pinned_tracker(cfg)
+        parents = [f"p{i}" for i in range(5)]
+        with caplog.at_level(logging.WARNING):
+            for p in parents:
+                registry.register(f"c_{p}", p)  # pin p (child edge)
+                tracker.update(p, [])
+                assert tracker.size <= 2 * cfg.max_sessions  # bounded, never exceeds 4
+
+        # p0 (smallest last_update) was force-evicted and is NOT tombstoned →
+        # its sub-tree reads own-tier, not tier3.
+        assert tracker.get_state("p0") is None
+        assert tracker.is_terminated("p0") is False
+        assert any("hard ceiling" in r.getMessage().lower() for r in caplog.records)
+
+        # Contrast: the tier-3 floor is unaffected — a terminated session's
+        # tombstone survives removal from _sessions.
+        tracker.terminate_session("survivor")
+        tracker.reset("survivor")  # drop the live state; tombstone must remain
+        assert tracker.is_terminated("survivor") is True
+
+    def test_feature_off_eviction_is_unchanged(self) -> None:
+        # is_pinned=None / on_terminate=None → eviction is byte-for-byte today's:
+        # an over-cap insert evicts the oldest, no pinning consulted.
+        cfg = _cfg(max_sessions=1)
+        tracker = FrequencyTracker(cfg)  # no callbacks
+        tracker.update("a", [])
+        tracker.update("b", [])  # over cap → 'a' evicted (no pin protection)
+        assert tracker.size == 1
+        assert tracker.get_state("a") is None
+        assert tracker.get_state("b") is not None

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -719,6 +719,22 @@ class TestDelegationFanout:
             t.join()
         assert sum(1 for r in results if r) == 1
 
+    def test_fanout_sweeps_stale_one_shot_sessions(self) -> None:
+        # A session that delegates once and is never touched again must not leave
+        # a stale deque in _events forever; the amortized global sweep (fired by a
+        # later consume past the window) drops it so the map tracks active windows
+        # rather than every distinct session ID ever seen.
+        from petasos.session.guard import SpawnBudget
+
+        budget = SpawnBudget(window_seconds=60.0)
+        for sid in ("a", "b", "c"):
+            assert budget.try_consume(sid, 5, 1000.0) is True
+        assert len(budget._events) == 3
+        # A later consume past the window triggers the global sweep; the three
+        # one-shot sessions are gone and only the live one remains.
+        assert budget.try_consume("d", 5, 2000.0) is True
+        assert set(budget._events) == {"d"}
+
 
 class TestConcurrentChildren:
     def test_concurrent_children_threadsafe(self) -> None:

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import MappingProxyType
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +17,7 @@ from petasos.session.guard import (
     GuardResult,
     ToolCallGuard,
 )
+from petasos.session.lineage import LineageRegistry
 from petasos.session.profiles import ResolvedProfile, TierThresholds
 
 
@@ -544,3 +547,238 @@ class TestScanParamsCatchAll:
         result = await g.evaluate("read", {"path": "/etc/passwd"}, "s1")
         assert result.param_scan_unsafe is True
         assert result.findings == ()
+
+
+# ---------------------------------------------------------------------------
+# PET-107: sub-agent lineage (A) + delegation fan-out gate (C)
+# ---------------------------------------------------------------------------
+
+_GUARD_CLOCK = "petasos.session.guard.time.monotonic"
+
+
+def _lineage_setup(
+    cfg: PetasosConfig | None = None,
+    profile: ResolvedProfile | None = None,
+) -> tuple[Pipeline, LineageRegistry, FrequencyTracker, ToolCallGuard]:
+    """Build a guard wired to a shared registry + a tracker whose pin/unpin
+    callbacks point at that registry (mirrors the reference plugin)."""
+    cfg = cfg or _cfg()
+    pipe = Pipeline(config=cfg, host_id="test-host")
+    registry = LineageRegistry(cfg)
+    tracker = FrequencyTracker(cfg, is_pinned=registry.is_pinned, on_terminate=registry.unregister)
+    guard = ToolCallGuard(pipe, tracker, cfg, profile=profile, lineage=registry)
+    return pipe, registry, tracker, guard
+
+
+class TestLineageInheritance:
+    async def test_subagent_inherits_parent_tier(self) -> None:
+        # Brief A: parent at tier 2, child inherits it on its first evaluate().
+        _pipe, registry, tracker, guard = _lineage_setup()
+        tracker._sessions["parent"] = SessionState(last_score=31.0, last_update=0.0)
+        registry.register("child", "parent")
+        result = await guard.evaluate("read", {}, "child")
+        assert result.tier == "tier2"
+        assert result.allowed is False  # tier2 blocks the non-exempt child tool
+
+    async def test_parent_tier3_blocks_child_tools(self) -> None:
+        # Brief A / #2: a terminated parent forces the child to tier3 even after
+        # the parent's live state is gone (tombstone-backed is_terminated).
+        _pipe, registry, tracker, guard = _lineage_setup()
+        tracker.terminate_session("parent")
+        registry.register("child", "parent")
+        result = await guard.evaluate("read", {}, "child")
+        assert result.tier == "tier3"
+        assert result.allowed is False
+
+    async def test_lineage_with_session_token(self) -> None:
+        # PET-31 regression: ancestor tiers must be read via per-ancestor minted
+        # tokens, never the raw id (a raw-id get_state raises with a secret set).
+        secret = b"test-secret-key-32-bytes-long!!!"
+        cfg = _cfg(session_secret=secret)
+        pipe = Pipeline(config=cfg, host_id="test-host")
+        registry = LineageRegistry(cfg)
+        tracker = FrequencyTracker(
+            cfg, is_pinned=registry.is_pinned, on_terminate=registry.unregister
+        )
+        guard = ToolCallGuard(pipe, tracker, cfg, lineage=registry)
+        parent_token = tracker.mint_token("parent", "test-host")
+        tracker.update(parent_token, ["petasos.syntactic.injection.x"] * 4)  # → tier2
+        registry.register("child", "parent")
+        result = await guard.evaluate("read", {}, "child")
+        assert result.tier == "tier2"
+
+    async def test_child_cannot_register_arbitrary_parent(self) -> None:
+        # D2 trust model: registration is host-hook-only. Tool *content* naming a
+        # parent must never create or alter a lineage edge.
+        _pipe, registry, tracker, guard = _lineage_setup()
+        tracker._sessions["victim"] = SessionState(last_score=31.0, last_update=0.0)
+        await guard.evaluate(
+            "read",
+            {"parent_session_id": "victim", "child_session_id": "child"},
+            "child",
+        )
+        assert registry.ancestors("child") == []
+        assert registry.is_pinned("victim") is False
+
+    async def test_laundering_closed_under_eviction(self) -> None:
+        # D6/#1: a tier-2 parent with a live child is pinned, so a TTL-eviction
+        # pass keeps it and the child keeps inheriting tier 2.
+        cfg = _cfg(session_ttl_seconds=10.0)
+        clock = {"t": 0.0}
+
+        def _now() -> float:
+            return clock["t"]
+
+        with (
+            patch("petasos.session.frequency.time.monotonic", _now),
+            patch("petasos.session.lineage.time.monotonic", _now),
+        ):
+            pipe = Pipeline(config=cfg, host_id="test-host")
+            registry = LineageRegistry(cfg)
+            tracker = FrequencyTracker(
+                cfg, is_pinned=registry.is_pinned, on_terminate=registry.unregister
+            )
+            guard = ToolCallGuard(pipe, tracker, cfg, lineage=registry)
+            tracker.update("parent", ["petasos.syntactic.injection.x"] * 4)  # → tier2
+            registry.register("child", "parent")
+            clock["t"] = 100.0  # past session_ttl (10s), within edge_ttl (3600s)
+            tracker.update("trigger", [])  # runs passive eviction — parent pinned
+            assert tracker.get_state("parent") is not None  # retained, not evicted
+            result = await guard.evaluate("read", {}, "child")
+            assert result.tier == "tier2"  # still inherited
+
+
+class TestDelegationFanout:
+    async def test_tier2_blocks_delegate_task(self) -> None:
+        # C: tier-2 delegate blocked by the ladder (step 6); Step 3.5 counted the
+        # first attempt, so the second is blocked by the fan-out budget instead.
+        _pipe, _registry, tracker, guard = _lineage_setup()
+        tracker._sessions["s1"] = SessionState(last_score=31.0, last_update=0.0)
+        r1 = await guard.evaluate("delegate_task", {}, "s1")
+        assert r1.allowed is False
+        assert "tier2" in r1.reason
+        r2 = await guard.evaluate("delegate_task", {}, "s1")
+        assert r2.allowed is False
+        assert "fan-out" in r2.reason
+
+    def test_delegate_not_exempt_rejected_at_construction(self) -> None:
+        # D8: a delegate tool name in the profile exempt list is a hard error.
+        cfg = _cfg()
+        pipe = Pipeline(config=cfg)
+        tracker = FrequencyTracker(cfg)
+        p = _profile(tool_exempt_list=frozenset({"delegate_task"}))
+        with pytest.raises(ValueError, match="exempt"):
+            ToolCallGuard(pipe, tracker, cfg, profile=p)
+
+    async def test_delegate_fanout_budget_enforced(self) -> None:
+        cfg = _cfg()  # base cap 3, window 60s
+        pipe = Pipeline(config=cfg)
+        tracker = FrequencyTracker(cfg)
+        guard = ToolCallGuard(pipe, tracker, cfg)  # lineage=None → C only
+        with patch(_GUARD_CLOCK, return_value=1000.0):
+            for _ in range(3):  # base_cap spawns allowed at tier none
+                assert (await guard.evaluate("delegate_task", {}, "s1")).allowed is True
+            over = await guard.evaluate("delegate_task", {}, "s1")  # the next blocked
+            assert over.allowed is False
+            assert "fan-out" in over.reason
+        with patch(_GUARD_CLOCK, return_value=1000.0 + 120.0):  # aged out
+            assert (await guard.evaluate("delegate_task", {}, "s1")).allowed is True
+
+    async def test_fanout_tier1_cap_halved(self) -> None:
+        # tier1 cap = max(1, base_cap // 2) = 1 for base_cap 3.
+        cfg = _cfg()
+        pipe = Pipeline(config=cfg)
+        tracker = FrequencyTracker(cfg)
+        tracker._sessions["s1"] = SessionState(last_score=15.0, last_update=0.0)  # tier1
+        guard = ToolCallGuard(pipe, tracker, cfg)
+        with patch(_GUARD_CLOCK, return_value=1000.0):
+            assert (await guard.evaluate("delegate_task", {}, "s1")).allowed is True
+            r2 = await guard.evaluate("delegate_task", {}, "s1")
+            assert r2.allowed is False
+            assert "fan-out" in r2.reason
+
+    def test_fanout_concurrent_atomic(self) -> None:
+        # C TOCTOU: N threads racing a budget of 1 → exactly one passes.
+        from petasos.session.guard import SpawnBudget
+
+        budget = SpawnBudget(window_seconds=60.0)
+        results: list[bool] = []
+        results_lock = threading.Lock()
+        start = threading.Barrier(20)
+
+        def worker() -> None:
+            start.wait()
+            ok = budget.try_consume("s", 1, 1000.0)
+            with results_lock:
+                results.append(ok)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert sum(1 for r in results if r) == 1
+
+
+class TestConcurrentChildren:
+    def test_concurrent_children_threadsafe(self) -> None:
+        # Brief #4: >=3 real-thread children registering + evaluating against the
+        # shared registry + locked tracker → no race/exception, consistent reads.
+        _pipe, registry, tracker, guard = _lineage_setup()
+        tracker._sessions["parent"] = SessionState(last_score=31.0, last_update=0.0)
+        errors: list[Exception] = []
+        results: dict[int, str] = {}
+
+        def child_worker(k: int) -> None:
+            try:
+                registry.register(f"child{k}", "parent")
+                res = asyncio.run(guard.evaluate("read", {}, f"child{k}"))
+                results[k] = res.tier
+            except Exception as exc:  # noqa: BLE001 — record, assert empty later
+                errors.append(exc)
+
+        def noise_writer(k: int) -> None:
+            try:
+                for _ in range(10):
+                    tracker.update(f"noise{k}", ["petasos.syntactic.injection.x"])
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=child_worker, args=(k,)) for k in range(5)]
+        threads += [threading.Thread(target=noise_writer, args=(k,)) for k in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert len(results) == 5
+        assert all(tier == "tier2" for tier in results.values())
+
+
+class TestFeatureDisabledNoop:
+    async def test_lineage_none_no_inheritance(self) -> None:
+        cfg = _cfg()
+        pipe = Pipeline(config=cfg)
+        tracker = FrequencyTracker(cfg)
+        tracker._sessions["parent"] = SessionState(last_score=31.0, last_update=0.0)
+        guard = ToolCallGuard(pipe, tracker, cfg, lineage=None)  # A off
+        result = await guard.evaluate("read", {}, "child")  # no own state
+        assert result.tier == "none"
+        assert result.allowed is True
+
+    async def test_lineage_flag_off_no_inheritance(self) -> None:
+        cfg = _cfg(subagent_lineage_enabled=False)
+        _pipe, registry, tracker, guard = _lineage_setup(cfg=cfg)
+        tracker._sessions["parent"] = SessionState(last_score=31.0, last_update=0.0)
+        registry.register("child", "parent")
+        result = await guard.evaluate("read", {}, "child")
+        assert result.tier == "none"  # flag off → no chain walk
+
+    async def test_fanout_flag_off_not_gated(self) -> None:
+        cfg = _cfg(delegate_fanout_enabled=False)
+        pipe = Pipeline(config=cfg)
+        tracker = FrequencyTracker(cfg)
+        guard = ToolCallGuard(pipe, tracker, cfg)
+        for _ in range(6):  # well past base_cap — gate inert
+            assert (await guard.evaluate("delegate_task", {}, "s1")).allowed is True

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -773,7 +773,20 @@ class TestFeatureDisabledNoop:
         tracker._sessions["parent"] = SessionState(last_score=31.0, last_update=0.0)
         registry.register("child", "parent")
         result = await guard.evaluate("read", {}, "child")
-        assert result.tier == "none"  # flag off → no chain walk
+        assert result.tier == "none"  # flag off → optional tier-1/2 not inherited
+
+    async def test_lineage_flag_off_still_enforces_terminated_tier3(self) -> None:
+        # D4 floor: subagent_lineage_enabled=False disables only the OPTIONAL
+        # tier-1/2 inheritance; a terminated ancestor's tier3 has no config
+        # override ("Tier 3 escalation cannot be disabled"), so the child of a
+        # terminated parent is still forced to tier3 with the flag off.
+        cfg = _cfg(subagent_lineage_enabled=False)
+        _pipe, registry, tracker, guard = _lineage_setup(cfg=cfg)
+        tracker.terminate_session("parent")
+        registry.register("child", "parent")
+        result = await guard.evaluate("read", {}, "child")
+        assert result.tier == "tier3"
+        assert result.allowed is False
 
     async def test_fanout_flag_off_not_gated(self) -> None:
         cfg = _cfg(delegate_fanout_enabled=False)

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,204 @@
+"""PET-107: LineageRegistry unit tests + max_tier combinator.
+
+Covers the spec's ``test_lineage_registry_*`` row: register/unregister
+idempotency, self-edge + empty-id rejection, last-writer-wins re-parent
+(in-place, no collateral eviction at the cap), bounded + cycle-safe chain walk,
+monotonic edge-TTL prune, ``max_edges`` cap, ``is_pinned`` only on a live edge,
+and ``max_tier`` raising on an unknown tier string.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from petasos.config import PetasosConfig
+from petasos.session.escalation import max_tier
+from petasos.session.lineage import LineageRegistry
+
+_CLOCK = "petasos.session.lineage.time.monotonic"
+
+
+def _cfg(**overrides: object) -> PetasosConfig:
+    return PetasosConfig(**overrides)  # type: ignore[arg-type]
+
+
+def _registry(**overrides: object) -> LineageRegistry:
+    return LineageRegistry(_cfg(**overrides))
+
+
+# ---------------------------------------------------------------------------
+# max_tier — single ordering source
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTier:
+    def test_returns_highest_rank(self) -> None:
+        assert max_tier("none", "tier2", "tier1") == "tier2"
+        assert max_tier("tier3", "none") == "tier3"
+        assert max_tier("tier1", "tier1") == "tier1"
+
+    def test_no_args_is_none(self) -> None:
+        assert max_tier() == "none"
+        assert max_tier("none") == "none"
+
+    def test_raises_on_unknown(self) -> None:
+        with pytest.raises(ValueError, match="unknown tier"):
+            max_tier("bogus")
+        with pytest.raises(ValueError, match="unknown tier"):
+            max_tier("none", "tier4")
+
+
+# ---------------------------------------------------------------------------
+# register / unregister
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterUnregister:
+    def test_basic_edge_and_ancestors(self) -> None:
+        reg = _registry()
+        reg.register("child", "parent")
+        assert reg.ancestors("child") == ["parent"]
+
+    def test_unregister_drops_edge_and_is_idempotent(self) -> None:
+        reg = _registry()
+        reg.register("child", "parent")
+        reg.unregister("child")
+        assert reg.ancestors("child") == []
+        # idempotent — a missed/duplicate stop is a no-op
+        reg.unregister("child")
+        reg.unregister("never-seen")
+
+    def test_self_edge_rejected(self) -> None:
+        reg = _registry()
+        reg.register("x", "x")
+        assert reg.ancestors("x") == []
+
+    def test_empty_ids_rejected(self) -> None:
+        reg = _registry()
+        reg.register("", "parent")
+        reg.register("child", "")
+        assert reg.ancestors("child") == []
+        assert reg.ancestors("") == []
+
+    def test_register_is_idempotent_same_parent(self) -> None:
+        reg = _registry()
+        reg.register("c", "p")
+        reg.register("c", "p")
+        assert reg.ancestors("c") == ["p"]
+
+
+# ---------------------------------------------------------------------------
+# last-writer-wins re-parent
+# ---------------------------------------------------------------------------
+
+
+class TestReparent:
+    def test_last_writer_wins(self) -> None:
+        reg = _registry()
+        reg.register("c", "stale_parent")
+        reg.register("c", "fresh_parent")
+        # newest parent wins — a stale clean parent cannot mask an escalating one
+        assert reg.ancestors("c") == ["fresh_parent"]
+
+    def test_reparent_in_place_does_not_evict_unrelated_edge_at_cap(self) -> None:
+        # max_edges=2: fill with c1, c2; re-parenting c1 must NOT evict c2.
+        reg = _registry(lineage_max_edges=2)
+        with patch(_CLOCK, return_value=1.0):
+            reg.register("c1", "p1")
+        with patch(_CLOCK, return_value=2.0):
+            reg.register("c2", "p2")
+        with patch(_CLOCK, return_value=3.0):
+            reg.register("c1", "p3")  # in-place update, not a new insertion
+        with patch(_CLOCK, return_value=3.5):  # within TTL of the patched edges
+            assert reg.ancestors("c1") == ["p3"]
+            assert reg.ancestors("c2") == ["p2"]  # survived — no collateral eviction
+
+
+# ---------------------------------------------------------------------------
+# chain walk — bounded + cycle-safe
+# ---------------------------------------------------------------------------
+
+
+class TestAncestorsWalk:
+    def test_multi_hop_nearest_first(self) -> None:
+        reg = _registry()
+        reg.register("c", "p")
+        reg.register("p", "g")
+        reg.register("g", "gg")
+        assert reg.ancestors("c") == ["p", "g", "gg"]
+
+    def test_bounded_by_max_depth(self) -> None:
+        reg = _registry(lineage_max_depth=2)
+        reg.register("c", "p")
+        reg.register("p", "g")
+        reg.register("g", "gg")
+        assert reg.ancestors("c") == ["p", "g"]
+
+    def test_cycle_is_safe(self) -> None:
+        reg = _registry()
+        reg.register("a", "b")
+        reg.register("b", "a")  # cycle
+        # terminates; b appended once, then a is already visited → stop
+        assert reg.ancestors("a") == ["b"]
+        assert reg.ancestors("b") == ["a"]
+
+    def test_no_edge_returns_empty(self) -> None:
+        reg = _registry()
+        assert reg.ancestors("orphan") == []
+
+
+# ---------------------------------------------------------------------------
+# edge TTL (monotonic) + max_edges cap
+# ---------------------------------------------------------------------------
+
+
+class TestTtlAndCap:
+    def test_expired_edge_skipped_in_walk(self) -> None:
+        reg = _registry(lineage_edge_ttl_seconds=10.0)
+        with patch(_CLOCK, return_value=0.0):
+            reg.register("c", "p")
+        with patch(_CLOCK, return_value=5.0):
+            assert reg.ancestors("c") == ["p"]  # still live
+        with patch(_CLOCK, return_value=20.0):
+            assert reg.ancestors("c") == []  # expired
+
+    def test_max_edges_evicts_oldest(self) -> None:
+        reg = _registry(lineage_max_edges=2)
+        with patch(_CLOCK, return_value=1.0):
+            reg.register("c1", "p")
+        with patch(_CLOCK, return_value=2.0):
+            reg.register("c2", "p")
+        with patch(_CLOCK, return_value=3.0):
+            reg.register("c3", "p")  # over cap → evict oldest (c1)
+        with patch(_CLOCK, return_value=3.5):  # within TTL of the patched edges
+            assert reg.ancestors("c1") == []
+            assert reg.ancestors("c2") == ["p"]
+            assert reg.ancestors("c3") == ["p"]
+
+
+# ---------------------------------------------------------------------------
+# is_pinned — only a live edge
+# ---------------------------------------------------------------------------
+
+
+class TestIsPinned:
+    def test_parent_of_live_edge_is_pinned(self) -> None:
+        reg = _registry()
+        reg.register("c", "p")
+        assert reg.is_pinned("p") is True
+        assert reg.is_pinned("c") is False  # a leaf child pins nobody
+
+    def test_unregister_unpins_parent(self) -> None:
+        reg = _registry()
+        reg.register("c", "p")
+        reg.unregister("c")
+        assert reg.is_pinned("p") is False
+
+    def test_expired_edge_does_not_pin(self) -> None:
+        reg = _registry(lineage_edge_ttl_seconds=10.0)
+        with patch(_CLOCK, return_value=0.0):
+            reg.register("c", "p")
+        with patch(_CLOCK, return_value=100.0):
+            assert reg.is_pinned("p") is False

--- a/tests/test_subagent_plugin_wiring.py
+++ b/tests/test_subagent_plugin_wiring.py
@@ -1,0 +1,157 @@
+"""PET-107: reference-plugin sub-agent hook wiring + graceful degradation.
+
+Precondition 2 of the spec: if the host's ``subagent_start``/``subagent_stop``
+hooks are unavailable (or only one of the pair registers), lineage-linked
+escalation (A) no-ops (``lineage=None``) and only the delegation fan-out gate (C)
+stays active — no edge store is created that would never be drained.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import types
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet107", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeCtx:
+    """Minimal Hermes plugin ctx that can reject named hooks (unknown-hook sim)."""
+
+    def __init__(self, reject: set[str] | None = None) -> None:
+        self.registered: list[str] = []
+        self._reject = reject or set()
+
+    def register_hook(self, name: str, handler: object) -> None:
+        if name in self._reject:
+            raise ValueError(f"unknown hook: {name!r}")
+        self.registered.append(name)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PETASOS_LICENSE_KEY", "PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _prep_init(mod: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_config", {})
+    monkeypatch.setattr(mod, "_initialized", False)
+    monkeypatch.setattr(mod, "_init_error", None)
+    monkeypatch.setattr(mod, "_pipeline", None)
+    monkeypatch.setattr(mod, "_guard", None)
+
+
+# ---------------------------------------------------------------------------
+# register(): hook availability detection
+# ---------------------------------------------------------------------------
+
+
+class TestHookRegistration:
+    def test_both_hooks_registered_marks_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ref = _import_reference_plugin()
+        monkeypatch.setattr(ref, "_load_config", lambda: {})
+        monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # neutralize bg thread
+        ctx = _FakeCtx()
+        ref.register(ctx)
+        assert ref._subagent_hooks_available is True
+        assert {"subagent_start", "subagent_stop"} <= set(ctx.registered)
+
+    def test_stop_hook_rejected_degrades_to_C(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ref = _import_reference_plugin()
+        monkeypatch.setattr(ref, "_load_config", lambda: {})
+        monkeypatch.setattr(ref, "_deferred_init", lambda: None)
+        ctx = _FakeCtx(reject={"subagent_stop"})
+        ref.register(ctx)
+        # start accepted, stop rejected → A NOT entered (start-only mode unsafe)
+        assert ref._subagent_hooks_available is False
+        assert "subagent_start" in ctx.registered
+        assert "subagent_stop" not in ctx.registered
+        # core hooks unaffected
+        assert "pre_tool_call" in ctx.registered
+
+
+# ---------------------------------------------------------------------------
+# _deferred_init(): wiring honors the availability flag
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredInitWiring:
+    def test_subagent_hooks_available_wires_lineage(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ref = _import_reference_plugin()
+        _prep_init(ref, monkeypatch)
+        monkeypatch.setattr(ref, "_subagent_hooks_available", True)
+        ref._deferred_init()
+        assert ref._lineage_registry is not None
+        assert ref._guard is not None
+        assert ref._guard._lineage is ref._lineage_registry  # A wired
+
+    def test_lineage_unavailable_degrades_to_C(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ref = _import_reference_plugin()
+        _prep_init(ref, monkeypatch)
+        monkeypatch.setattr(ref, "_subagent_hooks_available", False)
+        ref._deferred_init()
+        assert ref._lineage_registry is None  # A no-ops, no edge store created
+        assert ref._guard is not None
+        assert ref._guard._lineage is None
+        # C still active: delegate recognized + fan-out gate enabled
+        assert "delegate_task" in ref._guard._delegate_tool_names
+        assert ref._guard._config.delegate_fanout_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Hook handlers respect the trust boundary + lazy registry
+# ---------------------------------------------------------------------------
+
+
+class TestHookHandlers:
+    def test_start_handler_noop_before_registry_ready(self) -> None:
+        # A subagent_start firing before _deferred_init builds the registry is a
+        # safe no-op (no crash).
+        ref = _import_reference_plugin()
+        assert ref._lineage_registry is None
+        ref._subagent_start(parent_session_id="p", child_session_id="c")  # no raise
+
+    def test_handlers_register_and_unregister_edges(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from petasos import LineageRegistry, PetasosConfig
+
+        ref = _import_reference_plugin()
+        registry = LineageRegistry(PetasosConfig())
+        monkeypatch.setattr(ref, "_lineage_registry", registry)
+        ref._subagent_start(parent_session_id="parent", child_session_id="child")
+        assert registry.ancestors("child") == ["parent"]
+        ref._subagent_stop(child_session_id="child")
+        assert registry.ancestors("child") == []
+
+    def test_start_handler_ignores_missing_ids(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from petasos import LineageRegistry, PetasosConfig
+
+        ref = _import_reference_plugin()
+        registry = LineageRegistry(PetasosConfig())
+        monkeypatch.setattr(ref, "_lineage_registry", registry)
+        ref._subagent_start(parent_session_id="", child_session_id="child")
+        ref._subagent_start(parent_session_id="parent", child_session_id="")
+        assert registry.ancestors("child") == []

--- a/tests/test_subagent_plugin_wiring.py
+++ b/tests/test_subagent_plugin_wiring.py
@@ -133,9 +133,7 @@ class TestHookHandlers:
         assert ref._lineage_registry is None
         ref._subagent_start(parent_session_id="p", child_session_id="c")  # no raise
 
-    def test_handlers_register_and_unregister_edges(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_handlers_register_and_unregister_edges(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from petasos import LineageRegistry, PetasosConfig
 
         ref = _import_reference_plugin()


### PR DESCRIPTION
## Summary
- Closes the session-intelligence gap for Hermes delegation trees (PET-107, brief **A+C**): a `delegate_task` child gets a fresh `session_id`, so a session escalating toward tier 2/3 could launder its frequency state through a clean child, and a parent's tier-3 termination never reached its children.
- **A — lineage-linked escalation:** a child's tier becomes `max(own, parent-chain)` read live; a terminated ancestor forces tier 3 on the child's next guarded call. **C — delegation fan-out gate:** an escalation-tied budget on `delegate_task` spawns so a high-frequency session cannot spray sub-agents.
- All hook-based (no Hermes fork), thread-safe under concurrent children, behind config toggles (default on per PET-78). **A and C are independently shippable** — C needs only `pre_tool_call`; A is gated on host `subagent_start`/`subagent_stop` hooks and degrades cleanly to C if they are unavailable.

## Layered defense
1. **Tier ordering** (`escalation.py`): `_TIER_RANK` + `max_tier(*tiers)` — single ordering source; raises `ValueError` on an unknown tier (no fail-open in a security max).
2. **LineageRegistry** (`session/lineage.py`, new): thread-safe `child→parent` edge store — bounded snapshot chain walk, cycle guard, edge TTL/cap, last-writer-wins re-parent, `is_pinned`. Pure store — **never calls `FrequencyTracker`** (load-bearing for the lock discipline; lock order is always tracker→registry, no cycle).
3. **Concurrency + bounded pinning** (`frequency.py`): an `RLock` guards all mutable state; eviction skips pinned sessions (bounded deque re-append, no spin) under a hard `2×max_sessions` ceiling; all four tombstone paths fire `on_terminate` so a terminated child immediately unpins its parent.
4. **Lineage tier + fan-out gate** (`guard.py`): `_derive_tier` → `max(own, parent-chain)`, fail-**secure** to tier3; a `SpawnBudget` enforces the fan-out budget at **Step 3.5** (before the exempt check, so a delegate is never exempt); construction rejects a delegate name appearing in the profile exempt list.
5. **Config + Console** (`config.py`, `console/_config_meta.py`): new toggle/budget/lineage fields with validation + Console metadata; `delegate_tool_names` stored raw, list→tuple coerced so a `to_dict`/`from_dict` round-trip preserves the tuple.
6. **Reference wiring** (`reference_plugin/`, `plugin.yaml`, `hermes-desktop.md`): one `LineageRegistry` constructed before the tracker; `is_pinned`/`on_terminate`/`lineage=registry` wired; `subagent_start`/`subagent_stop` registered defensively (degrade to C on partial/absent availability) and declared in the manifest + deployment doc.

## Files changed

| File | Change |
|------|--------|
| `petasos/session/lineage.py` | New — `LineageRegistry` edge store |
| `petasos/session/escalation.py` | Adds `_TIER_RANK` + `max_tier` |
| `petasos/session/frequency.py` | `RLock`, bounded pinning, `on_terminate` |
| `petasos/session/guard.py` | Lineage tier-max + `SpawnBudget` Step 3.5 gate |
| `petasos/config.py` | New toggle/budget/lineage fields + validation |
| `petasos/console/_config_meta.py` | Console metadata for the 8 new fields |
| `petasos/{__init__,session/__init__}.py` | Export `LineageRegistry` / `max_tier` |
| `docs/deployment/reference_plugin/__init__.py` | Wire registry + subagent hooks |
| `docs/deployment/reference_plugin/plugin.yaml` | Declare `subagent_start`/`subagent_stop` |
| `docs/deployment/hermes-desktop.md` | Document sub-agent session semantics + hooks |
| `tests/test_lineage.py`, `tests/test_subagent_plugin_wiring.py` | New test suites |
| `tests/test_{guard,frequency,config}.py` | Lineage / fan-out / pinning / round-trip tests |

## Test plan
- [x] `python -m pytest tests/test_lineage.py tests/test_guard.py tests/test_frequency.py -v` — 120/120 pass (full output: `docs/specs/TODO/PET-107.test-output.txt`)
- [x] `python -m pytest` — **1315 passed**, 36 skipped, 1 xfailed. The one failure (`test_console_validation.py::test_default_ignorable_rejected`) is **pre-existing on master** (verified): a Unicode-14 sweep the local CPython 3.10.6 / Unicode 13.0.0 interpreter cannot satisfy; the repo targets Python 3.11+ (Unicode 14). With it deselected the suite is green (exit 0). Untouched by this change.
- [x] `ruff check .` — clean
- [x] `mypy --strict .` — clean (106 files)
- [ ] Post-merge: wiki `decisions/` A+C entry + `projects/petasos/architecture.md` sub-agent semantics & `evaluate(..., session_id)` signature fix (deferred per ship-spec; needs merge SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PET-107 sub-agent lineage support using `subagent_start` / `subagent_stop` hooks, enabling tier inheritance across linked sessions.
  * Added delegation fan-out throttling for `delegate_task` with a rolling-window budget.
  * Introduced new configuration options for lineage limits and delegation fan-out caps.
* **Bug Fixes**
  * Improved thread-safe frequency tracking and eviction behavior when lineage pinning is active.
* **Documentation**
  * Updated PET-107 Hermes desktop deployment docs, including graceful fallback when sub-agent hooks are unavailable.
* **Tests**
  * Expanded lineage, throttling, hook-wiring, and concurrency test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->