### PR TITLE
fix(pet-112): egress-scope the PII gate; stop blocking the agent's own local writes

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -23,6 +23,8 @@ import time
 import uuid
 from typing import Any
 
+from petasos._types import Severity  # PET-112: dep-light (enum + dataclasses, no ML imports)
+
 logger = logging.getLogger("petasos.plugin")
 
 # ---------------------------------------------------------------------------
@@ -87,6 +89,52 @@ READ_ONLY_TOOLS = frozenset(
 
 def _is_dangerous(tool_name: str) -> bool:
     return tool_name not in READ_ONLY_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# PET-112: ordinal severity gate + egress-sink classification
+# ---------------------------------------------------------------------------
+
+# Lower rank = worse — the established convention (four existing copies in
+# pipeline.py / presidio.py / alerting.py / formatting.py). A fifth copy in this
+# deployment artifact is preferable to importing a private name across the
+# package -> docs/deployment/ boundary.
+_SEVERITY_RANK: dict[Severity, int] = {
+    Severity.CRITICAL: 0,
+    Severity.HIGH: 1,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 3,
+    Severity.INFO: 4,
+}
+_BLOCK_RANK = _SEVERITY_RANK[Severity.HIGH]  # block at HIGH or worse (rank <= 1)
+
+
+def _blocks(severity: Severity) -> bool:
+    """Ordinal severity gate (replaces the broken lexicographic compare, PET-112 D-CAVEAT).
+
+    Unknown severities sort to 999 -> do not block, matching the _SEVERITY_RANK.get(..., 999)
+    idiom used across the package.
+    """
+    return _SEVERITY_RANK.get(severity, 999) <= _BLOCK_RANK
+
+
+def _worst(findings):
+    """Severity-first, confidence-tiebreak selection (PET-51 ordering).
+
+    Caller guarantees a non-empty sequence (only ever called inside an `if list:` guard),
+    so min() never raises on empty input.
+    """
+    return min(findings, key=lambda f: (_SEVERITY_RANK.get(f.severity, 999), -f.confidence))
+
+
+# Resolved in _deferred_init from config.egress_sink_tools; raw membership mirrors
+# _is_dangerous. Written once under _init_lock before _initialized flips; read lock-free in
+# _pre_tool_call (which only runs post-init). Atomic name rebind — no torn read under the GIL.
+_egress_sink_tools: frozenset[str] = frozenset()
+
+
+def _is_egress_sink(tool_name: str) -> bool:
+    return tool_name in _egress_sink_tools
 
 
 # ---------------------------------------------------------------------------
@@ -340,6 +388,18 @@ def _deferred_init() -> None:
                     "inactive (sub-agent hooks unavailable)"
                 )
 
