### PR TITLE
fix(pet-109): scope Presidio PII detection + cross-scanner suppression/downgrade

### DIFF
--- a/.github/workflows/extras-presidio.yml
+++ b/.github/workflows/extras-presidio.yml
@@ -1,0 +1,33 @@
+# PET-109: non-skipping lane with the real presidio extra + spaCy model installed,
+# so the tightened-default detection set (D2) is proven not to blind the scanner —
+# the benign-technical-corpus regression and the real-PII-still-detected test (D4)
+# run on the shipping PR instead of silently self-skipping. PETASOS_REQUIRE_PRESIDIO=1
+# arms the collection-time fail-loud guard in tests/conftest.py: with presidio +
+# the spaCy model present, TestPresidioTightenedDefault must run, never skip.
+name: extras-presidio
+on:
+  pull_request:
+    paths:
+      - "petasos/scanners/presidio.py"
+      - "petasos/config.py"
+      - "petasos/console/hermes/plugin_api.py"
+      - "tests/test_presidio_scanner.py"
+      - "tests/test_presidio_entity_scoping.py"
+      - "tests/conftest.py" # home of the fail-loud collection guard this lane arms
+  schedule:
+    - cron: "13 4 * * 1" # Mondays 04:13 UTC — off-peak, off-minute, distinct from the other extras lanes
+  workflow_dispatch:
+jobs:
+  scanner-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PETASOS_REQUIRE_PRESIDIO: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[presidio,dev]"
+      - run: python -m spacy download en_core_web_lg
+      - run: pytest tests/test_presidio_entity_scoping.py tests/test_presidio_scanner.py -v --tb=short

--- a/.github/workflows/extras-presidio.yml
+++ b/.github/workflows/extras-presidio.yml
@@ -29,5 +29,9 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install -e ".[presidio,dev]"
+      # spaCy's model-download CLI imports `click`, which is not always pulled in
+      # transitively via presidio-analyzer -> spacy -> typer; install it explicitly
+      # so `spacy download` doesn't fail with ModuleNotFoundError: No module named 'click'.
+      - run: python -m pip install click
       - run: python -m spacy download en_core_web_lg
       - run: pytest tests/test_presidio_entity_scoping.py tests/test_presidio_scanner.py -v --tb=short

--- a/docs/specs/TODO/PET-109.test-output.txt
+++ b/docs/specs/TODO/PET-109.test-output.txt
@@ -1,0 +1,20 @@
+PET-109 test gate — captured 2026-06-14T07:49:19Z
+Interpreter: Python 3.10.6  (presidio + spaCy en_core_web_lg installed locally)
+
+### ruff check .
+All checks passed!
+
+### ruff format --check .
+112 files already formatted
+
+### mypy --strict .
+Success: no issues found in 112 source files
+
+### python -m pytest -q  (deselect pre-existing Unicode-13 local failure)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1489 passed, 40 skipped, 1 deselected, 1 xfailed, 52 warnings in 26.20s
+
+### Non-skipping presidio lane: PETASOS_REQUIRE_PRESIDIO=1 (extras-presidio.yml equivalent)
+................................................................         [100%]
+64 passed in 16.80s

--- a/docs/specs/TODO/PET-109.test-output.txt
+++ b/docs/specs/TODO/PET-109.test-output.txt
@@ -1,20 +1,15 @@
-PET-109 test gate — captured 2026-06-14T07:49:19Z
+PET-109 test gate — captured 2026-06-14T09:32:57Z
 Interpreter: Python 3.10.6  (presidio + spaCy en_core_web_lg installed locally)
 
 ### ruff check .
 All checks passed!
-
 ### ruff format --check .
 112 files already formatted
-
 ### mypy --strict .
 Success: no issues found in 112 source files
-
 ### python -m pytest -q  (deselect pre-existing Unicode-13 local failure)
-
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-1489 passed, 40 skipped, 1 deselected, 1 xfailed, 52 warnings in 26.20s
-
-### Non-skipping presidio lane: PETASOS_REQUIRE_PRESIDIO=1 (extras-presidio.yml equivalent)
-................................................................         [100%]
-64 passed in 16.80s
+1490 passed, 40 skipped, 1 deselected, 1 xfailed, 52 warnings in 24.80s
+### Non-skipping presidio lane: PETASOS_REQUIRE_PRESIDIO=1
+.................................................................        [100%]
+65 passed in 16.42s

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -180,8 +180,14 @@ class PetasosConfig:
                 "redaction_mode='hash' and anonymize=True"
             )
         for entity in self.pii_entities:
-            if not isinstance(entity, str) or not entity:
-                raise ValueError(f"pii_entities entries must be non-empty strings, got {entity!r}")
+            if not isinstance(entity, str) or not entity.strip():
+                raise ValueError(
+                    f"pii_entities entries must be non-empty, non-whitespace strings, "
+                    f"got {entity!r}"
+                )
+        # Trim surrounding whitespace so a " EMAIL_ADDRESS " entry isn't a silent no-op in
+        # the Stage 9 anonymize filter (which matches on the uppercased entity type, D7).
+        object.__setattr__(self, "pii_entities", tuple(e.strip() for e in self.pii_entities))
 
         # Presidio detection scoping (PET-109). presidio_entities: None = use the
         # scanner default; an explicit value replaces it wholesale (mirrors the
@@ -200,15 +206,18 @@ class PetasosConfig:
                     "presidio_entities must be non-empty when not None (use None for default)"
                 )
             for e in self.presidio_entities:
-                if not isinstance(e, str) or not e:
+                if not isinstance(e, str) or not e.strip():
                     raise ValueError(
-                        f"presidio_entities entries must be non-empty strings, got {e!r}"
+                        f"presidio_entities entries must be non-empty, non-whitespace strings, "
+                        f"got {e!r}"
                     )
-            # Normalize to Presidio's case-sensitive uppercase vocabulary so a
-            # lowercase/typo entry isn't a silent no-op (edge: "person" matches
-            # nothing in analyzer.analyze).
+            # Trim, then normalize to Presidio's case-sensitive uppercase vocabulary so a
+            # lowercase/typo/whitespace entry (e.g. "person", " URL ") isn't a silent no-op
+            # (it would match nothing in analyzer.analyze).
             object.__setattr__(
-                self, "presidio_entities", tuple(e.upper() for e in self.presidio_entities)
+                self,
+                "presidio_entities",
+                tuple(e.strip().upper() for e in self.presidio_entities),
             )
 
         # presidio_entities_extra: additive opt-ins; empty () is the default and is
@@ -225,14 +234,15 @@ class PetasosConfig:
                 self, "presidio_entities_extra", tuple(self.presidio_entities_extra)
             )
         for e in self.presidio_entities_extra:
-            if not isinstance(e, str) or not e:
+            if not isinstance(e, str) or not e.strip():
                 raise ValueError(
-                    f"presidio_entities_extra entries must be non-empty strings, got {e!r}"
+                    f"presidio_entities_extra entries must be non-empty, non-whitespace strings, "
+                    f"got {e!r}"
                 )
         object.__setattr__(
             self,
             "presidio_entities_extra",
-            tuple(e.upper() for e in self.presidio_entities_extra),
+            tuple(e.strip().upper() for e in self.presidio_entities_extra),
         )
 
         # presidio_score_threshold: finite and inclusive [0.0, 1.0]. 0.0 is the

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -78,6 +78,12 @@ class PetasosConfig:
     # Anonymization
     anonymize: bool = False
     pii_entities: tuple[str, ...] = ()
