### PR TITLE
fix(pet-99): scan playground visibility + cross-tab never-throw hardening

### DIFF
--- a/docs/specs/TODO/PET-99.test-output.txt
+++ b/docs/specs/TODO/PET-99.test-output.txt
@@ -1,0 +1,34 @@
+PET-99 — full pre-merge gate
+Captured: 2026-06-14T05:18:08Z · python Python 3.10.6 · node v25.6.1
+Note: tests/test_console_validation.py::test_default_ignorable_rejected is deselected — pre-existing
+local-env failure (interpreter ships Unicode 13.0 vs the test's Unicode 14.0 corpus); unrelated to PET-99.
+
+==================== python -m pytest (--deselect Unicode-13 case) ====================
+........................................................................ [ 98%]
+....................                                                     [100%]
+============================== warnings summary ===============================
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+1279 passed, 36 skipped, 1 deselected, 1 xfailed, 52 warnings in 21.53s
+
+==================== node --test tests/js/*.test.mjs ====================
+✔ existing statuses keep their established pill colors (0.2404ms)
+ℹ tests 34
+ℹ suites 0
+ℹ pass 34
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 68.4255
+
+==================== ruff check . ====================
+All checks passed!
+
+==================== ruff format --check . ====================
+104 files already formatted
+
+==================== mypy --strict . ====================
+Success: no issues found in 104 source files

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -220,7 +220,14 @@ async def run_scan(request: Request) -> Any:
     except SessionIdError as exc:
         err = {"field": "session_id", "message": str(exc)}
         return JSONResponse(status_code=422, content={"detail": [err]})
-    return await h.run_scan(text, direction=direction, session_id=session_id)
+    try:
+        return await h.run_scan(text, direction=direction, session_id=session_id)
+    except Exception as exc:  # PET-99 D8: defense-in-depth; pipeline.inspect never throws
+        logger.exception("console scan failed")
+        return JSONResponse(
+            status_code=500,
+            content={"detail": [{"field": "scan", "message": str(exc)}]},
+        )
 
 
 @router.get("/health")

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -333,7 +333,14 @@ def build_app(pipeline: "Pipeline") -> "FastAPI":
         except SessionIdError as exc:
             err = {"field": "session_id", "message": str(exc)}
             return JSONResponse(status_code=422, content={"detail": [err]})
-        return await handlers.run_scan(text, direction=direction, session_id=session_id)
+        try:
+            return await handlers.run_scan(text, direction=direction, session_id=session_id)
+        except Exception as exc:  # PET-99 D8: defense-in-depth; pipeline.inspect never throws
+            _logger.exception("console scan failed")
+            return JSONResponse(
+                status_code=500,
+                content={"detail": [{"field": "scan", "message": str(exc)}]},
+            )
 
     @app.get("/api/health")
     async def api_get_health() -> dict[str, Any]:

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -218,8 +218,12 @@
 .pet .finding .rail { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
 .pet .finding .body { flex: 1; min-width: 0; }
 .pet .finding .rid { font-family: var(--font-mono); font-size: 11.5px; color: var(--tx-bright); font-weight: 600; }
-.pet .finding .msg { font-size: 12px; color: var(--tx-mut); margin-top: 3px; }
-.pet .finding .matched { font-family: var(--font-mono); font-size: 11px; background: var(--bg-input); color: var(--high); padding: 1px 5px; border-radius: 3px; }
+.pet .finding .msg { font-size: 12px; color: var(--tx-mut); margin-top: 3px; overflow-wrap: anywhere; }
+/* PET-99 D4: long unbroken matched_text must wrap inside the overflow:hidden
+   finding card rather than overflowing into invisibility. .matched is an inline
+   span with no width box, so it also needs display:inline-block + max-width:100%
+   to give overflow-wrap a box to wrap within. */
+.pet .finding .matched { font-family: var(--font-mono); font-size: 11px; background: var(--bg-input); color: var(--high); padding: 1px 5px; border-radius: 3px; overflow-wrap: anywhere; display: inline-block; max-width: 100%; }
 .pet .conf-bar { height: 4px; border-radius: 2px; background: var(--bg-input); overflow: hidden; }
 .pet .conf-bar i { display: block; height: 100%; border-radius: 2px; }
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -239,7 +239,6 @@
     auditLog: [],
     scannerHealth: [],
     pipelineHealth: null,
-    lastScanResult: null,
     profiles: [],
     about: null,
   };