+            # PET-112: publish the egress-sink set under the same happens-before as
+            # _pipeline/_guard (written before _initialized flips; read lock-free in the
+            # post-init hot path). The `global` is MANDATORY — without it the assignment
+            # binds a function-local and leaves the module frozenset empty forever,
+            # silently disabling egress PII blocking.
+            global _egress_sink_tools
+            _egress_sink_tools = frozenset(config.egress_sink_tools)
+            if not _egress_sink_tools:
+                logger.warning(
+                    "egress_sink_tools is empty — PII will not be blocked on any egress tool"
+                )
+
             scanner_names = [s.name for s in scanners]
             logger.info(
                 "Petasos initialized: scanners=%s, unavailable=%s, fail_mode=%s, host_id=%s",
@@ -435,10 +495,10 @@ def _fallback_pre_tool_call(
         param_text = json.dumps(args, default=str)[:100_000]
         result = _run_async(scanner.scan(param_text, direction="inbound"))
         if result.findings:
-            from petasos._types import Severity
-
-            worst = max(result.findings, key=lambda f: f.severity.value)
-            if worst.severity.value >= Severity.HIGH.value:
+            # PET-112: ordinal gate (a lone CRITICAL now blocks; MEDIUM/LOW no longer do).
+            # MinimalScanner emits no PII findings (syntactic only), so no egress logic here.
+            worst = _worst(result.findings)
+            if _blocks(worst.severity):
                 logger.warning(
                     "PETASOS_FALLBACK_BLOCK tool=%s — init in progress, syntactic scan found: %s",
                     tool_name,
@@ -527,33 +587,63 @@ def _pre_tool_call(
         )
         return {"action": "block", "message": result.reason}
 
-    if result.param_scan_unsafe and _is_dangerous(tool_name):
+    # PET-112: read-only tools never take a content block (both old blocks were
+    # _is_dangerous-gated; preserved exactly).
+    if not _is_dangerous(tool_name):
+        return None
+
+    egress = _is_egress_sink(tool_name)
+    # HIGH/CRITICAL only, via the ordinal gate (D-CAVEAT) — partitioned by finding type.
+    blocking = [f for f in result.findings if _blocks(f.severity)]
+    non_pii_blocking = [f for f in blocking if f.finding_type != "pii"]
+    pii_blocking = [f for f in blocking if f.finding_type == "pii"]
+
+    # 1. Scan degraded/unreliable -> block ALL dangerous tools (fail-mode; cannot trust the
+    #    scan). Independent of finding type, so a degraded scanner co-occurring with a PII
+    #    finding still blocks (D-DEGRADED, closes the degraded+PII hole).
+    if result.param_scan_degraded:
         logger.warning(
-            "PETASOS_QUARANTINE tool=%s session=%s — param scan unsafe on non-read-only tool",
+            "PETASOS_QUARANTINE tool=%s session=%s — param scan degraded",
             tool_name,
             session_id,
         )
         return {
             "action": "block",
-            "message": f"Parameter scan flagged unsafe content: {result.reason}",
+            "message": (
+                "Parameter scan unavailable (scanner degraded) — blocked by fail-mode policy."
+            ),
         }
 
-    if result.findings and _is_dangerous(tool_name):
-        from petasos._types import Severity
+    # 2. Non-PII finding (injection/command/structural/credential) at HIGH+ -> block ALL
+    #    dangerous tools (D3 posture; credentials are deliberately NOT egress-scoped).
+    if non_pii_blocking:
+        worst = _worst(non_pii_blocking)
+        logger.warning(
+            "PETASOS_QUARANTINE tool=%s session=%s — %s finding: %s",
+            tool_name,
+            session_id,
+            worst.severity.name,
+            worst.message,
+        )
+        return {
+            "action": "block",
+            "message": f"Parameter scan flagged unsafe content: {worst.message}",
+        }
 
-        worst = max(result.findings, key=lambda f: f.severity.value)
-        if worst.severity.value >= Severity.HIGH.value:
-            logger.warning(
-                "PETASOS_QUARANTINE tool=%s session=%s — %s finding: %s",
-                tool_name,
-                session_id,
-                worst.severity.name,
-                worst.message,
-            )
-            return {
-                "action": "block",
-                "message": (f"Security finding ({worst.severity.name}): {worst.message}"),
-            }
+    # 3. PII at HIGH+ -> block ONLY egress sinks (D-EGRESS). Internal tools are exempt, so
+    #    an agent's own local write/terminal/edit of PII is permitted.
+    if pii_blocking and egress:
+        worst = _worst(pii_blocking)
+        logger.warning(
+            "PETASOS_QUARANTINE tool=%s session=%s — PII to egress sink: %s",
+            tool_name,
+            session_id,
+            worst.message,
+        )
+        return {
+            "action": "block",
+            "message": f"Security finding (PII, {worst.severity.name}): {worst.message}",
+        }
 
     return None
 

--- a/docs/specs/TODO/PET-112.test-output.txt
+++ b/docs/specs/TODO/PET-112.test-output.txt
@@ -1,0 +1,26 @@
+PET-112 test gate — captured 2026-06-14T10:54:02Z
+Interpreter: Python 3.10.6  (deps-bearing local interpreter)
+
+=== Local gate (spec ## Test command) ===
+$ python -m pytest tests/test_reference_plugin_egress.py tests/test_config.py \
+    tests/test_config_meta.py tests/test_guard.py tests/test_subagent_plugin_wiring.py \
+    tests/test_plugin_init_logging.py tests/test_plugin_api_paths.py -q
+
+........................................................................ [ 37%]
+........................................................................ [ 74%]
+..................................................                       [100%]
+194 passed in 0.55s
+
+=== Full pre-PR gate (Done-when) ===
+$ python -m pytest -q --deselect "tests/test_console_validation.py::test_default_ignorable_rejected"
+  (deselect = pre-existing Unicode-13-vs-14 local failure, unrelated to PET-112)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1543 passed, 40 skipped, 1 deselected, 1 xfailed, 68 warnings in 25.95s
+
+$ ruff check .
+All checks passed!
+$ ruff format --check .
+115 files already formatted
+$ mypy --strict .
+Success: no issues found in 115 source files

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -155,6 +155,19 @@ class PetasosConfig:
     # Tool names treated as delegation spawns. Stored RAW here; the guard
     # normalizes them through its own _normalize_tool_name at construction.
     delegate_tool_names: tuple[str, ...] = ("delegate_task",)
+    # Tool names treated as egress sinks (outbound content: email/social/HTTP/webhook/
+    # clipboard-out). The PII-finding block applies ONLY to these tools; internal tools
+    # (write_file/terminal/execute_code/edit) are exempt. Stored RAW; matched raw by the
+    # plugin, mirroring READ_ONLY_TOOLS/_is_dangerous. Best-effort default names — operators
+    # must align to their host's tool registry (frontend-bindable, PET-112).
+    egress_sink_tools: tuple[str, ...] = (
+        "send_email",
+        "send_message",
+        "post_social",
+        "http_request",
+        "send_webhook",
+        "clipboard_write",
+    )
 
     def __post_init__(self) -> None:
         for fname in _BOOL_FIELDS:
@@ -390,6 +403,29 @@ class PetasosConfig:
                 raise ValueError(
                     f"delegate_tool_names entries must be non-empty strings, got {tool_name!r}"
                 )
+        # egress_sink_tools (PET-112): RAW tool names matched by the plugin's
+        # _is_egress_sink. Mirrors the delegate_tool_names template — bare-str reject
+        # (tuple("send_email") would char-explode and silently empty the set),
+        # list→tuple coerce, per-entry non-empty check — but an EMPTY tuple is allowed
+        # (an operator may disable egress PII blocking entirely; the plugin warns).
+        if isinstance(self.egress_sink_tools, str):
+            raise ValueError(
+                "egress_sink_tools must be an iterable of tool names, not a string, "
+                f"got {self.egress_sink_tools!r}"
+            )
+        if not isinstance(self.egress_sink_tools, tuple):
+            try:
+                object.__setattr__(self, "egress_sink_tools", tuple(self.egress_sink_tools))
+            except TypeError as exc:
+                raise ValueError(
+                    f"egress_sink_tools must be an iterable of non-empty strings, "
+                    f"got {self.egress_sink_tools!r}"
+                ) from exc
+        for tool_name in self.egress_sink_tools:
+            if not isinstance(tool_name, str) or not tool_name:
+                raise ValueError(
+                    f"egress_sink_tools entries must be non-empty strings, got {tool_name!r}"
+                )
         if self.frequency_weights is not None:
             for k, v in self.frequency_weights.items():
                 if not isinstance(k, str) or not k:
@@ -571,6 +607,8 @@ class PetasosConfig:
             filtered["pii_entities"] = tuple(filtered["pii_entities"])
         if "delegate_tool_names" in filtered and isinstance(filtered["delegate_tool_names"], list):
             filtered["delegate_tool_names"] = tuple(filtered["delegate_tool_names"])
+        if "egress_sink_tools" in filtered and isinstance(filtered["egress_sink_tools"], list):
+            filtered["egress_sink_tools"] = tuple(filtered["egress_sink_tools"])
         # PET-109: coerce only when a list — preserve None so the None round-trip holds.
         if "presidio_entities" in filtered and isinstance(filtered["presidio_entities"], list):
             filtered["presidio_entities"] = tuple(filtered["presidio_entities"])

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -627,6 +627,17 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         ),
         "section": "tool_guard",
     },
+    "egress_sink_tools": {
+        "description": "Tool names treated as egress sinks; the PII block applies only to these.",
+        "help_plain": (
+            "The tools that send content OUT of the machine — email, social posts, external"
+            " web requests, webhooks, clipboard. Detected personal data (cards, SSNs, emails)"
+            " is blocked only when an agent tries to send it through one of these. Writing to"
+            " local files or the terminal is never blocked for personal data. Set these to your"
+            " host's actual outbound tool names."
+        ),
+        "section": "tool_guard",
+    },
 }
 
 _EXCLUDED_FIELDS = frozenset({"session_secret"})

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -51,6 +51,13 @@ class GuardResult:
     findings: tuple[ScanFinding, ...]
     tier: str
     param_scan_unsafe: bool
+    # PET-112: True iff the param scan flipped unsafe AND a scanner errored, i.e. the
+    # unsafe verdict is degraded-mode driven rather than finding-driven. Lets the plugin
+    # honor the "ML failure blocks content" invariant independently of finding type
+    # (degraded co-occurring with PII still blocks). Last + defaulted so every existing
+    # construction stays valid. fail-mode-correct: gates on `not result.safe`, so
+    # fail_mode="open" (scanner error doesn't flip safe) yields False → no block.
+    param_scan_degraded: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -59,6 +66,7 @@ class GuardResult:
             "findings": [f.to_dict() for f in self.findings],
             "tier": self.tier,
             "param_scan_unsafe": self.param_scan_unsafe,
+            "param_scan_degraded": self.param_scan_degraded,
         }
 
 
