### PR TITLE
chore(pet-110): settle llamafirewall slots-only stdio window on gibson

### DIFF
--- a/docs/platform/hermes-desktop-footguns.md
+++ b/docs/platform/hermes-desktop-footguns.md
@@ -486,15 +486,21 @@ a future `llamafirewall` upgrade that routes logging through structlog's
 default `PrintLogger` (or any weakref-keyed-stream path) re-trips it RED in the
 non-skipping lane instead of silently re-creating the production-dead failure.
 
-**Residual (because `EMITTED=0`):** the model-free probe did not exercise a
-*construction/scan-time* emission — that path needs the HF-gated PromptGuard
-model. The mechanism reason above already covers every window, but the
-*empirical* construction/scan-window check is model-gated: the shipped gated
-test `test_llamafirewall_scan_under_slots_stdio_completes` settles it where the
-model exists (gibson per PET-97), tracked as **PET-110**. (`EMITTED` was also
-captured under `HF_HUB_OFFLINE=1`, which can itself suppress a telemetry
-import-time line, so `EMITTED=0` is not by itself proof of no *online*
-import-time emission — PET-110's online run closes that too.)
+**Settled (PET-110, 2026-06-14):** the construction/scan window was checked
+empirically on gibson — the model-bearing host where the accepted
+Llama-Prompt-Guard-2-86M license + HF token satisfy `_prompt_guard_prereq_error`,
+the predicate corrected in PET-100 (not PET-97, which is leetspeak normalization).
+The shipped gated test
+`tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes`
+ran **online** (no `HF_HUB_OFFLINE=1`) and passed weakref-clean (`1 passed`): a real
+`LlamaFirewallScanner().scan()` of an injection string under slots-only,
+non-`__weakref__` stdout returned `error is None` with a `petasos.llamafirewall.*`
+finding — no `cannot create weak reference` anywhere. This **confirms** the
+categorical mechanism reason above (it does not *replace* it), and together they
+close both the construction/scan-window residual and the `HF_HUB_OFFLINE=1`
+online-emission caveat: the online run surfaced no weakref-keyed import-time line
+(the only warnings were `torch.jit` deprecation notices — stdlib/torch, not
+weakref-keyed). Evidence: `docs/specs/TODO/PET-110.test-output.txt`.
 
 ---
 

--- a/docs/specs/TODO/PET-110.local-gate.txt
+++ b/docs/specs/TODO/PET-110.local-gate.txt
@@ -1,0 +1,99 @@
+PET-110 — local sanity gate (ship-spec Phase 3) — guards the docstring edits
+Environment: Windows, Python 3.10.6 (C:\python310). llamafirewall/structlog absent here,
+  so the model-free probe + model-gated 1b classes (TestProbeWeakrefUnderSlotsStdio,
+  TestShieldUnderSlotsStdio) self-skip — exactly the spec's 'non-model host, expected skips'
+  gate. The actual settlement (1 passed, online) is the separate gibson run captured in
+  docs/specs/TODO/PET-110.test-output.txt. This file only confirms the docstring edits keep
+  the suite collecting + green-with-expected-skips and lint/format/types clean.
+Date: 2026-06-14
+
+============================================================
+$ python -m pytest tests/test_llama_firewall_wrapper.py tests/test_llama_firewall_scanner.py -v --tb=short
+============================================================
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0 -- C:\python310\python.exe
+cachedir: .pytest_cache
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-110-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 57 items
+
+tests/test_llama_firewall_wrapper.py::TestProbeWeakrefUnderSlotsStdio::test_llamafirewall_no_weakref_during_load_under_slots_stdio SKIPPED [  1%]
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes SKIPPED [  3%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_name PASSED         [  5%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_protocol_conformance PASSED [  7%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_import_failure_returns_error PASSED [  8%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_import_failure_message PASSED [ 10%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_init_failure_returns_error PASSED [ 12%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_no_components_enabled PASSED [ 14%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_no_components_duration_tracked PASSED [ 15%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_single_component_enabled_no_error PASSED [ 17%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_all_disabled_warns_on_load PASSED [ 19%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_default_constructor PASSED [ 21%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_thread_safety PASSED [ 22%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_duration_tracking PASSED [ 24%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_exception_in_scan_returns_error PASSED [ 26%]
+tests/test_llama_firewall_scanner.py::TestUnit::test_empty_string PASSED [ 28%]
+tests/test_llama_firewall_scanner.py::TestAvailabilityProbe::test_unavailable_when_blocked PASSED [ 29%]
+tests/test_llama_firewall_scanner.py::TestAvailabilityProbe::test_available_with_mock PASSED [ 31%]
+tests/test_llama_firewall_scanner.py::TestAvailabilityProbe::test_terminal_error_returns_unavailable PASSED [ 33%]
+tests/test_llama_firewall_scanner.py::TestProbeIsolation::test_probe_isolation_hermetic PASSED [ 35%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_disabled_returns_none PASSED [ 36%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_model_present_returns_none PASSED [ 38%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_token_via_env_returns_none PASSED [ 40%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_token_via_file_returns_none PASSED [ 42%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_no_model_no_token_returns_error PASSED [ 43%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_empty_token_treated_as_absent PASSED [ 45%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_polluted_tilde_hf_home_expanded PASSED [ 47%]
+tests/test_llama_firewall_scanner.py::TestPromptGuardPrereqPredicate::test_save_pretrained_layout_returns_none PASSED [ 49%]
+tests/test_llama_firewall_scanner.py::TestFailFast::test_no_token_fails_fast PASSED [ 50%]
+tests/test_llama_firewall_scanner.py::TestStdinTripwire::test_scan_window_catches_input PASSED [ 52%]
+tests/test_llama_firewall_scanner.py::TestStdinTripwire::test_construction_window_catches_input PASSED [ 54%]
+tests/test_llama_firewall_scanner.py::TestStdinTripwire::test_nonblocking_guard_returns_warming_up PASSED [ 56%]
+tests/test_llama_firewall_scanner.py::TestStdinTripwire::test_warm_trigger_regression PASSED [ 57%]
+tests/test_llama_firewall_scanner.py::TestCrossAxisRecovery::test_blocked_to_prereq_to_healthy PASSED [ 59%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_block_produces_finding PASSED [ 61%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_allow_no_finding PASSED [ 63%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_confidence_clamped_high PASSED [ 64%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_confidence_clamped_low PASSED [ 66%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_direction_inbound_uses_user_message PASSED [ 68%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_direction_outbound_uses_assistant_message PASSED [ 70%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_multiple_components PASSED [ 71%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_partial_failure_preserves_findings PASSED [ 73%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_non_allow_decision_produces_finding PASSED [ 75%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_none_score_defaults_to_one PASSED [ 77%]
+tests/test_llama_firewall_scanner.py::TestMockFunctional::test_fail_once_semantics PASSED [ 78%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_prompt_guard_detects_jailbreak SKIPPED [ 80%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_prompt_guard_clean_message SKIPPED [ 82%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_code_shield_detects_unsafe SKIPPED [ 84%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_alignment_check_cot SKIPPED [ 85%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_direction_inbound SKIPPED [ 87%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_direction_outbound SKIPPED [ 89%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_multiple_components_enabled SKIPPED [ 91%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_finding_field_completeness SKIPPED [ 92%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_backend_exception_partial_findings SKIPPED [ 94%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_confidence_range SKIPPED [ 96%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_corpus SKIPPED [ 98%]
+tests/test_llama_firewall_scanner.py::TestIntegration::test_async_correctness SKIPPED [100%]
+
+======================= 43 passed, 14 skipped in 0.13s ========================
+EXIT=0
+
+============================================================
+$ ruff check .
+============================================================
+All checks passed!
+EXIT=0
+
+============================================================
+$ ruff format --check .
+============================================================
+110 files already formatted
+EXIT=0
+
+============================================================
+$ mypy --strict .
+============================================================
+Success: no issues found in 110 source files
+EXIT=0

--- a/docs/specs/TODO/PET-110.test-output.txt
+++ b/docs/specs/TODO/PET-110.test-output.txt
@@ -1,0 +1,47 @@
+PET-110 — gibson acceptance run (model-gated settling test, ONLINE)
+Host: gibson — the model-bearing Hermes environment (Windows; Hermes venv Python 3.11.14 at
+  C:\Users\zioni\AppData\Local\hermes\hermes-agent\venv, petasos editable-installed from this repo).
+Condition: ONLINE — HF_HUB_OFFLINE unset (Decision 7); HF_HOME unset -> ~/.cache/huggingface.
+Extras: llamafirewall installed. Model CACHED, no download:
+  ~/.cache/huggingface/hub/models--meta-llama--Llama-Prompt-Guard-2-86M (+ the save_pretrained dir).
+Gate: _prompt_guard_prereq_error(True) is None -> test is NON-SKIPPING. The authoritative
+  confirmation is the summary below reading "1 passed", not "1 skipped".
+Tree: PET-110 worktree at 61bb0c4 (PR #84) -> settling test + footguns § 16 residual line present.
+Date: 2026-06-14
+Pass bar (Decision 5): result.error is None AND >=1 petasos.llamafirewall.* finding on the
+  injection string, with NO "cannot create weak reference" anywhere. All satisfied (1 passed).
+Note: the only warnings are torch.jit.script DeprecationWarnings (not weakref-keyed; emitted
+  offline too, so not a Decision-7 online-only telemetry line). No construction/scan emission
+  reaches pytest stdout — it lands in the fixture's in-memory StringIO (the slots-only swap).
+
+============================================================
+$ python -m pytest "tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes" -v -rA
+============================================================
+============================= test session starts =============================
+platform win32 -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- C:\Users\zioni\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe
+cachedir: .pytest_cache
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-110-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, Faker-37.12.0, asyncio-1.3.0, benchmark-5.2.3, timeout-2.4.0
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 1 item
+
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes PASSED [100%]
+
+============================== warnings summary ===============================
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+  C:\Users\zioni\AppData\Local\hermes\hermes-agent\venv\Lib\site-packages\torch\jit\_script.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
+    warnings.warn(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=================================== PASSES ====================================
+=========================== short test summary info ===========================
+PASSED tests/test_llama_firewall_wrapper.py::TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes
+======================== 1 passed, 7 warnings in 3.81s ========================

--- a/tests/test_llama_firewall_wrapper.py
+++ b/tests/test_llama_firewall_wrapper.py
@@ -18,7 +18,9 @@ Two surfaces:
   stream-weakref path during the load window; a future upgrade that re-routes
   logging through structlog's default ``PrintLogger`` re-trips it (spec D5).
 * 1b — in-process, **model-gated** tests (``TestShieldUnderSlotsStdio``) that run
-  only where the PromptGuard model exists (gibson per PET-97). They settle the
+  only where the PromptGuard model exists (gibson — the HF-model-bearing host; the
+  accepted-license + HF-token environment is recognized by
+  ``_prompt_guard_prereq_error`` (PET-100), not PET-97 (leetspeak)). They settle the
   construction/scan window the model-free probe cannot reach (it gate-returns at the
   prereq check before any model load).
 """
@@ -197,11 +199,11 @@ def hostile_stdio_llamafirewall(
 
 @_skip_integration
 class TestShieldUnderSlotsStdio:
-    """1b — in-process, model-gated (run where the HF model exists: gibson per
-    PET-97). Held in a **separate class** from ``TestProbeWeakrefUnderSlotsStdio``
-    so the conftest guard's class-name filter (which targets only the probe class)
-    never flags these, and they self-skip cleanly in the no-token lane via the
-    imported ``_skip_integration`` (spec DF).
+    """1b — in-process, model-gated (run where the HF model exists: gibson;
+    HF-prereq gate per PET-100). Held in a **separate class** from
+    ``TestProbeWeakrefUnderSlotsStdio`` so the conftest guard's class-name filter
+    (which targets only the probe class) never flags these, and they self-skip
+    cleanly in the no-token lane via the imported ``_skip_integration`` (spec DF).
 
     On the not-exposed / indeterminate branch this holds only the construction/scan
     -window settling test (DE outcome 3). If the probe shows exposure (DE outcome 2),


### PR DESCRIPTION
## Summary
- Empirically settles the PET-105 outcome-3 residual: the already-shipped, model-gated settling test ran **online** on gibson (the PromptGuard model-bearing host) and passed weakref-clean (`1 passed`).
- Converts footguns § 16 *"Residual (because `EMITTED=0`)"* into a *"Settled (PET-110, 2026-06-14)"* line and marks the `HF_HUB_OFFLINE=1` online-emission caveat resolved.
- Corrects the host-attribution citation *"gibson per PET-97"* → **PET-100** (the HF-prereq predicate) in § 16 and the two test docstrings. **No `petasos/` runtime change ships.**

## What the gibson run verified
A real `LlamaFirewallScanner().scan()` of an injection string under Hermes's slots-only, non-`__weakref__` stdout returned `error is None` with a `petasos.llamafirewall.*` finding — no `cannot create weak reference` anywhere. This **confirms** (does not replace) the categorical mechanism reason: `llamafirewall` logs through stdlib `logging`, and `structlog` is absent from the `petasos[llamafirewall]` closure, so the `WRITE_LOCKS` weak-keyed crash class is impossible. Evidence: `docs/specs/TODO/PET-110.test-output.txt`.

## Files changed

| File | Change |
|------|--------|
| `docs/platform/hermes-desktop-footguns.md` | § 16 Residual → Settled line; `gibson per PET-97` → PET-100 citation |
| `tests/test_llama_firewall_wrapper.py` | Docstring prose only — PET-97 → PET-100 citation (module + class docstrings; class occurrence was line-wrapped) |
| `docs/specs/TODO/PET-110.test-output.txt` | New — gibson acceptance evidence (`1 passed`, online, model cached) |
| `docs/specs/TODO/PET-110.local-gate.txt` | New — ship-spec Phase 3 local gate capture |

## Test plan
- [x] **Acceptance (gibson, online, model-bearing — Hermes venv Python 3.11.14):** `...TestShieldUnderSlotsStdio::test_llamafirewall_scan_under_slots_stdio_completes` → **1 passed**, weakref-clean (evidence: `docs/specs/TODO/PET-110.test-output.txt`)
- [x] **Local sanity gate** `python -m pytest tests/test_llama_firewall_wrapper.py tests/test_llama_firewall_scanner.py -v --tb=short` → **43 passed, 14 skipped** (the slots-stdio + integration classes self-skip on the non-model interpreter) (full output: `docs/specs/TODO/PET-110.local-gate.txt`)
- [x] `ruff check .` → All checks passed · `ruff format --check .` → 110 files formatted · `mypy --strict .` → no issues
- [x] No `petasos/` runtime change — docstring prose + doc + evidence files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LlamaFirewall shield status documentation with verified test results confirming stability.

* **Tests**
  * Added test execution records documenting functionality verification and code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->