@@ -361,7 +360,10 @@
     _dispatch: function (evType, dataStr) {
       try { var d = JSON.parse(dataStr); } catch (_) { return; }
       if (evType === "scan_result") {
-        Pet.state.scanHistory.unshift(d);
+        // PET-99 D6: a malformed frame (JSON.parse("null"), a number, an array)
+        // must never enter the render buffer — scanHistoryRows/renderDashboard
+        // guard on read, but keeping the buffer object-only is the cheaper floor.
+        if (d && typeof d === "object") Pet.state.scanHistory.unshift(d);
         if (Pet.state.scanHistory.length > 500) Pet.state.scanHistory.length = 500;
         if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
       } else if (evType === "audit") {
@@ -545,6 +547,34 @@
     return table;
   };
 
+  // PET-99 D6/D9: the scan-history seed-merge, extracted as a pure seam so a
+  // malformed entry can never throw on render. Mirrors the existing
+  // `if (!e || typeof e !== "object") continue` guards in renderDashboard
+  // (js tile loop) and scanHistoryRows — closing the one buffer-consuming path
+  // that lacked them (the old inline seed-merge dereferenced `.scan_id` on every
+  // buffer entry AND every fetched entry with no shape guard). Skips non-object
+  // entries on BOTH the existing buffer and the fetched entries before reading
+  // `.scan_id`. Behavior-preserving vs the old inline loops: dedups by scan_id,
+  // appends unseen (a bare {} with scan_id===undefined is an object, unseen on
+  // first occurrence, so it survives — exactly the prior behavior). Mutates
+  // `buffer` in place and returns it (the `return` is for test ergonomics).
+  // Intentionally does NOT clamp to the SSE path's 500-entry cap — the request
+  // limit bounds the fetched set and the next SSE frame re-clamps (out of scope).
+  Pet.mergeScanHistory = function (buffer, entries) {
+    var seen = new Set();
+    for (var j = 0; j < buffer.length; j++) {
+      var cur = buffer[j];
+      if (cur && typeof cur === "object") seen.add(cur.scan_id);
+    }
+    for (var k = 0; k < entries.length; k++) {
+      var en = entries[k];
+      if (en && typeof en === "object" && !seen.has(en.scan_id)) {
+        buffer.push(en); seen.add(en.scan_id);
+      }
+    }
+    return buffer;
+  };
+
   Pet.renderDashboard = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "12px", height: "100%" } });
@@ -636,16 +666,171 @@
         // _req never rejects on HTTP error (it resolves an error envelope), and a
         // 200 {} body lacking .entries would make the merge throw on .scan_id.
         if (!d.error && d.entries && Array.isArray(d.entries)) {
-          var seen = new Set();
-          for (var j = 0; j < Pet.state.scanHistory.length; j++) seen.add(Pet.state.scanHistory[j].scan_id);
-          for (var k = 0; k < d.entries.length; k++) {
-            var en = d.entries[k];
-            if (!seen.has(en.scan_id)) { Pet.state.scanHistory.push(en); seen.add(en.scan_id); }
-          }
+          // PET-99 D6/D9: shape-guarded seed-merge (skips non-object entries on
+          // both sides before reading .scan_id) — replaces the inline dedup loops.
+          Pet.mergeScanHistory(Pet.state.scanHistory, d.entries);
           if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
         }
       });
     }