@@ -227,17 +235,22 @@ class ToolCallGuard:
                     tier=tier,
                     param_scan_unsafe=False,
                 )
-            findings, param_scan_unsafe = await self._scan_params(tool_params, session_id)
+            findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
+                tool_params, session_id
+            )
             return GuardResult(
                 allowed=True,
                 reason="exempt-with-scan",
                 findings=findings,
                 tier=tier,
                 param_scan_unsafe=param_scan_unsafe,
+                param_scan_degraded=param_scan_degraded,
             )
 
         # Step 5: Scan params
-        findings, param_scan_unsafe = await self._scan_params(tool_params, session_id)
+        findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
+            tool_params, session_id
+        )
 
         # Step 6: Tier 2 → block
         if tier == "tier2":
@@ -247,6 +260,7 @@ class ToolCallGuard:
                 findings=findings,
                 tier="tier2",
                 param_scan_unsafe=param_scan_unsafe,
+                param_scan_degraded=param_scan_degraded,
             )
 
         # Step 7: Tier 1 with unsafe → warn
@@ -257,6 +271,7 @@ class ToolCallGuard:
                 findings=findings,
                 tier="tier1",
                 param_scan_unsafe=param_scan_unsafe,
+                param_scan_degraded=param_scan_degraded,
             )
 
         # Step 8: Clean / no tier → allow