+    # Presidio detection scoping (PET-109). presidio_entities=None -> the scanner's
+    # curated default (DEFAULT_PRESIDIO_ENTITIES); a non-None tuple replaces it
+    # wholesale. presidio_entities_extra is additive (opt back in e.g. "URL").
+    presidio_entities: tuple[str, ...] | None = None
+    presidio_entities_extra: tuple[str, ...] = ()
+    presidio_score_threshold: float = 0.35
     redaction_mode: Literal["redact", "replace", "hash", "mask"] = "redact"
     hash_key: str | None = None
 
@@ -176,6 +182,68 @@ class PetasosConfig:
         for entity in self.pii_entities:
             if not isinstance(entity, str) or not entity:
                 raise ValueError(f"pii_entities entries must be non-empty strings, got {entity!r}")
+
+        # Presidio detection scoping (PET-109). presidio_entities: None = use the
+        # scanner default; an explicit value replaces it wholesale (mirrors the
+        # delegate_tool_names template — bare-str reject, list→tuple coerce, per-entry
+        # check — with a None early-out and an empty-tuple reject prepended).
+        if self.presidio_entities is not None:
+            if isinstance(self.presidio_entities, str):
+                raise ValueError(
+                    "presidio_entities must be an iterable of entity names, not a string, "
+                    f"got {self.presidio_entities!r}"
+                )
+            if not isinstance(self.presidio_entities, tuple):
+                object.__setattr__(self, "presidio_entities", tuple(self.presidio_entities))
+            if not self.presidio_entities:  # empty explicit tuple is meaningless
+                raise ValueError(
+                    "presidio_entities must be non-empty when not None (use None for default)"
+                )
+            for e in self.presidio_entities:
+                if not isinstance(e, str) or not e:
+                    raise ValueError(
+                        f"presidio_entities entries must be non-empty strings, got {e!r}"
+                    )
+            # Normalize to Presidio's case-sensitive uppercase vocabulary so a
+            # lowercase/typo entry isn't a silent no-op (edge: "person" matches
+            # nothing in analyzer.analyze).
+            object.__setattr__(
+                self, "presidio_entities", tuple(e.upper() for e in self.presidio_entities)
+            )
+
+        # presidio_entities_extra: additive opt-ins; empty () is the default and is
+        # allowed (no None early-out, no empty reject). The bare-str reject is
+        # load-bearing here too: tuple("URL") -> ("U","R","L") would pass the
+        # per-entry check and become three no-op recognizer names.
+        if isinstance(self.presidio_entities_extra, str):
+            raise ValueError(
+                "presidio_entities_extra must be an iterable of entity names, not a string, "
+                f"got {self.presidio_entities_extra!r}"
+            )
+        if not isinstance(self.presidio_entities_extra, tuple):
+            object.__setattr__(
+                self, "presidio_entities_extra", tuple(self.presidio_entities_extra)
+            )
+        for e in self.presidio_entities_extra:
+            if not isinstance(e, str) or not e:
+                raise ValueError(
+                    f"presidio_entities_extra entries must be non-empty strings, got {e!r}"
+                )
+        object.__setattr__(
+            self,
+            "presidio_entities_extra",
+            tuple(e.upper() for e in self.presidio_entities_extra),
+        )
+
+        # presidio_score_threshold: finite and inclusive [0.0, 1.0]. 0.0 is the
+        # documented power-user "all candidates" escape hatch.
+        if not math.isfinite(self.presidio_score_threshold) or not (
+            0.0 <= self.presidio_score_threshold <= 1.0
+        ):
+            raise ValueError(
+                f"presidio_score_threshold must be finite and in [0.0, 1.0], "
+                f"got {self.presidio_score_threshold!r}"
+            )
 
         # Scanner timeout + circuit breaker validation (PIPE-03)
         if self.scanner_timeout_seconds <= 0 or not math.isfinite(self.scanner_timeout_seconds):
@@ -493,6 +561,13 @@ class PetasosConfig:
             filtered["pii_entities"] = tuple(filtered["pii_entities"])
         if "delegate_tool_names" in filtered and isinstance(filtered["delegate_tool_names"], list):
             filtered["delegate_tool_names"] = tuple(filtered["delegate_tool_names"])