+  };
+
+  // ── Playground result/error builders (PET-99 D9 testability seam) ──
+  // Extracted from the former inline scan-button onClick closure so the console
+  // JS harness (node:vm + DOM shim) can assert them as pure builder calls.
+
+  // D2: the result region scrolls within its definite-height flex bound; it does
+  // not clip-to-invisible. flex:1 + minHeight:0 + overflowY:auto.
+  Pet.makeResultArea = function () {
+    return Pet.h("div", { style: { flex: "1", minHeight: "0", overflowY: "auto" } });
+  };
+
+  // D3: one legibility contract for every failure shape. The message is a real,
+  // selectable text node (present in textContent), not title-only; pre-wrap +
+  // overflow-wrap keep it readable, a bounded maxHeight + scroll keep it reachable.
+  Pet.scanErrorBlock = function (message) {
+    return Pet.h("div", { style: {
+      color: "var(--crit)", padding: "12px",
+      whiteSpace: "pre-wrap", overflowWrap: "anywhere",
+      maxHeight: "240px", overflowY: "auto",
+    } }, String(message == null ? "" : message));
+  };
+
+  // D5: shared button-restore for both promise arms (success + failure).
+  Pet.restoreScanButton = function (scanBtn) {
+    scanBtn.textContent = "";
+    scanBtn.appendChild(Pet.Icon("bolt"));
+    scanBtn.appendChild(document.createTextNode(" Scan"));
+  };
+
+  // The success render (verdict + findings + normalization diff + anonymized
+  // output + session overlay), lifted from the former onClick closure. Reads
+  // d.result shape-defensively (D5) so a malformed body returns a readable error
+  // block instead of throwing into runPlaygroundScan's .catch (which would
+  // discard the whole result for a generic message). Side-effect-free.
+  Pet.renderScanResult = function (d, rawText) {
+    var r = d && d.result;
+    if (!r || typeof r !== "object" || typeof r.safe !== "boolean" || !Array.isArray(r.findings)) {
+      return Pet.scanErrorBlock("Unexpected response shape from /scan");
+    }
+    var findings = Array.isArray(r.findings) ? r.findings : [];
+    var isSafe = (r.safe === true); // explicit, mirroring scanHistoryRows' ===false discipline
+
+    var frag = document.createDocumentFragment();
+
+    // Verdict
+    var verdict = isSafe
+      ? Pet.h("span", { className: "pill ok", style: { height: "18px", fontSize: "10px" } }, "safe")
+      : Pet.h("span", { className: "pill err", style: { height: "18px", fontSize: "10px" } }, "blocked");
+
+    var summary = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "10px", marginBottom: "12px" } },
+      verdict,
+      Pet.h("span", { style: { fontSize: "12px", color: "var(--tx-mut)" } }, findings.length + " findings")
+    );
+    frag.appendChild(summary);
+
+    // Findings
+    if (findings.length > 0) {
+      var findingsPanel = Pet.Panel({
+        icon: "radar", title: "findings", place: "detections by scanner",
+        help: Pet.HelpTip("<b>Findings</b> — individual detections from each scanner. Severity ranges from <code>INFO</code> to <code>CRITICAL</code>. High+ on dangerous tools triggers a block."),
+        content: Pet.h("div", { className: "vlist", style: { gap: "8px" } },
+          findings.map(function (f) {
+            var v = SEV[f.severity] || SEV.info;
+            var finding = Pet.h("div", { className: "finding" });
+            var rail = Pet.h("div", { className: "rail", style: { background: v.col } });
+            var body = Pet.h("div", { className: "body" },
+              Pet.h("div", { style: { display: "flex", gap: "8px", alignItems: "center" } },
+                Pet.h("span", { className: "rid" }, f.rule_id),
+                Pet.h("span", { className: "mono", style: { marginLeft: "auto", fontSize: "10px", color: "var(--tx-faint)" } }, f.scanner_name || "")
+              ),
+              Pet.h("div", { className: "msg" }, f.message || ""),
+              // D4: full matched_text on title as a hover affordance; the CSS wrap
+              // rules keep the visible badge text from clipping to invisibility.
+              f.matched_text ? Pet.h("span", { className: "matched", title: f.matched_text }, f.matched_text) : null
+            );
+            finding.appendChild(rail);
+            finding.appendChild(Pet.SevBadge(f.severity));
+            finding.appendChild(body);
+            return finding;
+          })
+        ),
+      });
+      frag.appendChild(findingsPanel);
+    }
+
+    // Normalized diff
+    if (d.normalized_text && d.normalized_text !== rawText) {
+      frag.appendChild(Pet.Panel({
+        icon: "trending", title: "normalization", place: "before → after",
+        content: Pet.h("div", { className: "mono", style: { fontSize: "11.5px", lineHeight: "1.7" } },
+          Pet.h("div", { style: { color: "var(--tx-ghost)" } }, "raw: ", Pet.h("span", { style: { color: "var(--tx-mut)" } }, rawText)),
+          Pet.h("div", { style: { color: "var(--tx-ghost)" } }, "norm: ", Pet.h("span", { style: { color: "var(--tx)" } }, d.normalized_text))
+        ),
+      }));
+    }
+
+    // Anonymized output
+    if (r.sanitized_content) {
+      frag.appendChild(Pet.Panel({
+        icon: "shieldCheck", title: "anonymized output", place: "PII redacted",
+        content: Pet.h("div", { className: "mono", style: { fontSize: "12px", color: "var(--tx-mut)", lineHeight: "1.7" } }, r.sanitized_content),
+      }));
+    }
+
+    // Session overlay
+    if (r.session_score != null || r.escalation_tier) {
+      var stats = Pet.h("div", { style: { display: "flex", gap: "10px" } });
+      if (r.session_score != null) {
+        // Numeric coercion (mirrors scanHistoryRows' Number(...) discipline): a
+        // present-but-non-numeric session_score degrades this one tile, never the
+        // whole result and never the UI.
+        var ss = Number(r.session_score);
+        if (ss === ss) { // not NaN
+          stats.appendChild(Pet.h("div", { style: { flex: "1", background: "var(--bg-raised)", border: "1px solid var(--border)", borderRadius: "var(--r-card)", padding: "7px 11px" } },
+            Pet.h("div", { className: "eyebrow" }, "session_score"),
+            Pet.h("div", { className: "num", style: { fontSize: "18px", fontWeight: "700", color: "var(--amber-bright)" } }, ss.toFixed(3))
+          ));
+        }
+      }
+      if (r.escalation_tier) {
+        stats.appendChild(Pet.h("div", { style: { flex: "1", background: "var(--bg-raised)", border: "1px solid var(--border)", borderRadius: "var(--r-card)", padding: "7px 11px" } },
+          Pet.h("div", { className: "eyebrow" }, "escalation_tier"),
+          Pet.h("div", { className: "num", style: { fontSize: "18px", fontWeight: "700", color: "var(--crit)" } }, r.escalation_tier)
+        ));
+      }
+      frag.appendChild(Pet.Panel({ icon: "user", title: "session overlay", place: "frequency + escalation", help: Pet.HelpTip("<b>Session Overlay</b> — cumulative session risk score and escalation tier. Score rises with repeated violations; tier thresholds trigger progressively stricter enforcement."), content: stats }));
+    }
+
+    return frag;
+  };
+
+  // D5: the extracted submit handler. Restores the button on EVERY path and
+  // routes both the {error|detail} response branch and the rejection branch
+  // through scanErrorBlock — no path leaves the UI stranded on "Scanning...".
+  // `api` is injected (defaults to Pet.api) so a test can pass a stub; the
+  // returned promise lets the test await completion.
+  Pet.runPlaygroundScan = function (opts) {
+    var scanBtn = opts.scanBtn;
+    var resultArea = opts.resultArea;
+    scanBtn.textContent = "Scanning...";
+    return (opts.api || Pet.api).postScan(opts.text, opts.dir, opts.sid)
+      .then(function (d) {
+        Pet.restoreScanButton(scanBtn);
+        resultArea.innerHTML = "";
+        if (d && (d.error || d.detail)) {
+          var msg = d.error;
+          if (msg == null) { try { msg = JSON.stringify(d.detail); } catch (_) { msg = String(d.detail); } }
+          resultArea.appendChild(Pet.scanErrorBlock(msg));
+          return;
+        }
+        resultArea.appendChild(Pet.renderScanResult(d, opts.text)); // shape-defensive
+      })
+      .catch(function (e) { // D5: any throw/rejection still restores + shows readable text
+        Pet.restoreScanButton(scanBtn);
+        resultArea.innerHTML = "";
+        resultArea.appendChild(Pet.scanErrorBlock((e && e.message) || "Scan failed"));
+      });
   };
 
   Pet.renderPlayground = function (container) {
@@ -658,7 +843,7 @@
       placeholder: "Paste text to scan... Try: 'ignore previous instructions' or 'email: test@example.com card: 4111 1111 1111 1234'",
     });
 