@@ -266,6 +281,7 @@ class ToolCallGuard:
             findings=findings,
             tier=tier,
             param_scan_unsafe=param_scan_unsafe,
+            param_scan_degraded=param_scan_degraded,
         )
 
     def _normalize_tool_name(self, tool_name: str) -> str:
@@ -369,10 +385,16 @@ class ToolCallGuard:
         self,
         tool_params: dict[str, Any],
         session_id: str,
-    ) -> tuple[tuple[ScanFinding, ...], bool]:
+    ) -> tuple[tuple[ScanFinding, ...], bool, bool]:
+        # PET-112: returns (findings, param_scan_unsafe, param_scan_degraded). The third
+        # element is True only when the unsafe verdict co-occurs with a scanner error
+        # (degraded-mode), so the plugin can block on degradation regardless of finding
+        # type. The two error early-returns force degraded=True regardless of fail_mode —
+        # a deliberate fail-safe on guard-internal/hook failure; the fail-mode-correct
+        # `not result.safe` gate applies to the normal finding-driven path only.
         try:
             if not tool_params:
-                return (), False
+                return (), False, False
 
             parts: list[str] = []
             for value in tool_params.values():
@@ -385,7 +407,7 @@ class ToolCallGuard:
 
             param_text = "\n".join(parts)
             if not param_text:
-                return (), False
+                return (), False, False
 
             if len(param_text) > _MAX_PARAM_TEXT_LEN:
                 _logger.warning(
@@ -405,11 +427,13 @@ class ToolCallGuard:
                     "param scan errored without findings, marking unsafe; error_count=%d",
                     len(result.errors),
                 )
-                return (), True
+                return (), True, True
 
             param_scan_unsafe = not result.safe
+            scanner_errored = any(r.error is not None for r in result.scanner_results)
+            param_scan_degraded = param_scan_unsafe and scanner_errored
             findings = result.findings
-            return findings, param_scan_unsafe
+            return findings, param_scan_unsafe, param_scan_degraded
         except Exception:
             _logger.exception("_scan_params failed unexpectedly, marking unsafe")