+        # PET-109: coerce only when a list — preserve None so the None round-trip holds.
+        if "presidio_entities" in filtered and isinstance(filtered["presidio_entities"], list):
+            filtered["presidio_entities"] = tuple(filtered["presidio_entities"])
+        if "presidio_entities_extra" in filtered and isinstance(
+            filtered["presidio_entities_extra"], list
+        ):
+            filtered["presidio_entities_extra"] = tuple(filtered["presidio_entities_extra"])
         if "session_secret" in filtered and isinstance(filtered["session_secret"], str):
             import base64
 

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -167,13 +167,51 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "section": "anonymization",
     },
     "pii_entities": {
-        "description": "Which PII entity types to detect (e.g., PERSON, EMAIL_ADDRESS).",
+        "description": "Which detected PII entity types to anonymize (empty = all).",
         "help_plain": (
-            "Meant to list which kinds of personal information to look for (like PERSON or"
-            " EMAIL_ADDRESS). Currently informational only — the personal-info scanner uses"
-            " its own list, so changing this value has no effect yet."
+            "Narrows which kinds of detected personal information actually get hidden at the"
+            " anonymize step — for example, list only EMAIL_ADDRESS to redact emails while"
+            " leaving other detected PII untouched. Leave empty to anonymize every detected"
+            " type (the default). This filters only what is hidden, not what the scanner"
+            " looks for — detection scope is set by the Presidio entity settings."
         ),
         "section": "anonymization",
+    },
+    # PET-109: detection-scope fields. section "scanning" (not "anonymization") keeps
+    # detection separate from the anonymize-stage filter (pii_entities), honoring D7.
+    "presidio_entities": {
+        "description": (
+            "PII entity types the Presidio scanner detects (unset = curated default set)."
+        ),
+        "help_plain": (
+            "Replaces the personal-info scanner's detected entity list wholesale. Leave unset"
+            " to use the curated default — the security-relevant types like credit cards,"
+            " SSNs, emails, and phone numbers — which deliberately omits noisier types (names,"
+            " locations, dates, URLs) that misfire on file paths and code. Set your own list"
+            " here only when you need a fully custom detection set."
+        ),
+        "section": "scanning",
+    },
+    "presidio_entities_extra": {
+        "description": "Extra Presidio entity types to add on top of the default set.",
+        "help_plain": (
+            "Adds entity types back on top of the curated default without replacing it — for"
+            ' example, add "URL" to detect web addresses again. Use this to opt one of the'
+            " noisier types back in while keeping the rest of the safe default. Entries are"
+            " uppercased automatically."
+        ),
+        "section": "scanning",
+    },
+    "presidio_score_threshold": {
+        "description": "Minimum confidence (0-1) a Presidio match needs before it is reported.",
+        "help_plain": (
+            "How confident the personal-info scanner must be before it reports a match, from"
+            " 0 to 1. Higher means fewer false alarms but more missed items; lower catches"
+            " more but gets noisier. Setting it all the way to 0 reports every candidate and"
+            " brings back a lot of the noise this scoping is meant to remove."
+        ),
+        "section": "scanning",
+        "constraints": {"min": 0, "max": 1},
     },
     "redaction_mode": {
         "description": "How to hide PII: redact, replace, hash, or mask.",

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -78,7 +78,11 @@ def _self_init() -> None:
 
     try:
         config = PetasosConfig.from_dict(raw_config)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        # PET-109: bind + log so a single bad field (e.g. presidio_score_threshold)
+        # discarding ALL operator tuning to defaults is diagnosable, not silent.
+        # A full per-field-tolerant load is out of scope (Deferred).
+        logger.warning("config.yaml rejected (%s); falling back to defaults", exc)
         config = PetasosConfig()
 
     scanners = [MinimalScanner(decode_encoded_payloads=config.decode_encoded_payloads)]
@@ -93,7 +97,23 @@ def _self_init() -> None:
             import importlib
 
             m = importlib.import_module(mod)
-            instance = getattr(m, cls)()
+            if name == "Presidio":
+                # PET-109: build Presidio from config (entities + score_threshold)
+                # instead of the bare no-arg ctor. resolve_presidio_entities lives in
+                # presidio.py, whose module imports are stdlib + petasos._types only —
+                # importing it does NOT import the presidio backend, so the
+                # "importable without the extra" invariant holds and the surrounding
+                # try/except ImportError still catches a genuinely-absent backend.
+                from petasos.scanners.presidio import resolve_presidio_entities
+
+                instance = getattr(m, cls)(
+                    entities=resolve_presidio_entities(
+                        config.presidio_entities, config.presidio_entities_extra
+                    ),
+                    score_threshold=config.presidio_score_threshold,
+                )
+            else:
+                instance = getattr(m, cls)()
             scanners.append(instance)
             probe = getattr(instance, "availability", None)
             if probe is not None:

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -23,7 +23,7 @@ from petasos._types import (
 )
 from petasos.config import PetasosConfig
 from petasos.normalize import normalize
-from petasos.scanners.minimal import MinimalScanner
+from petasos.scanners.minimal import _UNSUPPRESSIBLE_RULE_IDS, MinimalScanner
 from petasos.session.alerting import AlertManager
 from petasos.session.audit import AuditEmitter
 from petasos.session.frequency import FrequencyTracker, FrequencyUpdateResult
@@ -67,6 +67,43 @@ _TIMEOUT_ERROR_PREFIX = "ScannerTimeout"
 _BREAKER_OPEN_ERROR_PREFIX = "ScannerCircuitOpen"
 
 _STRUCTURAL_RULE_PREFIX = "petasos.syntactic.structural."
+
+
+def _is_floor_rule(rule_id: str) -> bool:
+    # Defense-in-depth (PET-109 D6): _UNSUPPRESSIBLE_RULE_IDS already includes every
+    # structural ID (_UNSUPPRESSIBLE_RULE_IDS = _STRUCTURAL_RULE_IDS | _ALL_INJECTION_IDS,
+    # minimal.py:440); the prefix disjunct is a belt-and-suspenders guard kept aligned
+    # by a tripwire test (_STRUCTURAL_RULE_IDS <= _UNSUPPRESSIBLE_RULE_IDS).
+    return rule_id in _UNSUPPRESSIBLE_RULE_IDS or rule_id.startswith(_STRUCTURAL_RULE_PREFIX)
+
+
+def _suppress_scanner_findings(
+    results: list[ScanResult], suppress_rules: frozenset[str]
+) -> list[ScanResult]:
+    """Drop findings whose rule_id is suppressed and NOT on the floor, per scanner.
+
+    ``replace(r, findings=kept)`` mutates ONLY ``findings``; ``scanner_name``,
+    ``error``, and ``duration_ms`` are preserved, so ``_compute_safe``'s ML-failure
+    accounting and the degraded fail-mode block are unaffected (suppression never
+    empties an errored result's error). A drop is logged at DEBUG so a later "why
+    was nothing flagged?" is a log grep, not a guess — the only runtime trace that
+    a profile suppressed a finding.
+    """
+    out: list[ScanResult] = []
+    for r in results:
+        kept = tuple(
+            f
+            for f in r.findings
+            if not (f.rule_id in suppress_rules and not _is_floor_rule(f.rule_id))
+        )
+        if len(kept) != len(r.findings):
+            dropped = sorted({f.rule_id for f in r.findings} - {f.rule_id for f in kept})
+            _logger.debug("profile suppressed %s on scanner %s", dropped, r.scanner_name)
+            out.append(replace(r, findings=kept))
+        else:
+            out.append(r)
+    return out
+
 
 _STANDALONE_TIER3_CRITICAL_COUNT = 3
 
@@ -594,6 +631,14 @@ class Pipeline:
 
         all_results = [minimal_result] + ml_results
 
+        # Stage 4b: Cross-scanner suppression (pre-merge; PET-109 D5). Drops
+        # suppressed non-floor findings before overlap resolution so a suppressed
+        # finding can neither evict a legitimate overlapping finding nor drive the
+        # tier-3 net / frequency / escalation. Downstream consumers all read the
+        # post-suppression set automatically — no per-consumer change.
+        if active_profile is not None and active_profile.suppress_rules:
+            all_results = _suppress_scanner_findings(all_results, active_profile.suppress_rules)
+
         # Stage 5: Merge findings
         merged = merge_findings(all_results)
 
@@ -604,28 +649,41 @@ class Pipeline:
         if active_profile is not None and active_profile.confidence_floor > 0.0:
             merged = tuple(f for f in merged if f.confidence >= active_profile.confidence_floor)
 
-        # Stage 5c: Severity overrides (PIPE-07 guards)
+        # Stage 5c: Severity overrides (PIPE-07 guards; PET-109 D6/D8 downgrade).
         if active_profile is not None and active_profile.severity_overrides:
             overridden: list[ScanFinding] = []
             for f in merged:
                 override = active_profile.severity_overrides.get(f.rule_id)
-                if override is not None:
-                    if f.rule_id.startswith(_STRUCTURAL_RULE_PREFIX):
-                        overridden.append(f)
-                        continue
+                if override is None:
+                    # Structural findings always land here: _check_structural_overrides
+                    # (profiles/__init__.py, enforced at parse + merge) guarantees no
+                    # structural rule_id ever reaches severity_overrides, so the floor
+                    # branch below is reached only by injection rules. (If that parse
+                    # guard is ever relaxed, structural findings would route into the
+                    # escalate branch — keep the guards coupled.)
+                    overridden.append(f)
+                    continue
+                if _is_floor_rule(f.rule_id):
+                    # Floor rules (injection): escalate-only. Refuse a downgrade or
+                    # no-op (keep original) — PET-54's threat, still covered.
                     try:
                         override_sev = Severity(override)
                     except ValueError:
                         overridden.append(f)
                         continue
-                    override_rank = _SEVERITY_RANK.get(override_sev, 999)
-                    current_rank = _SEVERITY_RANK.get(f.severity, 999)
-                    if override_rank > current_rank:
-                        overridden.append(f)
+                    if _SEVERITY_RANK.get(override_sev, 999) < _SEVERITY_RANK.get(f.severity, 999):
+                        overridden.append(replace(f, severity=override_sev))  # escalate only
                     else:
-                        overridden.append(replace(f, severity=override_sev))
+                        overridden.append(f)  # refuse downgrade/equal
                 else:
-                    overridden.append(f)
+                    # Non-floor (e.g. petasos.presidio.*): any valid severity,
+                    # including downgrade (PET-109 D8 narrows PET-54 to floor rules).
+                    try:
+                        override_sev = Severity(override)
+                    except ValueError:
+                        overridden.append(f)
+                        continue
+                    overridden.append(replace(f, severity=override_sev))
             merged = tuple(overridden)
 
         # Stage 6: Frequency hook
@@ -653,6 +711,18 @@ class Pipeline:
         sanitized_content: str | None = None
         if self._config.anonymize:
             pii_findings = [f for f in merged if f.finding_type == "pii"]
+            # PET-109 D7: when pii_entities is non-empty, anonymize only findings
+            # whose recovered entity type is in the set (case-insensitive); empty ()
+            # preserves the "anonymize all" default. Narrowing only — detection and
+            # `merged` are untouched. Coverage-reduction is intended (operator scoped
+            # what to anonymize) and tested explicitly.
+            if self._config.pii_entities:
+                from petasos.scanners.presidio import _recover_entity_type
+
+                allowed = {e.upper() for e in self._config.pii_entities}
+                pii_findings = [
+                    f for f in pii_findings if _recover_entity_type(f.rule_id) in allowed
+                ]
             if pii_findings:
                 try:
                     from petasos.scanners.presidio import anonymize as _anonymize
@@ -780,12 +850,12 @@ class Pipeline:
         self,
         profile: ResolvedProfile | None,
     ) -> MinimalScanner:
+        # PET-109: profile suppression no longer happens here. The single
+        # pre-merge cross-scanner suppression stage (Stage 4b) drives it for all
+        # scanners; MinimalScanner.with_suppress_rules remains as scanner API for
+        # direct callers/tests but is no longer profile-driven.
         assert self._minimal_scanner is not None
-        if profile is None:
-            return self._minimal_scanner
-        if not profile.suppress_rules:
-            return self._minimal_scanner
-        return self._minimal_scanner.with_suppress_rules(profile.suppress_rules)
+        return self._minimal_scanner
 
     async def _frequency_hook(
         self, findings: tuple[ScanFinding, ...], session_id: str | None

--- a/petasos/scanners/presidio.py
+++ b/petasos/scanners/presidio.py
@@ -54,6 +54,38 @@ _SEVERITY_RANK: dict[Severity, int] = {
     Severity.INFO: 4,
 }
 
+# PET-109: the security-relevant default detection set (the CRITICAL/HIGH band
+# of _SEVERITY_MAP). spaCy-NER (PERSON/LOCATION) and loose pattern (URL/DATE_TIME/
+# NRP) recognizers are noisy on technical text and are opt-in, not default.
+DEFAULT_PRESIDIO_ENTITIES: tuple[str, ...] = (
+    "CREDIT_CARD",
+    "IBAN_CODE",
+    "US_SSN",
+    "US_BANK_NUMBER",
+    "CRYPTO",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_DRIVER_LICENSE",
+    "US_PASSPORT",
+    "IP_ADDRESS",
+)
+NOISY_OPT_IN_ENTITIES: tuple[str, ...] = ("PERSON", "LOCATION", "DATE_TIME", "NRP", "URL")
+
+
+def resolve_presidio_entities(
+    base: tuple[str, ...] | None, extra: tuple[str, ...] = ()
+) -> list[str]:
+    """Resolve the effective detection entity list for a build path.
+
+    None base -> DEFAULT_PRESIDIO_ENTITIES; an explicit base is used verbatim.
+    ``extra`` is appended (additive opt-ins like ("URL",)). Order-preserving dedup.
+    Always returns a non-empty concrete list (never the analyzer's all-recognizers
+    sentinel), so a build path cannot accidentally re-enable everything.
+    """
+    chosen = DEFAULT_PRESIDIO_ENTITIES if base is None else base
+    return list(dict.fromkeys((*chosen, *extra)))
+
+
 _module_anonymizer: Any = None
 _module_anonymizer_lock = threading.Lock()
 
@@ -106,7 +138,11 @@ class PresidioScanner:
         language: str = "en",
         score_threshold: float = 0.35,
     ) -> None:
-        self._entities = entities
+        # PET-109 D3: entities=None now means the curated default detection set
+        # (not "all recognizers"). Defensive copy keeps the frozen module tuple
+        # immutable shared state; _scan_sync therefore always passes a concrete
+        # entity list to analyzer.analyze(), never the all-recognizers sentinel.
+        self._entities = list(DEFAULT_PRESIDIO_ENTITIES) if entities is None else list(entities)
         self._language = language
         self._score_threshold = score_threshold
         self._analyzer: Any = None