-    var resultArea = Pet.h("div", { style: { flex: "1", minHeight: "0" } });
+    var resultArea = Pet.makeResultArea();
 
     var dirBtn = { dir: "inbound" };
     var dirToggle = Pet.h("div", { className: "seg" });
@@ -673,94 +858,14 @@
     var scanBtn = Pet.h("button", { className: "btn btn-primary btn-sm", onClick: function () {
       var text = textArea.value;
       if (!text || !text.trim()) return;
-      scanBtn.textContent = "Scanning...";
-      Pet.api.postScan(text, dirBtn.dir, sessionInput.value || null).then(function (d) {
-        scanBtn.textContent = "";
-        scanBtn.appendChild(Pet.Icon("bolt"));
-        scanBtn.appendChild(document.createTextNode(" Scan"));
-        resultArea.innerHTML = "";
-        if (d.error || d.detail) {
-          resultArea.appendChild(Pet.h("div", { style: { color: "var(--crit)", padding: "12px" } }, d.error || JSON.stringify(d.detail)));
-          return;
-        }
-        Pet.state.lastScanResult = d;
-        var r = d.result;
-
-        // Verdict
-        var verdict = r.safe
-          ? Pet.h("span", { className: "pill ok", style: { height: "18px", fontSize: "10px" } }, "safe")
-          : Pet.h("span", { className: "pill err", style: { height: "18px", fontSize: "10px" } }, "blocked");
-
-        var summary = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "10px", marginBottom: "12px" } },
-          verdict,
-          Pet.h("span", { style: { fontSize: "12px", color: "var(--tx-mut)" } }, r.findings.length + " findings")
-        );
-        resultArea.appendChild(summary);
-
-        // Findings
-        if (r.findings.length > 0) {
-          var findingsPanel = Pet.Panel({
-            icon: "radar", title: "findings", place: "detections by scanner",
-            help: Pet.HelpTip("<b>Findings</b> — individual detections from each scanner. Severity ranges from <code>INFO</code> to <code>CRITICAL</code>. High+ on dangerous tools triggers a block."),
-            content: Pet.h("div", { className: "vlist", style: { gap: "8px" } },
-              r.findings.map(function (f) {
-                var v = SEV[f.severity] || SEV.info;
-                var finding = Pet.h("div", { className: "finding" });
-                var rail = Pet.h("div", { className: "rail", style: { background: v.col } });
-                var body = Pet.h("div", { className: "body" },
-                  Pet.h("div", { style: { display: "flex", gap: "8px", alignItems: "center" } },
-                    Pet.h("span", { className: "rid" }, f.rule_id),
-                    Pet.h("span", { className: "mono", style: { marginLeft: "auto", fontSize: "10px", color: "var(--tx-faint)" } }, f.scanner_name || "")
-                  ),
-                  Pet.h("div", { className: "msg" }, f.message || ""),
-                  f.matched_text ? Pet.h("span", { className: "matched" }, f.matched_text) : null
-                );
-                finding.appendChild(rail);
-                finding.appendChild(Pet.SevBadge(f.severity));
-                finding.appendChild(body);
-                return finding;
-              })
-            ),
-          });
-          resultArea.appendChild(findingsPanel);
-        }
-
-        // Normalized diff
-        if (d.normalized_text && d.normalized_text !== text) {
-          resultArea.appendChild(Pet.Panel({
-            icon: "trending", title: "normalization", place: "before → after",
-            content: Pet.h("div", { className: "mono", style: { fontSize: "11.5px", lineHeight: "1.7" } },
-              Pet.h("div", { style: { color: "var(--tx-ghost)" } }, "raw: ", Pet.h("span", { style: { color: "var(--tx-mut)" } }, text)),
-              Pet.h("div", { style: { color: "var(--tx-ghost)" } }, "norm: ", Pet.h("span", { style: { color: "var(--tx)" } }, d.normalized_text))
-            ),
-          }));
-        }
-
-        // Anonymized output
-        if (r.sanitized_content) {
-          resultArea.appendChild(Pet.Panel({
-            icon: "shieldCheck", title: "anonymized output", place: "PII redacted",
-            content: Pet.h("div", { className: "mono", style: { fontSize: "12px", color: "var(--tx-mut)", lineHeight: "1.7" } }, r.sanitized_content),
-          }));
-        }
-
-        // Session overlay
-        if (r.session_score != null || r.escalation_tier) {
-          var stats = Pet.h("div", { style: { display: "flex", gap: "10px" } });
-          if (r.session_score != null) {
-            stats.appendChild(Pet.h("div", { style: { flex: "1", background: "var(--bg-raised)", border: "1px solid var(--border)", borderRadius: "var(--r-card)", padding: "7px 11px" } },
-              Pet.h("div", { className: "eyebrow" }, "session_score"),
-              Pet.h("div", { className: "num", style: { fontSize: "18px", fontWeight: "700", color: "var(--amber-bright)" } }, r.session_score.toFixed(3))
-            ));
-          }
-          if (r.escalation_tier) {
-            stats.appendChild(Pet.h("div", { style: { flex: "1", background: "var(--bg-raised)", border: "1px solid var(--border)", borderRadius: "var(--r-card)", padding: "7px 11px" } },
-              Pet.h("div", { className: "eyebrow" }, "escalation_tier"),
-              Pet.h("div", { className: "num", style: { fontSize: "18px", fontWeight: "700", color: "var(--crit)" } }, r.escalation_tier)
-            ));
-          }
-          resultArea.appendChild(Pet.Panel({ icon: "user", title: "session overlay", place: "frequency + escalation", help: Pet.HelpTip("<b>Session Overlay</b> — cumulative session risk score and escalation tier. Score rises with repeated violations; tier thresholds trigger progressively stricter enforcement."), content: stats }));
-        }
+      // PET-99 D5/D9: thin call into the extracted handler with the live
+      // scanBtn/resultArea; all render + restore + error legibility lives there.
+      Pet.runPlaygroundScan({
+        text: text,
+        dir: dirBtn.dir,
+        sid: sessionInput.value || null,
+        scanBtn: scanBtn,
+        resultArea: resultArea,
       });
     } });
     scanBtn.appendChild(Pet.Icon("bolt"));

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -786,7 +786,7 @@
         // present-but-non-numeric session_score degrades this one tile, never the
         // whole result and never the UI.
         var ss = Number(r.session_score);