-            return (), True
+            return (), True, True

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -533,7 +533,7 @@ class TestScanParamsCatchAll:
     async def test_scan_params_exception_returns_unsafe(
         self, valid_key: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """_scan_params catch-all: Pipeline.inspect raising returns ((), True)."""
+        """_scan_params catch-all: Pipeline.inspect raising returns ((), True, True)."""
         cfg = _cfg()
         pipe = Pipeline(config=cfg)
         pipe.activate(valid_key)

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -1,0 +1,475 @@
+"""PET-112: egress-scoped PII enforcement in the reference plugin.
+
+Covers the tool-class x finding-type x severity x degraded matrix for
+``_pre_tool_call`` / ``_fallback_pre_tool_call``, the ``param_scan_degraded``
+guard signal, and the ``egress_sink_tools`` config wiring. Backend-free — no
+Presidio / no ML pipeline; the guard is stubbed and the pipeline's ``inspect``
+is monkeypatched to return crafted results.
+
+Regression for PET-112: an agent's own internal write/terminal/edit of PII must
+not be hard-blocked; outbound secrets through egress sinks still are.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from petasos import (
+    FrequencyTracker,
+    GuardResult,
+    PetasosConfig,
+    Pipeline,
+    PipelineResult,
+    ScanFinding,
+    ScanResult,
+    Severity,
+    ToolCallGuard,
+)
+
+if TYPE_CHECKING:
+    import types
+
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+# A small egress set for the enforcement tests — distinct from the config default
+# so the tests pin behavior on membership, not on the default names.
+_EGRESS = frozenset({"send_email", "http_request", "clipboard_write"})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PETASOS_LICENSE_KEY", "PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet112", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Finding + GuardResult builders
+# ---------------------------------------------------------------------------
+
+
+def _pii(severity: Severity, *, confidence: float = 0.9) -> ScanFinding:
+    return ScanFinding(
+        rule_id="petasos.presidio.person",
+        finding_type="pii",
+        severity=severity,
+        confidence=confidence,
+        message=f"PII detected: PERSON ({severity.name})",
+        scanner_name="presidio",
+    )
+
+
+def _non_pii(finding_type: str, severity: Severity = Severity.HIGH) -> ScanFinding:
+    return ScanFinding(
+        rule_id=f"petasos.{finding_type or 'unknown'}.x",
+        finding_type=finding_type,
+        severity=severity,
+        confidence=0.9,
+        message=f"{finding_type or 'untyped'} finding",
+        scanner_name="minimal",
+    )
+
+
+def _guard_result(
+    *,
+    findings: tuple[ScanFinding, ...] = (),
+    tier: str = "none",
+    allowed: bool = True,
+    reason: str = "allowed",
+    param_scan_unsafe: bool = False,
+    param_scan_degraded: bool = False,
+) -> GuardResult:
+    return GuardResult(
+        allowed=allowed,
+        reason=reason,
+        findings=findings,
+        tier=tier,
+        param_scan_unsafe=param_scan_unsafe,
+        param_scan_degraded=param_scan_degraded,
+    )
+
+
+def _drive(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    guard_result: GuardResult,
+    *,
+    egress: frozenset[str] = _EGRESS,
+    args: dict[str, object] | None = None,
+) -> Any:
+    """Drive ``_pre_tool_call`` against a crafted GuardResult on a freshly imported,
+    post-init, armed plugin module. Returns the block dict or None."""
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_egress_sink_tools", egress)
+    stub_guard = type("G", (), {"evaluate": lambda self, *a, **k: None})()
+    monkeypatch.setattr(ref, "_guard", stub_guard)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: guard_result)
+    return ref._pre_tool_call(tool_name, args or {"text": "x"}, task_id="s1")
+
+
+# ---------------------------------------------------------------------------
+# PII gate: internal tools exempt, egress sinks enforced
+# ---------------------------------------------------------------------------
+
+
+def test_pii_finding_does_not_block_internal_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The literal regression (MEDIUM) plus the live post-PET-109 friction (HIGH/CRITICAL):
+    # a PII finding on an internal tool never blocks.
+    for tool in ("write_file", "terminal", "execute_code"):
+        for sev in (Severity.MEDIUM, Severity.HIGH, Severity.CRITICAL):
+            unsafe = sev in (Severity.HIGH, Severity.CRITICAL)
+            gr = _guard_result(findings=(_pii(sev),), param_scan_unsafe=unsafe)
+            assert _drive(monkeypatch, tool, gr) is None, f"{tool}/{sev.name} should not block"
+
+
+def test_pii_finding_blocks_egress_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    out = _drive(
+        monkeypatch,
+        "send_email",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+    )
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("Security finding (PII, CRITICAL)")
+
+    out_high = _drive(
+        monkeypatch,
+        "http_request",
+        _guard_result(findings=(_pii(Severity.HIGH),), param_scan_unsafe=True),
+    )
+    assert out_high is not None and out_high["action"] == "block"
+    assert out_high["message"].startswith("Security finding (PII, HIGH)")
+
+
+# ---------------------------------------------------------------------------
+# Non-PII finding types block all dangerous tools (D3 / D-EGRESS partition)
+# ---------------------------------------------------------------------------
+
+
+def test_injection_still_blocks_all_dangerous_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    for tool in ("write_file", "terminal", "send_email"):
+        gr = _guard_result(
+            findings=(_non_pii("injection", Severity.HIGH),), param_scan_unsafe=True
+        )
+        out = _drive(monkeypatch, tool, gr)
+        assert out is not None and out["action"] == "block", f"{tool} should block injection"
+        assert out["message"].startswith("Parameter scan flagged unsafe content")
+
+
+def test_non_pii_types_block_all_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Locks the `finding_type != "pii"` partition across the full non-PII space, including
+    # llm-guard `credential` and an empty finding_type (which also proves no crash).
+    for ftype in ("command", "credential", ""):
+        gr = _guard_result(findings=(_non_pii(ftype, Severity.HIGH),), param_scan_unsafe=True)
+        out = _drive(monkeypatch, "write_file", gr)
+        assert out is not None and out["action"] == "block", f"finding_type={ftype!r} should block"
+        assert out["message"].startswith("Parameter scan flagged unsafe content")
+
+
+# ---------------------------------------------------------------------------
+# Ordinal severity gate (D-CAVEAT) at both plugin sites
+# ---------------------------------------------------------------------------
+
+
+def test_block_threshold_pinned(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolate the ordinal gate on an egress tool so egress-scoping doesn't mask it.
+    for sev in (Severity.MEDIUM, Severity.LOW, Severity.INFO):
+        gr = _guard_result(findings=(_pii(sev),))
+        assert _drive(monkeypatch, "send_email", gr) is None, f"{sev.name} must not block"
+    for sev in (Severity.HIGH, Severity.CRITICAL):
+        gr = _guard_result(findings=(_pii(sev),), param_scan_unsafe=True)
+        out = _drive(monkeypatch, "send_email", gr)
+        assert out is not None and out["action"] == "block", f"{sev.name} must block"
+
+    # Lone CRITICAL non-PII on an internal tool → blocked (closes the inverted-comparison hole
+    # where the old lexicographic compare let a lone CRITICAL through).
+    out_crit = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(
+            findings=(_non_pii("injection", Severity.CRITICAL),), param_scan_unsafe=True
+        ),
+    )
+    assert out_crit is not None and out_crit["action"] == "block"
+
+
+def test_fallback_ordinal_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+
+    def _make_scanner(finding: ScanFinding | None) -> object:
+        class _Stub:
+            name = "minimal"
+
+            async def scan(
+                self, text: str, *, direction: str = "inbound", session_id: str | None = None
+            ) -> ScanResult:
+                return ScanResult(scanner_name="minimal", findings=(finding,) if finding else ())
+
+        return _Stub()
+
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+
+    # Lone CRITICAL syntactic finding → blocked.
+    crit_scanner = _make_scanner(_non_pii("injection", Severity.CRITICAL))
+    monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: crit_scanner)
+    out = ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1")
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("Security scan (init in progress)")
+
+    # MEDIUM finding → no block (ordinal gate).
+    med_scanner = _make_scanner(_non_pii("injection", Severity.MEDIUM))
+    monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: med_scanner)
+    assert ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1") is None
+
+
+# ---------------------------------------------------------------------------
+# Robustness: unknown severity, empty findings
+# ---------------------------------------------------------------------------
+
+
+class _UnknownSeverity:
+    name = "UNKNOWN"
+    value = "unknown"
+
+
+def test_unknown_severity_and_empty_findings_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    unknown = ScanFinding(
+        rule_id="x",
+        finding_type="pii",
+        severity=cast("Severity", _UnknownSeverity()),
+        confidence=0.9,
+        message="weird",
+        scanner_name="presidio",
+    )
+    # Unknown severity sorts to 999 → never blocks, on internal and egress tools, no crash.
+    for tool in ("write_file", "send_email"):
+        gr = _guard_result(findings=(unknown,), param_scan_unsafe=True)
+        assert _drive(monkeypatch, tool, gr) is None, f"unknown severity must not block on {tool}"
+
+    # Empty findings + not degraded → None (proves _worst/min is never reached empty).
+    assert _drive(monkeypatch, "write_file", _guard_result(findings=())) is None
+
+
+# ---------------------------------------------------------------------------
+# Degraded-mode blocking (D-DEGRADED) — independent of finding type
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_blocks_internal_even_with_pii(monkeypatch: pytest.MonkeyPatch) -> None:
+    # (a) internal tool, degraded, no findings → block (fail-mode policy).
+    out_a = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(param_scan_unsafe=True, param_scan_degraded=True),
+    )
+    assert out_a is not None and out_a["action"] == "block"
+    assert "degraded" in out_a["message"].lower()
+
+    # (b) internal tool, degraded + HIGH/CRITICAL PII → block (degraded wins over egress-scoping).
+    out_b = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(
+            findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True, param_scan_degraded=True
+        ),
+    )
+    assert out_b is not None and out_b["action"] == "block"
+    assert "degraded" in out_b["message"].lower()
+
+    # (c) not degraded, only HIGH PII on internal → allowed (degraded did not fire).
+    out_c = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(findings=(_pii(Severity.HIGH),), param_scan_unsafe=True),
+    )
+    assert out_c is None
+
+
+# ---------------------------------------------------------------------------
+# Read-only + escalation paths unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_tool_never_content_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    out_pii = _drive(
+        monkeypatch,
+        "read_file",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+    )
+    assert out_pii is None
+    out_degraded = _drive(
+        monkeypatch,
+        "read_file",
+        _guard_result(param_scan_unsafe=True, param_scan_degraded=True),
+    )
+    assert out_degraded is None
+
+
+def test_tier3_and_not_allowed_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # tier3 is checked before _is_dangerous: even a read-only tool is blocked (proves the
+    # new read-only early return does not shadow the escalation blocks).
+    out_t3 = _drive(
+        monkeypatch,
+        "read_file",
+        _guard_result(tier="tier3", allowed=False, reason="session terminated (tier3)"),
+    )
+    assert out_t3 is not None and out_t3["action"] == "block"
+    assert "Tier 3" in out_t3["message"]
+
+    out_blocked = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(allowed=False, reason="tier2: tool calls blocked"),
+    )
+    assert out_blocked is not None and out_blocked["action"] == "block"
+    assert out_blocked["message"] == "tier2: tool calls blocked"
+
+
+# ---------------------------------------------------------------------------
+# egress_sink_tools config field
+# ---------------------------------------------------------------------------
+
+
+def test_egress_classification_config_roundtrip() -> None:
+    cfg = PetasosConfig()
+    assert isinstance(cfg.egress_sink_tools, tuple)
+    assert len(cfg.egress_sink_tools) > 0  # frozen non-empty default
+
+    # to_dict emits a list; from_dict coerces back to a tuple.
+    d = cfg.to_dict()
+    assert isinstance(d["egress_sink_tools"], list)
+    assert PetasosConfig.from_dict(d).egress_sink_tools == cfg.egress_sink_tools
+
+    # Empty tuple is accepted and round-trips.
+    empty = PetasosConfig(egress_sink_tools=())
+    assert empty.egress_sink_tools == ()
+    assert PetasosConfig.from_dict(empty.to_dict()).egress_sink_tools == ()
+
+    # Bare string is rejected (would char-explode into a per-character set).
+    with pytest.raises(ValueError):
+        PetasosConfig(egress_sink_tools="send_email")  # type: ignore[arg-type]
+    # Per-entry validation.
+    with pytest.raises(ValueError):
+        PetasosConfig(egress_sink_tools=("",))
+    with pytest.raises(ValueError):
+        PetasosConfig(egress_sink_tools=(1,))  # type: ignore[arg-type]
+
+
+def test_egress_from_dict_ingestion() -> None:
+    cfg = PetasosConfig.from_dict({"egress_sink_tools": ["send_email"]})
+    assert cfg.egress_sink_tools == ("send_email",)
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict({"egress_sink_tools": "send_email"})
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict({"egress_sink_tools": ["a", ""]})
+
+
+def _prep_init(mod: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_initialized", False)
+    monkeypatch.setattr(mod, "_init_error", None)
+    monkeypatch.setattr(mod, "_pipeline", None)
+    monkeypatch.setattr(mod, "_guard", None)
+
+
+def test_deferred_init_populates_egress_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Live from_dict path: _config is the raw dict, not a tuple kwarg.
+    ref = _import_reference_plugin()
+    _prep_init(ref, monkeypatch)
+    monkeypatch.setattr(ref, "_config", {"egress_sink_tools": ["send_email"]})
+    ref._deferred_init()
+    assert ref._egress_sink_tools == frozenset({"send_email"})
+
+    # Default config → the non-empty default set (catches the F-4 global-shadow bug).
+    ref2 = _import_reference_plugin()
+    _prep_init(ref2, monkeypatch)
+    monkeypatch.setattr(ref2, "_config", {})
+    ref2._deferred_init()
+    assert ref2._egress_sink_tools == frozenset(PetasosConfig().egress_sink_tools)
+    assert len(ref2._egress_sink_tools) > 0
+
+
+# ---------------------------------------------------------------------------
+# Guard surfaces param_scan_degraded
+# ---------------------------------------------------------------------------
+
+
+def _guard_with(monkeypatch: pytest.MonkeyPatch, result: PipelineResult) -> ToolCallGuard:
+    """Real Pipeline with inspect monkeypatched to a crafted result (backend-free)."""
+    cfg = PetasosConfig()
+    pipe = Pipeline(config=cfg)
+
+    async def _fake_inspect(
+        text: str, *, direction: str = "inbound", session_id: str | None = None
+    ) -> PipelineResult:
+        return result
+
+    monkeypatch.setattr(pipe, "inspect", _fake_inspect)
+    return ToolCallGuard(pipe, FrequencyTracker(cfg), cfg)
+
+
+async def test_guard_surfaces_param_scan_degraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # (i) default + to_dict carries the additive key.
+    gr = GuardResult(allowed=True, reason="ok", findings=(), tier="none", param_scan_unsafe=False)
+    assert gr.param_scan_degraded is False
+    assert gr.to_dict()["param_scan_degraded"] is False
+
+    high = _non_pii("injection", Severity.HIGH)
+
+    # (ii) safe=False + a scanner error (no findings) → degraded True.
+    _f, unsafe, degraded = await _guard_with(
+        monkeypatch,
+        PipelineResult(
+            safe=False, findings=(), scanner_results=(ScanResult("llm_guard", (), error="boom"),)
+        ),
+    )._scan_params({"a": "x"}, "s1")
+    assert unsafe is True and degraded is True
+
+    # (iii) safe=False, finding-driven (no scanner error) → degraded False.
+    _f, unsafe, degraded = await _guard_with(
+        monkeypatch,
+        PipelineResult(
+            safe=False, findings=(high,), scanner_results=(ScanResult("presidio", (high,)),)
+        ),
+    )._scan_params({"a": "x"}, "s1")
+    assert unsafe is True and degraded is False
+
+    # (iv) fail_mode="open" arm: safe=True + scanner error → degraded False (no block).
+    _f, unsafe, degraded = await _guard_with(
+        monkeypatch,
+        PipelineResult(
+            safe=True, findings=(), scanner_results=(ScanResult("llm_guard", (), error="boom"),)
+        ),
+    )._scan_params({"a": "x"}, "s1")
+    assert unsafe is False and degraded is False
+
+    # (v) syntactic-only (minimal-only, ml_total==0) degraded → degraded True.
+    _f, unsafe, degraded = await _guard_with(
+        monkeypatch,
+        PipelineResult(
+            safe=False, findings=(), scanner_results=(ScanResult("minimal", (), error="boom"),)
+        ),
+    )._scan_params({"a": "x"}, "s1")
+    assert unsafe is True and degraded is True


### PR DESCRIPTION
## Summary
- Scope the tool-call guard's PII block to **egress sinks** (email/social/HTTP/webhook/clipboard-out): an agent's own internal `write_file`/`terminal`/`execute_code`/`edit` of PII is no longer hard-blocked, while cards/SSNs/emails sent through an egress tool still are.
- Keep **injection / command / structural / credential** findings and **degraded-mode** blocking on *all* dangerous tools, regardless of finding type (degraded co-occurring with PII still blocks).
- Fix the severity gate: a broken lexicographic string compare (`"medium" > "critical"`; `"critical" >= "high"` is False) is replaced with an **ordinal** gate at both plugin sites, so MEDIUM/LOW/INFO never block, HIGH/CRITICAL do, and a **lone CRITICAL** finally blocks.

## Layered defense (post-restructure `_pre_tool_call`)
`tier3` → `not allowed` (escalation, unchanged) → read-only early return → then, on dangerous tools only:
1. `param_scan_degraded` → block **all** dangerous tools (fail-mode; can't trust the scan).
2. non-PII HIGH+ (`finding_type != "pii"`) → block **all** dangerous tools (D3; credentials deliberately not egress-scoped).
3. PII HIGH+ (`finding_type == "pii"`) → block **only** egress sinks; internal tools exempt.

`param_scan_degraded` is a new `GuardResult` signal (`= not safe AND any scanner errored`) — fail-mode-correct, so `fail_mode="open"` (scanner error doesn't flip `safe`) does not block.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/__init__.py` | Restructures `_pre_tool_call` content-block into the partitioned/egress-scoped logic; ordinal gate (`_SEVERITY_RANK`/`_blocks`/`_worst`) at the main + fallback sites; `_is_egress_sink` + `_egress_sink_tools` populated in `_deferred_init`; hoists `Severity` import |
| `petasos/session/guard.py` | Adds `param_scan_degraded` to `GuardResult` (+`to_dict`); `_scan_params` returns the triple; threads it through `evaluate` |
| `petasos/config.py` | New frozen `egress_sink_tools` field + `__post_init__` validation (bare-str reject, per-entry check, empty allowed) + `from_dict` list→tuple coercion |
| `petasos/console/_config_meta.py` | Frontend-bindable `_FIELD_META` entry for `egress_sink_tools` |
| `tests/test_reference_plugin_egress.py` | New: tool-class × finding-type × severity × degraded matrix, config round-trip, `_deferred_init` wiring, guard `param_scan_degraded` arms (backend-free) |
| `tests/test_guard.py` | Stale docstring `((), True)` → `((), True, True)` |

## Test plan
- [x] `python -m pytest tests/test_reference_plugin_egress.py tests/test_config.py tests/test_config_meta.py tests/test_guard.py tests/test_subagent_plugin_wiring.py tests/test_plugin_init_logging.py tests/test_plugin_api_paths.py -q` — 194/194 pass (full output: `docs/specs/TODO/PET-112.test-output.txt`)
- [x] `python -m pytest -q` — 1543 passed, 40 skipped, 1 xfailed (1 deselected = pre-existing Unicode-13-vs-14 local failure, unrelated)
- [x] `ruff check .`, `ruff format --check .`, `mypy --strict .` — clean

**Operator action (non-merge-gating):** the default `egress_sink_tools` names are best-effort and must be reconciled to the deployed Hermes build's actual outbound tool registry (or overridden in `config.yaml`) — misnamed defaults silently leave PII unblocked on real egress tools. Recorded in the field's `help_plain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `egress_sink_tools` configuration to control which tools receive PII-specific blocking.
  * Updated reference plugin blocking to use ordinal severity gating with tiered decisions and improved fallback behavior.

* **Bug Fixes**
  * Refined enforcement so PII findings block only configured egress sink tools, while read-only tools follow the new non-blocking rules.

* **Documentation**
  * Updated configuration editor help/metadata for `egress_sink_tools`.

* **Tests**
  * Added extensive coverage for egress-scoped PII enforcement, ordinal/degraded-mode behavior, and guard result propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->