--- a/petasos/scanners/presidio.py
+++ b/petasos/scanners/presidio.py
@@ -83,7 +83,13 @@ def resolve_presidio_entities(
     sentinel), so a build path cannot accidentally re-enable everything.
     """
     chosen = DEFAULT_PRESIDIO_ENTITIES if base is None else base
-    return list(dict.fromkeys((*chosen, *extra)))
+    resolved = list(dict.fromkeys((*chosen, *extra)))
+    if not resolved:
+        # Enforce the documented non-empty contract: a degenerate base=() with no
+        # extra would otherwise silently disable detection (the config layer already
+        # rejects an empty explicit presidio_entities; this guards direct callers).
+        raise ValueError("effective Presidio entity set must be non-empty")
+    return resolved
 
 
 _module_anonymizer: Any = None

--- a/tests/adversarial/pipeline/test_degraded_fail_open.py
+++ b/tests/adversarial/pipeline/test_degraded_fail_open.py
@@ -441,13 +441,18 @@ def _make_profile(
 
 @pytest.mark.asyncio
 async def test_override_cannot_downgrade_critical_to_info(valid_key: str) -> None:
-    """PIPE-07: severity floor blocks CRITICAL→info downgrade."""
-    ml = _FindingScanner("ml.critical.rule", Severity.CRITICAL)
+    """PIPE-07 / PET-109 D8: the severity floor still blocks a CRITICAL→info downgrade
+    for FLOOR rules (injection/structural). D8 deliberately narrowed PET-54's
+    upgrade-only floor to floor-rules-only — so this test now pins a real injection
+    (floor) rule. Non-floor downgrade is the intended new behavior and is covered in
+    tests/test_pipeline_suppression.py::test_severity_override_can_downgrade_pii."""
+    floor_rule = "petasos.syntactic.injection.role-switch-capability"
+    ml = _FindingScanner(floor_rule, Severity.CRITICAL)
     pipe = Pipeline([MinimalScanner(), ml])
     pipe.activate(valid_key)
-    profile = _make_profile({"ml.critical.rule": "info"})
+    profile = _make_profile({floor_rule: "info"})
     result = await pipe.inspect("hello world", profile=profile)
-    crit_findings = [f for f in result.findings if f.rule_id == "ml.critical.rule"]
+    crit_findings = [f for f in result.findings if f.rule_id == floor_rule]
     assert len(crit_findings) == 1
     assert crit_findings[0].severity == Severity.CRITICAL
 
@@ -507,15 +512,29 @@ async def test_structural_rule_override_skipped_at_runtime(valid_key: str) -> No
 
 
 @pytest.mark.asyncio
-async def test_suppress_rules_does_not_affect_ml_findings(valid_key: str) -> None:
-    """PIPE-07 / Decision 5: suppress_rules only affects MinimalScanner."""
+async def test_suppress_rules_now_affects_ml_findings(valid_key: str) -> None:
+    """PET-109 D5: suppression is now cross-scanner — a non-floor ML rule_id IS
+    suppressed (supersedes PET-14 Decision 5's MinimalScanner-only behavior). The
+    _UNSUPPRESSIBLE_RULE_IDS floor still protects ML findings (second arm)."""
     ml = _FindingScanner("ml.test.rule", Severity.HIGH)
     pipe = Pipeline([MinimalScanner(), ml])
     pipe.activate(valid_key)
     profile = _make_profile({}, suppress_rules=frozenset({"ml.test.rule"}))
     result = await pipe.inspect("hello world", profile=profile)
     ml_findings = [f for f in result.findings if f.rule_id == "ml.test.rule"]
-    assert len(ml_findings) == 1
+    assert len(ml_findings) == 0  # non-floor ML finding suppressed cross-scanner
+
+    # Floor guarantee: a floor rule_id is stripped from suppress_rules at profile
+    # construction (_validate_suppress_rules), so an ML scanner emitting it is never
+    # suppressed — the pipeline-stage _is_floor_rule re-check is the defense-in-depth
+    # backstop (tested directly in test_pipeline_suppression.py).
+    floor_id = "petasos.syntactic.injection.role-switch-capability"
+    ml_floor = _FindingScanner(floor_id, Severity.HIGH)
+    pipe2 = Pipeline([MinimalScanner(), ml_floor])
+    pipe2.activate(valid_key)
+    profile2 = _make_profile({}, suppress_rules=frozenset({floor_id}))
+    result2 = await pipe2.inspect("hello world", profile=profile2)
+    assert any(f.rule_id == floor_id for f in result2.findings)
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,3 +155,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         target_class="TestProbeWeakrefUnderSlotsStdio",
         lane="extras-llamafirewall",
     )
+    _enforce_nonskipping_lane(
+        items,
+        env_flag="PETASOS_REQUIRE_PRESIDIO",
+        import_target="presidio_analyzer",
+        target_class="TestPresidioTightenedDefault",
+        lane="extras-presidio",
+    )

--- a/tests/test_pipeline_suppression.py
+++ b/tests/test_pipeline_suppression.py
@@ -1,0 +1,257 @@
+"""PET-109: cross-scanner suppression (pre-merge), PII severity downgrade, and the
+config.pii_entities anonymize-stage filter (D5/D6/D7/D8).
+
+These pipeline tests use a small in-test stub Scanner emitting fixed
+``petasos.presidio.*`` findings, so they need no real Presidio and run on every
+lane — except the single hash-mode D7 row, which exercises the anonymizer engine
+path and is gated on the presidio libraries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from petasos._types import Direction, Position, ScanFinding, ScanResult, Severity
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline, _is_floor_rule, _suppress_scanner_findings
+
+_INJECTION_ID = "petasos.syntactic.injection.role-switch-capability"  # a floor rule
+
+_presidio_libs = True
+try:
+    import presidio_analyzer  # noqa: F401
+    import presidio_anonymizer  # noqa: F401
+except ImportError:
+    _presidio_libs = False
+
+requires_presidio_libs = pytest.mark.skipif(
+    not _presidio_libs, reason="presidio-analyzer + presidio-anonymizer required"
+)
+
+
+def _pii(
+    rule_id: str,
+    *,
+    start: int,
+    end: int,
+    matched: str | None = None,
+    severity: Severity = Severity.MEDIUM,
+    confidence: float = 0.9,
+) -> ScanFinding:
+    return ScanFinding(
+        rule_id=rule_id,
+        finding_type="pii",
+        severity=severity,
+        confidence=confidence,
+        message="pii",
+        scanner_name="presidio",
+        position=Position(start=start, end=end),
+        matched_text=matched,
+    )
+
+
+def _injection(start: int = 0, end: int = 10) -> ScanFinding:
+    return ScanFinding(
+        rule_id=_INJECTION_ID,
+        finding_type="injection",
+        severity=Severity.HIGH,
+        confidence=1.0,
+        message="injection",
+        scanner_name="presidio",
+        position=Position(start=start, end=end),
+    )
+
+
+class _StubScanner:
+    """Emits a fixed set of findings regardless of input text (name != 'minimal',
+    so the pipeline routes it as an ML scanner)."""
+
+    def __init__(self, findings: tuple[ScanFinding, ...], name: str = "presidio") -> None:
+        self._findings = findings
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def scan(
+        self, text: str, *, direction: Direction = "inbound", session_id: str | None = None
+    ) -> ScanResult:
+        return ScanResult(scanner_name=self._name, findings=self._findings, duration_ms=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Cross-scanner suppression + downgrade
+# ---------------------------------------------------------------------------
+
+
+def test_profile_suppresses_presidio_finding_end_to_end() -> None:
+    stub = _StubScanner((_pii("petasos.presidio.location", start=0, end=5),))
+    p = Pipeline(scanners=[stub])
+    result = asyncio.run(
+        p.inspect("hello world", profile={"suppress_rules": ["petasos.presidio.location"]})
+    )
+    assert not any(f.rule_id == "petasos.presidio.location" for f in result.findings)
+    # control: without suppression the finding is present
+    plain = asyncio.run(p.inspect("hello world"))
+    assert any(f.rule_id == "petasos.presidio.location" for f in plain.findings)
+
+
+def test_suppress_cannot_silence_injection_or_structural() -> None:
+    # End-to-end: a profile attempting to suppress a floor (injection) rule is a
+    # no-op — the injection finding still fires.
+    stub = _StubScanner((_injection(),))
+    p = Pipeline(scanners=[stub])
+    result = asyncio.run(p.inspect("payload", profile={"suppress_rules": [_INJECTION_ID]}))
+    assert any(f.rule_id == _INJECTION_ID for f in result.findings)
+    assert result.safe is False  # HIGH injection still blocks
+
+
+def test_suppress_helper_honors_floor_directly() -> None:
+    # Defense-in-depth (D6): even a suppress set that contains a floor rule (which
+    # the profile layer would normally strip) cannot drop it at the pipeline stage.
+    results = [ScanResult(scanner_name="stub", findings=(_injection(),), duration_ms=0.0)]
+    out = _suppress_scanner_findings(results, frozenset({_INJECTION_ID}))
+    assert _is_floor_rule(_INJECTION_ID) is True
+    assert len(out[0].findings) == 1
+    assert out[0].findings[0].rule_id == _INJECTION_ID
+
+
+def test_severity_override_can_downgrade_pii() -> None:
+    stub = _StubScanner(
+        (
+            _pii("petasos.presidio.person", start=0, end=5, severity=Severity.MEDIUM),
+            _injection(start=10, end=20),
+        )
+    )
+    p = Pipeline(scanners=[stub])
+    result = asyncio.run(
+        p.inspect(
+            "name here payload here",
+            profile={
+                "severity_overrides": {
+                    "petasos.presidio.person": "info",
+                    _INJECTION_ID: "info",  # injection downgrade must be refused
+                }
+            },
+        )
+    )
+    by_rule = {f.rule_id: f for f in result.findings}
+    assert by_rule["petasos.presidio.person"].severity == Severity.INFO  # downgraded
+    assert by_rule[_INJECTION_ID].severity == Severity.HIGH  # refused downgrade
+
+
+def test_suppressed_finding_does_not_escalate() -> None:
+    # Three CRITICAL findings would trip the standalone tier-3 net (>=3 CRITICAL);
+    # suppressing them pre-merge removes that contribution (D5 ordering guard).
+    crits = tuple(
+        _pii("petasos.presidio.location", start=i, end=i + 3, severity=Severity.CRITICAL)
+        for i in (0, 4, 8)
+    )
+    stub = _StubScanner(crits)
+    p = Pipeline(scanners=[stub])
+
+    control = asyncio.run(p.inspect("abcdefghijkl", session_id="s1"))
+    assert control.escalation_tier == "tier3"  # the findings WOULD escalate
+    assert control.safe is False
+
+    suppressed = asyncio.run(
+        p.inspect(
+            "abcdefghijkl",
+            session_id="s2",
+            profile={"suppress_rules": ["petasos.presidio.location"]},
+        )
+    )
+    assert suppressed.findings == ()
+    assert suppressed.escalation_tier != "tier3"
+
+
+def test_suppressed_overlap_does_not_evict_legitimate() -> None:
+    # A suppressed HIGH finding overlapping a legitimate LOW finding at the same
+    # span: pre-merge suppression keeps the legitimate one alive (the post-merge
+    # hazard D5 guards against — HIGH would win the overlap then be dropped).
+    stub = _StubScanner(
+        (
+            _pii("petasos.presidio.location", start=0, end=5, severity=Severity.HIGH),
+            _pii("petasos.presidio.email_address", start=0, end=5, severity=Severity.LOW),
+        )
+    )
+    p = Pipeline(scanners=[stub])
+    result = asyncio.run(
+        p.inspect("hello", profile={"suppress_rules": ["petasos.presidio.location"]})
+    )
+    rule_ids = {f.rule_id for f in result.findings}
+    assert "petasos.presidio.email_address" in rule_ids  # legitimate survives
+    assert "petasos.presidio.location" not in rule_ids  # suppressed
+
+
+# ---------------------------------------------------------------------------
+# D7 — config.pii_entities anonymize-stage filter
+# ---------------------------------------------------------------------------
+
+# text:  "email a@b.co ssn 111-22-3333"
+#         0123456789...                 email span [6,12], ssn span [17,28]
+_D7_TEXT = "email a@b.co ssn 111-22-3333"
+
+
+def _email_and_ssn() -> tuple[ScanFinding, ...]:
+    return (
+        _pii(
+            "petasos.presidio.email_address",
+            start=6,
+            end=12,
+            matched="a@b.co",
+            severity=Severity.HIGH,
+        ),
+        _pii(
+            "petasos.presidio.us_ssn",
+            start=17,
+            end=28,
+            matched="111-22-3333",
+            severity=Severity.CRITICAL,
+        ),
+    )
+
+
+def test_pii_entities_filters_anonymize_set() -> None:
+    cfg = PetasosConfig(anonymize=True, redaction_mode="replace", pii_entities=("EMAIL_ADDRESS",))
+    p = Pipeline(scanners=[_StubScanner(_email_and_ssn())], config=cfg)
+    result = asyncio.run(p.inspect(_D7_TEXT))
+    assert result.sanitized_content is not None
+    assert "a@b.co" not in result.sanitized_content  # email anonymized
+    assert "111-22-3333" in result.sanitized_content  # SSN left unredacted (coverage cut)
+
+
+def test_pii_entities_empty_anonymizes_all() -> None:
+    cfg = PetasosConfig(anonymize=True, redaction_mode="replace", pii_entities=())
+    p = Pipeline(scanners=[_StubScanner(_email_and_ssn())], config=cfg)
+    result = asyncio.run(p.inspect(_D7_TEXT))
+    assert result.sanitized_content is not None
+    assert "a@b.co" not in result.sanitized_content
+    assert "111-22-3333" not in result.sanitized_content  # back-compat: anonymize all
+
+
+def test_pii_entities_excludes_all_skips_anonymize() -> None:
+    cfg = PetasosConfig(anonymize=True, redaction_mode="replace", pii_entities=("CRYPTO",))
+    p = Pipeline(scanners=[_StubScanner(_email_and_ssn())], config=cfg)
+    result = asyncio.run(p.inspect(_D7_TEXT))
+    # no finding matches the filter -> anonymize skipped -> sanitized stays None
+    assert result.sanitized_content is None
+
+
+@requires_presidio_libs
+def test_pii_entities_filter_hash_mode() -> None:
+    cfg = PetasosConfig(
+        anonymize=True,
+        redaction_mode="hash",
+        hash_key="test-key",
+        pii_entities=("EMAIL_ADDRESS",),
+    )
+    p = Pipeline(scanners=[_StubScanner(_email_and_ssn())], config=cfg)
+    result = asyncio.run(p.inspect(_D7_TEXT))
+    assert result.sanitized_content is not None
+    assert "a@b.co" not in result.sanitized_content  # email hashed (engine path)
+    # non-vacuous: the SSN appears in cleartext (Stage 9 ran, but filtered it out)
+    assert "111-22-3333" in result.sanitized_content

--- a/tests/test_presidio_entity_scoping.py
+++ b/tests/test_presidio_entity_scoping.py
@@ -132,12 +132,27 @@ def test_config_round_trips_presidio_fields() -> None:
 
 
 def test_presidio_entities_casing_normalized() -> None:
+    # case-folded AND surrounding whitespace trimmed (a " URL " entry would otherwise
+    # be a silent no-op — it matches no recognizer in analyzer.analyze).
     cfg = PetasosConfig(
-        presidio_entities=("person", "url"),
-        presidio_entities_extra=("ip_address",),
+        presidio_entities=(" person ", "url"),
+        presidio_entities_extra=("ip_address ",),
+        pii_entities=(" EMAIL_ADDRESS ",),
     )
     assert cfg.presidio_entities == ("PERSON", "URL")
     assert cfg.presidio_entities_extra == ("IP_ADDRESS",)
+    assert cfg.pii_entities == ("EMAIL_ADDRESS",)  # trimmed (D7 filter uppercases at read)
+
+
+def test_whitespace_only_entity_entries_rejected() -> None:
+    # whitespace-only entries are non-empty but normalize to nothing — reject them
+    # rather than let them silently disable a security-sensitive detector/filter.
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities=("   ",))
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities_extra=("\t",))
+    with pytest.raises(ValueError):
+        PetasosConfig(pii_entities=("  ",))
 
 
 def test_structural_ids_subset_of_unsuppressible() -> None:

--- a/tests/test_presidio_entity_scoping.py
+++ b/tests/test_presidio_entity_scoping.py
@@ -86,6 +86,9 @@ def test_resolve_entities_default_and_extra() -> None:
     assert resolve_presidio_entities(("EMAIL_ADDRESS", "EMAIL_ADDRESS"), ("EMAIL_ADDRESS",)) == [
         "EMAIL_ADDRESS"
     ]
+    # a degenerate empty base + empty extra violates the non-empty contract
+    with pytest.raises(ValueError):
+        resolve_presidio_entities((), ())
 
 
 def test_default_scanner_entities_wired() -> None:

--- a/tests/test_presidio_entity_scoping.py
+++ b/tests/test_presidio_entity_scoping.py
@@ -1,0 +1,219 @@
+"""PET-109: Presidio entity scoping — default-set, config round-trip/apply, and
+real-backend regression (benign technical corpus + real-PII preservation).
+
+The backend-free rows are module-level functions. The two `@requires_presidio`
+rows live in class ``TestPresidioTightenedDefault`` — the ``target_class`` the
+conftest non-skipping-lane guard pins for ``extras-presidio`` (D4).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from petasos.config import PetasosConfig
+from petasos.scanners.minimal import _STRUCTURAL_RULE_IDS, _UNSUPPRESSIBLE_RULE_IDS
+from petasos.scanners.presidio import (
+    DEFAULT_PRESIDIO_ENTITIES,
+    NOISY_OPT_IN_ENTITIES,
+    PresidioScanner,
+    resolve_presidio_entities,
+)
+
+# ---------------------------------------------------------------------------
+# Skip markers for optional-dependency tests (mirrors test_presidio_scanner.py)
+# ---------------------------------------------------------------------------
+
+_presidio_available = True
+try:
+    import presidio_analyzer  # noqa: F401
+    import presidio_anonymizer  # noqa: F401
+except ImportError:
+    _presidio_available = False
+
+_spacy_model_available = False
+if _presidio_available:
+    try:
+        import spacy
+
+        spacy.load("en_core_web_lg")
+        _spacy_model_available = True
+    except (ImportError, OSError):
+        pass
+
+requires_presidio = pytest.mark.skipif(
+    not (_presidio_available and _spacy_model_available),
+    reason="presidio + spaCy model required",
+)
+
+
+# ---------------------------------------------------------------------------
+# Backend-free unit tests (run on every lane)
+# ---------------------------------------------------------------------------
+
+
+def test_default_entities_exclude_noisy_set() -> None:
+    assert isinstance(DEFAULT_PRESIDIO_ENTITIES, tuple)  # frozen/immutable (D6)
+    # The five noisy NER/loose-pattern entities are excluded from the default.
+    for noisy in NOISY_OPT_IN_ENTITIES:
+        assert noisy not in DEFAULT_PRESIDIO_ENTITIES
+    # The 10-entity CRITICAL/HIGH security band is present.
+    expected = {
+        "CREDIT_CARD",
+        "IBAN_CODE",
+        "US_SSN",
+        "US_BANK_NUMBER",
+        "CRYPTO",
+        "EMAIL_ADDRESS",
+        "PHONE_NUMBER",
+        "US_DRIVER_LICENSE",
+        "US_PASSPORT",
+        "IP_ADDRESS",
+    }
+    assert set(DEFAULT_PRESIDIO_ENTITIES) == expected
+    assert len(DEFAULT_PRESIDIO_ENTITIES) == 10
+
+
+def test_resolve_entities_default_and_extra() -> None:
+    assert resolve_presidio_entities(None) == list(DEFAULT_PRESIDIO_ENTITIES)
+    # extra is additive (opt back in URL)
+    assert resolve_presidio_entities(None, ("URL",)) == list(DEFAULT_PRESIDIO_ENTITIES) + ["URL"]
+    # explicit base replaces wholesale
+    assert resolve_presidio_entities(("PERSON",)) == ["PERSON"]
+    assert resolve_presidio_entities(("PERSON",), ("URL",)) == ["PERSON", "URL"]
+    # order-preserving dedup
+    assert resolve_presidio_entities(("EMAIL_ADDRESS", "EMAIL_ADDRESS"), ("EMAIL_ADDRESS",)) == [
+        "EMAIL_ADDRESS"
+    ]
+
+
+def test_default_scanner_entities_wired() -> None:
+    assert PresidioScanner()._entities == list(DEFAULT_PRESIDIO_ENTITIES)
+    # contract change (D3): an explicit list is used verbatim
+    assert PresidioScanner(entities=["PERSON"])._entities == ["PERSON"]
+
+
+def test_config_round_trips_presidio_fields() -> None:
+    cfg = PetasosConfig(
+        presidio_entities=("EMAIL_ADDRESS", "US_SSN"),
+        presidio_entities_extra=("URL",),
+        presidio_score_threshold=0.5,
+    )
+    rt = PetasosConfig.from_dict(cfg.to_dict())
+    assert rt.presidio_entities == ("EMAIL_ADDRESS", "US_SSN")
+    assert rt.presidio_entities_extra == ("URL",)
+    assert rt.presidio_score_threshold == 0.5
+
+    # None -> to_dict -> from_dict -> None (no existing precedent; assert explicitly)
+    base = PetasosConfig()
+    assert base.presidio_entities is None
+    rt_none = PetasosConfig.from_dict(base.to_dict())
+    assert rt_none.presidio_entities is None
+
+    # invalid threshold
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_score_threshold=1.5)
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_score_threshold=math.nan)
+    # empty explicit presidio_entities is meaningless
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities=())
+    # bare-string / empty-string entries
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities="EMAIL_ADDRESS")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities=("",))
+    with pytest.raises(ValueError):
+        PetasosConfig(presidio_entities_extra="URL")  # type: ignore[arg-type]
+
+
+def test_presidio_entities_casing_normalized() -> None:
+    cfg = PetasosConfig(
+        presidio_entities=("person", "url"),
+        presidio_entities_extra=("ip_address",),
+    )
+    assert cfg.presidio_entities == ("PERSON", "URL")
+    assert cfg.presidio_entities_extra == ("IP_ADDRESS",)
+
+
+def test_structural_ids_subset_of_unsuppressible() -> None:
+    # Tripwire (D6): the _is_floor_rule structural-prefix disjunct can never diverge
+    # from the set, because every structural ID is already unsuppressible.
+    assert _STRUCTURAL_RULE_IDS <= _UNSUPPRESSIBLE_RULE_IDS
+
+
+def test_config_scopes_presidio_entities_and_threshold() -> None:
+    # A scanner built the way plugin_api builds it yields the expected wiring.
+    cfg = PetasosConfig(presidio_entities_extra=("URL",), presidio_score_threshold=0.4)
+    scanner = PresidioScanner(
+        entities=resolve_presidio_entities(cfg.presidio_entities, cfg.presidio_entities_extra),
+        score_threshold=cfg.presidio_score_threshold,
+    )
+    assert scanner._entities == list(DEFAULT_PRESIDIO_ENTITIES) + ["URL"]
+    assert scanner._score_threshold == 0.4
+
+
+@requires_presidio
+def test_presidio_entities_extra_url_fires() -> None:
+    # Integration arm of the config-scoping row: opting URL in via the extra makes
+    # URL fire on a URL string (it does not under the curated default).
+    cfg = PetasosConfig(presidio_entities_extra=("URL",))
+    scanner = PresidioScanner(
+        entities=resolve_presidio_entities(cfg.presidio_entities, cfg.presidio_entities_extra),
+    )
+    import asyncio
+
+    result = asyncio.run(scanner.scan("Visit https://example.com for the docs"))
+    assert result.error is None
+    assert any("url" in f.rule_id for f in result.findings)
+
+    # control: under the curated default, URL does NOT fire
+    default_scanner = PresidioScanner()
+    default_result = asyncio.run(default_scanner.scan("Visit https://example.com for the docs"))
+    assert default_result.error is None
+    assert not any("url" in f.rule_id for f in default_result.findings)
+
+
+# ---------------------------------------------------------------------------
+# Real-backend regression — non-skipping on the extras-presidio lane (D4)
+# ---------------------------------------------------------------------------
+
+
+@requires_presidio
+class TestPresidioTightenedDefault:
+    def test_benign_technical_corpus_no_pii_findings(self) -> None:
+        import asyncio
+
+        scanner = PresidioScanner()  # curated default
+        corpus = "\n".join(
+            [
+                "Vigil Harbor Wiki Location",
+                "$WIKI/projects/petasos/state.md and $WIKI/index.md",
+                'node wiki-lint.mjs . --repos "petasos,dynasty"',
+                "version 2.1.0",
+                "tickets: DYN RAD MCP PET",
+                "See https://vigilharbor.com/docs/petasos for details",
+            ]
+        )
+        result = asyncio.run(scanner.scan(corpus))
+        assert result.error is None
+        assert result.findings == (), f"expected zero findings, got {result.findings}"
+
+    def test_real_pii_still_detected(self) -> None:
+        import asyncio
+
+        scanner = PresidioScanner()  # curated default
+        # Phrasing chosen so each entity scores above the default 0.35 threshold:
+        # the SSN needs its "social security number" context to clear the bar.
+        corpus = (
+            "Please update records: social security number 219-09-9999 on file, "
+            "card 4111 1111 1111 1111, email john@example.com, call 555-123-4567."
+        )
+        result = asyncio.run(scanner.scan(corpus))
+        assert result.error is None
+        rule_ids = {f.rule_id for f in result.findings}
+        assert any("us_ssn" in r for r in rule_ids), rule_ids
+        assert any("credit_card" in r for r in rule_ids), rule_ids
+        assert any("email" in r for r in rule_ids), rule_ids
+        assert any("phone" in r for r in rule_ids), rule_ids

--- a/tests/test_presidio_scanner.py
+++ b/tests/test_presidio_scanner.py
@@ -419,7 +419,10 @@ class TestPresidioScannerIntegration:
         phone_findings = [f for f in result.findings if "phone" in f.rule_id]
         assert len(phone_findings) > 0
 
-    def test_detect_person(self, scanner: PresidioScanner) -> None:
+    def test_detect_person(self) -> None:
+        # PET-109 D3: PERSON is opt-in under the tightened default, so this test
+        # (intent: "PERSON detection works") builds a PERSON-scoped scanner.
+        scanner = PresidioScanner(entities=["PERSON"])
         result = asyncio.run(scanner.scan("My name is John Smith and I live in New York"))
         assert result.error is None
         persons = [f for f in result.findings if "person" in f.rule_id]
@@ -459,7 +462,9 @@ class TestPresidioScannerIntegration:
         assert result.duration_ms > 0
 
     def test_score_threshold_filtering(self) -> None:
-        scanner = PresidioScanner(score_threshold=0.9)
+        # PET-109 D3: scope PERSON in explicitly so the threshold assertion is
+        # non-vacuous (PERSON is opt-in under the tightened default).
+        scanner = PresidioScanner(entities=["PERSON"], score_threshold=0.9)
         result = asyncio.run(scanner.scan("Maybe John from somewhere"))
         assert result.error is None
         for f in result.findings:
@@ -478,6 +483,12 @@ class TestPresidioScannerIntegration:
         )
         assert result.error is None
         assert len(result.findings) >= 2
+        # PET-109: PERSON no longer fires under the tightened default, so the >= 2
+        # now rests on exactly email+phone — pin those entity types so a future
+        # tightening of either yields a clear failure, not a confusing count miss.
+        rule_ids = {f.rule_id for f in result.findings}
+        assert any("email" in r for r in rule_ids)
+        assert any("phone" in r for r in rule_ids)
 
     def test_scanner_name_in_findings(self, scanner: PresidioScanner) -> None:
         result = asyncio.run(scanner.scan("john@example.com"))
@@ -492,8 +503,12 @@ class TestAnonymizeIntegration:
         text: str,
         mode: str = "redact",
         hash_key: str | None = None,
+        entities: list[str] | None = None,
     ) -> str:
-        scanner = PresidioScanner()
+        # PET-109: entities=None keeps the curated default (preserves the email/SSN
+        # siblings); test_replace_with_counters passes entities=["PERSON"] because
+        # PERSON is opt-in under the tightened default.
+        scanner = PresidioScanner(entities=entities)
         result = asyncio.run(scanner.scan(text))
         return anonymize(
             text,
@@ -510,7 +525,7 @@ class TestAnonymizeIntegration:
 
     def test_replace_with_counters(self) -> None:
         text = "Contact John Smith or Jane Doe"
-        result = self._scan_and_anonymize(text, mode="replace")
+        result = self._scan_and_anonymize(text, mode="replace", entities=["PERSON"])
         assert "John Smith" not in result or "Jane Doe" not in result
 
     def test_hash_with_key_deterministic(self) -> None:


### PR DESCRIPTION
## Summary
- Tightens the **default** Presidio entity set to the 10-entity CRITICAL/HIGH security band; the five noisy NER/loose-pattern entities (`PERSON`, `LOCATION`, `DATE_TIME`, `NRP`, `URL`) become opt-in. `entities=None` now resolves to the curated default, not "all recognizers" (deliberate constructor contract change).
- Adds three runtime config levers — `presidio_entities`, `presidio_entities_extra`, `presidio_score_threshold` — validated, JSON-round-tripping, and wired into the dashboard scanner-build path.
- Makes profile `suppress_rules` and `severity_overrides`-downgrade apply to **all** scanner findings (pre-merge, overlap-safe), while the `_UNSUPPRESSIBLE_RULE_IDS` floor stays absolute.
- Repurposes the dead `config.pii_entities` field as the anonymize-stage entity filter it always appeared to be (`()` = anonymize all, back-compat preserved).

This is a **noise/usability** fix, not a wrongful-block fix: under default config these `MEDIUM`/`LOW` PII findings never flip `_compute_safe` and `petasos.presidio.*` carries zero frequency weight, so nothing blocks or escalates today — the harm is operator-facing noise.

## Layered defense (suppression + downgrade)
Cross-scanner suppression runs **pre-merge** (D5): a suppressed non-floor finding is dropped before `merge_findings`' severity-first overlap resolution, so it can neither evict a legitimate overlapping finding nor drive the tier-3 net / frequency / escalation. Stage 5c downgrade is allowed only for non-floor rules; floor rules (injection/structural) keep escalate-only behavior — narrowing PET-54's upgrade-only floor to floor-rules-only (D8), with the floor independently re-checked at the suppression stage (D6).

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/presidio.py` | Adds `DEFAULT_PRESIDIO_ENTITIES` / `NOISY_OPT_IN_ENTITIES` / `resolve_presidio_entities()`; `entities=None` → curated default |
| `petasos/config.py` | Adds 3 presidio fields + `__post_init__` validation + `from_dict` list→tuple coercion |
| `petasos/pipeline.py` | New pre-merge suppression stage; `_profile_hook` no longer drives suppression; Stage 5c non-floor downgrade; Stage 9 `pii_entities` anonymize filter |
| `petasos/console/hermes/plugin_api.py` | Builds Presidio from config (entities + threshold); boot-path config-reject now logged |
| `petasos/console/_config_meta.py` | `_FIELD_META` for 3 new fields (`scanning`); `pii_entities` description+help_plain rewritten |
| `tests/conftest.py` | Third `_enforce_nonskipping_lane` call (`PETASOS_REQUIRE_PRESIDIO`) |
| `tests/test_presidio_entity_scoping.py` | New: default-set, config round-trip/apply, benign-corpus + real-PII regression |
| `tests/test_pipeline_suppression.py` | New: cross-scanner suppression, PII downgrade, no-escalation, `pii_entities` filter |
| `tests/test_presidio_scanner.py` | Updated tests assuming default `PERSON` detection (D3) |
| `tests/adversarial/pipeline/test_degraded_fail_open.py` | Two tests updated to the superseded-by-design behavior (D5/D8), floor guarantees preserved |
| `.github/workflows/extras-presidio.yml` | New non-skipping CI lane (presidio + spaCy model, `PETASOS_REQUIRE_PRESIDIO=1`) |

> ⚠️ **Reviewer note — out-of-spec-scope test edit:** `tests/adversarial/pipeline/test_degraded_fail_open.py` was **not** in the spec's "Files to change" list. Its `test_override_cannot_downgrade_critical_to_info` (used a non-floor synthetic rule) and `test_suppress_rules_does_not_affect_ml_findings` encoded exactly the old behavior D8/D5 deliberately supersede — the spec flagged this reliance in D8 and Deferred. Both were updated to the new behavior while keeping the `_UNSUPPRESSIBLE_RULE_IDS` floor guarantees intact (test 1 repointed to a real injection floor rule; test 2 gains a floor arm).

## Test plan
- [x] `python -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 1489 passed, 40 skipped, 1 xfailed (full output: `docs/specs/TODO/PET-109.test-output.txt`)
- [x] `ruff check .` — clean; `ruff format --check .` — clean; `mypy --strict .` — clean (112 files)
- [x] Non-skipping presidio lane locally (`PETASOS_REQUIRE_PRESIDIO=1`, presidio + `en_core_web_lg` installed) — 64 passed, **0 skipped** (conftest guard satisfied)
- [x] Benign-technical corpus → zero Presidio findings under default; real PII (SSN/credit-card/email/phone) still detected
- [ ] Post-merge: `/wiki-after-merge <sha>` — architecture PII/anonymize + suppression sections; new decision entry recording a `supersedes`/`amends` edge to `2026-05-28-pet-54-severity-override-structural-protection.md` (D8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Presidio entity scoping controls and a configurable detection score threshold.
  * Added options to extend detection entities and to restrict which detected PII types are anonymized.
* **Improvements**
  * Tightened Presidio defaults to reduce false positives.
  * Updated suppression and severity override behavior so floor rules aren’t silenced/downgraded unexpectedly.
  * Improved config fallback behavior when dashboard initialization encounters invalid settings.
* **Tests**
  * Added and expanded coverage for Presidio scoping, suppression interactions, severity overrides, and anonymization filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->