-        if (ss === ss) { // not NaN
+        if (!Number.isNaN(ss)) { // present-but-non-numeric score → skip this tile
           stats.appendChild(Pet.h("div", { style: { flex: "1", background: "var(--bg-raised)", border: "1px solid var(--border)", borderRadius: "var(--r-card)", padding: "7px 11px" } },
             Pet.h("div", { className: "eyebrow" }, "session_score"),
             Pet.h("div", { className: "num", style: { fontSize: "18px", fontWeight: "700", color: "var(--amber-bright)" } }, ss.toFixed(3))

--- a/tests/js/playground.test.mjs
+++ b/tests/js/playground.test.mjs
@@ -1,0 +1,289 @@
+// Unit tests for the Scan Playground builders in petasos/console/static/petasos.js.
+//
+// Regression for PET-99:
+//   D2  result region scrolls (overflowY:auto + minHeight:0) — never clip-to-hidden.
+//   D3  error/detail text is fully legible: pre-wrap + overflow-wrap + bounded
+//       scroll, and the full message is a real selectable text node.
+//   D4  long matched_text is not lost — present in the DOM + on `title`.
+//   D5  a failed scan restores the Scan button and shows a readable error on
+//       BOTH the {error|detail} branch and a rejected promise — never stranded
+//       on "Scanning...".
+//   D6  a playground scan must not corrupt the Observability tab: the
+//       render-consumed scan-history path (Pet.scanHistoryRows) and the
+//       seed-merge path (Pet.mergeScanHistory) skip malformed entries instead
+//       of throwing on the next render — the concrete cross-tab crash found in
+//       spec review (an unguarded `.scan_id` deref) is pinned here.
+//
+// Zero npm dependencies: Node's built-in test runner + assert, an extended DOM
+// shim (a superset of scanner-health.test.mjs's), and node:vm to evaluate the
+// real shipped petasos.js. Run with:
+//   node --test tests/js/playground.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Extended DOM shim (PET-99) ──────────────────────────────────────────────
+// Superset of the scanner-health shim. Differences (see spec Test plan):
+//   * textContent SETTER is real-DOM-faithful (clears childNodes, appends one
+//     text node for a non-empty value) — NOT the scanner-health throwing setter,
+//     because the playground legitimately assigns `scanBtn.textContent =
+//     "Scanning..."`. The aggregating getter is kept so text appended via Pet.h
+//     children reads back.
+//   * innerHTML setter clears childNodes (the `resultArea.innerHTML = ""` clear
+//     idiom — real-DOM semantics, so children don't accumulate across calls).
+//   * no-op addEventListener / setAttribute (Pet.HelpTip / Pet.svg touch them).
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    addEventListener(_type, _fn) {},
+    setAttribute(_k, _v) {},
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      // Real-DOM semantics: clear children; for a non-empty value, append one
+      // text node. (Empty string clears to no children.)
+      this.childNodes = [];
+      const s = v == null ? "" : String(v);
+      if (s !== "") {
+        const n = makeNode(3);
+        n.nodeValue = s;
+        this.childNodes.push(n);
+      }
+    },
+    set innerHTML(_v) {
+      // Only `... = ""` is used in production; model the clear, ignore the value.
+      this.childNodes = [];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase(); // mirrors real DOM (uppercase for HTML)
+    el.localName = tag;
+    return el;
+  },
+  createElementNS(_ns, tag) {
+    return this.createElement(tag); // Pet.svg path
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ──────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+// Depth-first search for the first element node matching `pred`.
+function findEl(node, pred) {
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (pred(child)) return child;
+      const found = findEl(child, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+const isErrorBlock = (el) => el.style && el.style.whiteSpace === "pre-wrap";
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+// Guards that the export ran and the extracted seam is present.
+test("loader: petasos.js exports the playground builders + mergeScanHistory", () => {
+  assert.equal(typeof Pet, "object");
+  for (const fn of [
+    "makeResultArea",
+    "scanErrorBlock",
+    "restoreScanButton",
+    "renderScanResult",
+    "runPlaygroundScan",
+    "mergeScanHistory",
+  ]) {
+    assert.equal(typeof Pet[fn], "function", `Pet.${fn} missing`);
+  }
+});
+
+// D2 — the result region scrolls within its flex bound; it does not clip.
+test("test_result_area_scrolls_not_clips", () => {
+  const ra = Pet.makeResultArea();
+  assert.equal(ra.style.overflowY, "auto");
+  assert.equal(ra.style.minHeight, "0");
+  assert.equal(ra.style.flex, "1"); // the definite-height chain depends on this
+});
+
+// D3 — a multi-kilobyte, multi-line error is rendered in full as a real text
+// node with the legibility style contract. The fixture is compared by variable
+// (never a re-typed literal) to dodge CRLF/control-char round-trip false-fails.
+test("test_long_error_fully_rendered", () => {
+  const fixture =
+    "SCAN FAILED\n\t" +
+    "x".repeat(5000) +
+    "\nNESTED\tTAB line\n" +
+    "y".repeat(3000) +
+    "\n— end —";
+  const el = Pet.scanErrorBlock(fixture);
+  assert.equal(el.textContent, fixture); // full, selectable, byte-for-byte
+  assert.equal(el.style.whiteSpace, "pre-wrap");
+  assert.equal(el.style.overflowWrap, "anywhere");
+  assert.ok(el.style.maxHeight, "expected a bounded maxHeight");
+  assert.equal(el.style.overflowY, "auto");
+});
+
+// D4 — a long matched_text survives into the DOM and onto `title`; it is never
+// dropped. (CSS wrap is not measurable in the shim; the JS guard is presence.)
+test("test_long_matched_text_not_lost", () => {
+  const big = "M".repeat(4000) + "—" + "atched".repeat(50);
+  const d = {
+    result: {
+      safe: false,
+      findings: [
+        {
+          rule_id: "PROMPT_INJECTION",
+          severity: "high",
+          scanner_name: "minimal",
+          message: "possible instruction override",
+          matched_text: big,
+        },
+      ],
+    },
+  };
+  const tree = Pet.renderScanResult(d, "x");
+  assert.ok(tree.textContent.includes(big), "matched_text absent from rendered DOM");
+  const matched = findEl(tree, (el) => el.className === "matched");
+  assert.ok(matched, ".matched span not found");
+  assert.equal(matched.title, big, ".matched title not set to full matched_text");
+});
+
+// D5 — both failure shapes restore the button and render a scanErrorBlock; the
+// UI is never stranded on "Scanning...". Same nodes across both calls (the
+// innerHTML="" clear means no special handling is needed).
+test("test_failed_scan_restores_button", async () => {
+  const scanBtn = document.createElement("button");
+  const resultArea = document.createElement("div");
+
+  // (a) rejected promise → the .catch arm
+  await Pet.runPlaygroundScan({
+    text: "hi",
+    dir: "inbound",
+    sid: null,
+    scanBtn,
+    resultArea,
+    api: { postScan: () => Promise.reject(new Error("network down")) },
+  });
+  assert.equal(scanBtn.textContent, " Scan", "button not restored after rejection");
+  let err = findEl(resultArea, isErrorBlock);
+  assert.ok(err, "no scanErrorBlock rendered for rejection");
+  assert.ok(err.textContent.includes("network down"), "rejection message not shown");
+
+  // (b) resolved {error: ...} envelope → the .then {error|detail} branch
+  await Pet.runPlaygroundScan({
+    text: "hi",
+    dir: "inbound",
+    sid: null,
+    scanBtn,
+    resultArea,
+    api: { postScan: () => Promise.resolve({ error: "boom from server" }) },
+  });
+  assert.equal(scanBtn.textContent, " Scan", "button not restored after error envelope");
+  err = findEl(resultArea, isErrorBlock);
+  assert.ok(err, "no scanErrorBlock rendered for error envelope");
+  assert.ok(err.textContent.includes("boom from server"), "error envelope text not shown");
+});
+
+// D6 (render side) — the obs-render path a tab-switch triggers must not throw on
+// a poisoned scan-history buffer. Pet.scanHistoryRows already guards non-objects;
+// this pins that it stays guarded.
+test("test_scan_then_switch_tab_no_throw", () => {
+  const hist = [
+    null,
+    5,
+    {},
+    { safe: false, duration_ms: "x" }, // present-but-non-numeric latency
+    {
+      scan_id: "a",
+      safe: true,
+      finding_count: 2,
+      duration_ms: 1.5,
+      direction: "inbound",
+      timestamp: 0,
+    },
+  ];
+  assert.doesNotThrow(() => Pet.scanHistoryRows(hist));
+});
+
+// D6 (seed-merge side) — the real, non-tautological guard. The pre-fix inline
+// loops dereferenced `.scan_id` on every buffer + fetched entry; a malformed
+// entry threw on the next render. mergeScanHistory must skip non-objects on both
+// sides AND preserve the prior dedup/append behavior exactly.
+test("test_seed_merge_skips_malformed", () => {
+  // Buffer already holds malformed entries (null, 5) + one real scan; the fetched
+  // set repeats null/7, a bare {}, the already-seen "a", and a fresh "b".
+  const buffer = [null, 5, { scan_id: "a" }];
+  const result = Pet.mergeScanHistory(buffer, [
+    null,
+    7,
+    {},
+    { scan_id: "a" },
+    { scan_id: "b" },
+  ]);
+
+  assert.equal(result, buffer, "should mutate + return the same buffer by reference");
+  // null/5 stay physically in the buffer (skipped only during seen-building);
+  // {} (scan_id undefined, unseen) and {scan_id:"b"} append; {scan_id:"a"} dedups.
+  assert.equal(result.length, 5);
+  const ids = result
+    .filter((e) => e && typeof e === "object")
+    .map((e) => e.scan_id);
+  assert.deepEqual(ids, ["a", undefined, "b"]); // a (kept), {} survives, b appended
+  assert.equal(ids.filter((x) => x === "a").length, 1, "scan_id 'a' not deduped");
+
+  // Two scan_id-less objects: the first adds `undefined` to seen, deduping the
+  // second — exactly one {} survives (pins the existing-buffer + fetched derefs).
+  const r2 = Pet.mergeScanHistory([], [{}, {}]);
+  assert.equal(r2.length, 1);
+});
+
+// Defensiveness (correctness/edge-cases F-10) — a malformed /scan body returns a
+// readable scanErrorBlock instead of throwing into runPlaygroundScan's .catch.
+test("test_render_scan_result_malformed", () => {
+  for (const bad of [{}, { result: {} }]) {
+    let node;
+    assert.doesNotThrow(() => {
+      node = Pet.renderScanResult(bad, "x");
+    });
+    assert.ok(isErrorBlock(node), "expected a scanErrorBlock for malformed shape");
+    assert.ok(
+      node.textContent.includes("Unexpected response shape"),
+      "expected the shape-error message"
+    );
+  }
+});

--- a/tests/test_console_playground.py
+++ b/tests/test_console_playground.py
@@ -1,0 +1,111 @@
+"""Tests for the console scan routes' error-envelope hardening (PET-99 D8).
+
+The console scan endpoints (standalone ``/api/scan`` and the Hermes plugin
+``/scan``) share ``ConsoleHandlers.run_scan``. Both routes wrap that call in a
+try/except that returns a structured ``{"detail": [{field, message}]}`` 500
+envelope instead of a bare unhandled 500, so the frontend always receives
+readable text (the D3/D5 legibility contract) regardless of where a failure
+originates. ``Pipeline.inspect`` is contractually never-throwing; this envelope
+is defense-in-depth at the HTTP boundary for any non-pipeline failure
+(serialization, broadcast, future code).
+
+Mirrors ``tests/test_console_validation.py`` — same params-based ``client``
+fixture so each assertion runs once per route flavor (the route-parity test) —
+but builds the TestClient with ``raise_server_exceptions=False`` so a *regressed*
+(un-enveloped) handler exception surfaces as an observable 500 response the
+assertions can fail cleanly against, rather than being re-raised into the test.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+_SCAN_TEXT = "hello world this is a test"
+
+
+def _make_pipeline() -> Pipeline:
+    return Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded"),
+    )
+
+
+@pytest.fixture(params=["standalone", "plugin"])
+def client(request: pytest.FixtureRequest) -> Iterator[tuple[TestClient, str]]:
+    """Yield (test_client, scan_path) for each console route flavor.
+
+    Carries its own copy of the plugin-handler reset (pattern from
+    tests/test_plugin_api_sse.py — fixtures are not importable across modules).
+    ``raise_server_exceptions=False`` is a deliberate departure from
+    test_console_validation.py: it keeps an unhandled 500 observable instead of
+    re-raised, so a regression that drops the D8 envelope fails the assertion
+    cleanly rather than erroring the test.
+    """
+    import petasos.console.hermes.plugin_api as plugin_mod
+
+    plugin_mod._handlers = None
+    if request.param == "standalone":
+        from petasos.console.server import build_app
+
+        tc = TestClient(build_app(_make_pipeline()), raise_server_exceptions=False)
+        yield tc, "/api/scan"
+    else:
+        from petasos.console.hermes.plugin_api import init_handlers, router
+
+        init_handlers(_make_pipeline())
+        app = FastAPI()
+        app.include_router(router)
+        tc = TestClient(app, raise_server_exceptions=False)
+        yield tc, "/scan"
+    plugin_mod._handlers = None
+
+
+def test_valid_scan_returns_200(client: tuple[TestClient, str]) -> None:
+    """Sanity anchor: the un-monkeypatched route returns a well-formed 200, so
+    the error-shape test below is witnessing the except branch, not a broken
+    fixture."""
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT})
+    assert resp.status_code == 200
+    assert "result" in resp.json()
+
+
+def test_scan_error_payload_shape(
+    client: tuple[TestClient, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for PET-99 D8: a handler-level exception yields a *structured*
+    500 (``{"detail": [{field, message}]}``), never a bare/unstructured 500.
+
+    Monkeypatches the shared ``ConsoleHandlers.run_scan`` (the call both routes
+    wrap) to raise; both route flavors must convert it to the readable envelope
+    so the playground's scanErrorBlock always has selectable text to render.
+    """
+    from petasos.console.server import ConsoleHandlers
+
+    async def _boom(self: object, *args: object, **kwargs: object) -> dict[str, object]:
+        raise RuntimeError("synthetic scan failure")
+
+    monkeypatch.setattr(ConsoleHandlers, "run_scan", _boom)
+
+    tc, path = client
+    resp = tc.post(path, json={"text": _SCAN_TEXT})
+
+    assert resp.status_code == 500
+    body = resp.json()
+    detail = body.get("detail")
+    assert isinstance(detail, list) and detail, f"expected non-empty detail list, got {body!r}"
+    first = detail[0]
+    assert isinstance(first, dict)
+    assert first.get("field") == "scan"
+    # str(exc) is surfaced verbatim (internal operator console) — the readable
+    # text the operator needs is present, not swallowed into a generic 500.
+    assert "synthetic scan failure" in first.get("message", "")


### PR DESCRIPTION
## Summary
- **Visibility:** the Scan Playground result region now scrolls (`overflowY:auto`), errors/`detail` render through one `Pet.scanErrorBlock` contract (`pre-wrap` + `overflow-wrap` + bounded scroll, full *selectable* text), and `.msg`/`.matched` wrap so a long `matched_text`/`message` never clips to invisibility.
- **Never-stranded fetch:** the submit path gains a `.catch`; both the `{error|detail}` branch and any rejection route through `scanErrorBlock`, and the Scan button is restored on every path — no stuck "Scanning…".
- **Cross-tab never-throw (D6):** the SSE `_dispatch` unshift and the scan-history seed-merge (new `Pet.mergeScanHistory` seam) skip non-object entries before reading `.scan_id`, closing the concrete crash found in spec review. Backend scan routes wrap `run_scan` in a structured `{detail:[…]}` 500 envelope.

## Root cause (D6)
The pre-fix Observability seed-merge (`petasos.js:638–646`) dereferenced `.scan_id` on every existing-buffer **and** fetched entry with no shape guard, and `_dispatch` unshifted any decoded SSE frame into that buffer unchecked. A single malformed entry (`JSON.parse("null")`, a number, an array) makes the next Observability render throw `TypeError: Cannot read properties of null (reading 'scan_id')` — the "scan then switch breaks" symptom. Demonstrated via a `node:vm` repro (pre-fix throws; post-fix `mergeScanHistory` survives). The operator's *specific* report is not reproducible from first-party code (the backend always broadcasts a well-formed summary), so per the spec D6 gate this is the **frontend-cause / standing-guard** branch; the dead write-only `Pet.state.lastScanResult` lead was ruled out and removed. Full note in `docs/briefs/PET-99-scanner-playground-robustness.md`.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Extracts `Pet.makeResultArea` / `scanErrorBlock` / `restoreScanButton` / `renderScanResult` / `runPlaygroundScan` / `mergeScanHistory` (D9 seam); D2–D5 fixes; SSE + seed-merge shape guards (D6); removes dead `lastScanResult` write |
| `petasos/console/static/petasos.css` | `.msg` / `.matched` gain `overflow-wrap:anywhere`; `.matched` gets `display:inline-block; max-width:100%` (D4) |
| `petasos/console/server.py` | `/api/scan` wraps `run_scan` in a structured 500 envelope via `_logger` (D8) |
| `petasos/console/hermes/plugin_api.py` | Plugin `/scan` parity envelope via `logger` (D8) |
| `tests/js/playground.test.mjs` | New — 8 builder/seam regression tests (extended DOM shim) |
| `tests/test_console_playground.py` | New — route error-shape parity (`raise_server_exceptions=False`) |

## Test plan
- [x] `python -m pytest` — 1279 passed, 36 skipped, 1 xfailed (full output: `docs/specs/TODO/PET-99.test-output.txt`)
- [x] `node --test tests/js/*.test.mjs` — 34/34 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --strict .` — clean (104 files)

> One pre-existing local-env case is deselected: `test_console_validation.py::test_default_ignorable_rejected` (interpreter ships Unicode 13.0 vs the test's Unicode 14.0 corpus) — unrelated to PET-99; CI runs the full set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error handling to scan endpoints to return proper error responses with descriptive messages when scans fail
  * Fixed text wrapping for long matched text in finding cards to prevent content overflow

* **Tests**
  * Added comprehensive test coverage for scan endpoints and playground scanning functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->