### PR TITLE
feat(pet-114): collapsible, grouped config sections with section metadata

### DIFF
--- a/docs/specs/TODO/PET-114.test-output.txt
+++ b/docs/specs/TODO/PET-114.test-output.txt
@@ -1,0 +1,70 @@
+### PET-114 test command output (2026-06-14T11:01:08Z)
+
+=== python -m pytest tests/test_config_meta.py tests/test_console_handlers.py -v --tb=short ===
+tests/test_console_handlers.py::test_metadata_endpoint_carries_help_plain PASSED [ 37%]
+tests/test_console_handlers.py::test_get_config_redacts_secrets PASSED   [ 38%]
+tests/test_console_handlers.py::test_update_config_valid PASSED          [ 40%]
+tests/test_console_handlers.py::test_update_config_invalid PASSED        [ 42%]
+tests/test_console_handlers.py::test_run_scan PASSED                     [ 44%]
+tests/test_console_handlers.py::test_run_scan_with_injection PASSED      [ 45%]
+tests/test_console_handlers.py::test_get_health PASSED                   [ 47%]
+tests/test_console_handlers.py::test_get_scan_history_empty PASSED       [ 49%]
+tests/test_console_handlers.py::test_get_scan_history_after_scan PASSED  [ 50%]
+tests/test_console_handlers.py::test_get_profiles PASSED                 [ 52%]
+tests/test_console_handlers.py::test_get_about PASSED                    [ 54%]
+tests/test_console_handlers.py::test_scan_history_limit PASSED           [ 55%]
+tests/test_console_handlers.py::test_pipeline_scanner_health PASSED      [ 57%]
+tests/test_console_handlers.py::test_pipeline_list_profiles PASSED       [ 59%]
+tests/test_console_handlers.py::test_pipeline_result_to_dict PASSED      [ 61%]
+tests/test_console_handlers.py::test_config_persist_writes_yaml PASSED   [ 62%]
+tests/test_console_handlers.py::test_config_persist_preserves_enabled_and_host_id PASSED [ 64%]
+tests/test_console_handlers.py::test_get_armed_reflects_read PASSED      [ 66%]
+tests/test_console_handlers.py::test_set_armed_persists PASSED           [ 67%]
+tests/test_console_handlers.py::test_set_armed_persist_failure PASSED    [ 69%]
+tests/test_console_handlers.py::test_health_surfaces_scan_errors PASSED  [ 71%]
+tests/test_console_handlers.py::test_health_unavailable_status PASSED    [ 72%]
+tests/test_console_handlers.py::test_health_recovery_to_healthy PASSED   [ 74%]
+tests/test_console_handlers.py::test_health_unavailable_wins_over_breaker PASSED [ 76%]
+tests/test_console_handlers.py::test_minimal_never_unavailable PASSED    [ 77%]
+tests/test_console_handlers.py::test_health_has_last_error_field PASSED  [ 79%]
+tests/test_console_handlers.py::test_idle_recovery_transition PASSED     [ 81%]
+tests/test_console_handlers.py::test_health_load_failed_distinct_from_unavailable PASSED [ 83%]
+tests/test_console_handlers.py::test_health_unavailable_means_absent PASSED [ 84%]
+tests/test_console_handlers.py::test_health_unavailable_legacy_2tuple PASSED [ 86%]
+tests/test_console_handlers.py::test_health_retryable_load_failure_is_degraded PASSED [ 88%]
+tests/test_console_handlers.py::test_health_error_last_error_is_crash_reason PASSED [ 89%]
+tests/test_console_handlers.py::test_availability_returns_cause_discriminator PASSED [ 91%]
+tests/test_console_handlers.py::test_health_not_healthy_under_pending_weakref_failure PASSED [ 93%]
+tests/test_console_handlers.py::test_health_returns_healthy_after_recovery PASSED [ 94%]
+tests/test_console_handlers.py::test_scanner_health_no_attributeerror_on_sibling_ml PASSED [ 96%]
+tests/test_console_handlers.py::test_scan_summary_carries_tile_contract PASSED [ 98%]
+tests/test_console_handlers.py::test_scan_summary_session_id_present_when_omitted PASSED [100%]
+
+============================= 59 passed in 0.37s ==============================
+
+=== node --test tests/js/config-sections.test.mjs ===
+✔ loader: petasos.js exports the PET-114 surfaces (0.4637ms)
+✔ groupConfigSections: registry order + labels + booleans (0.6266ms)
+✔ groupConfigSections: default_collapsed is coerced to a real boolean (0.0755ms)
+✔ groupConfigSections: skips registry sections with no fields (0.1131ms)
+✔ groupConfigSections: unknown-section field is a trailing expanded group (0.1104ms)
+✔ groupConfigSections: stale-backend fallback (no sections) (0.1201ms)
+✔ groupConfigSections: empty/non-array fields return [] (0.0696ms)
+✔ Pet.Panel collapsible: structure (collapsed) (0.4701ms)
+✔ Pet.Panel collapsible: structure (expanded) (0.1428ms)
+✔ Pet.Panel collapsible: click toggles live state + aria + onToggle (0.6133ms)
+✔ Pet.Panel collapsible: Enter key toggles (0.1323ms)
+✔ Pet.Panel collapsible: Space key toggles (0.1103ms)
+✔ Pet.Panel collapsible: other keys do not toggle (0.0774ms)
+✔ Pet.Panel collapsible: petSetCollapsed expands without firing onToggle (0.0669ms)
+✔ Pet.Panel non-collapsible: unchanged (regression guard) (0.0801ms)
+✔ revealFieldSections: expands the owning section of an errored field (0.1187ms)
+✔ revealFieldSections: unknown / missing-panel field is a safe no-op (0.111ms)
+ℹ tests 17
+ℹ suites 0
+ℹ pass 17
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 49.8051

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -643,6 +643,117 @@ _FIELD_META: dict[str, dict[str, Any]] = {
 _EXCLUDED_FIELDS = frozenset({"session_secret"})
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class ConfigSection:
+    """Display metadata for one Config Editor section group."""
+
+    key: str  # matches the per-field `section` value
+    label: str  # human-readable group title
+    description: str  # one-line group summary
+    default_collapsed: bool
+
+
+# Ordered tuple — tuple position IS the canonical render order.
+# Common controls first/open (PET-114 D3), advanced groups after, collapsed.
+# The 11 keys are exactly the in-use `section` values on the _FIELD_META fields.
+# The "unknown" missing-metadata sentinel is deliberately NOT a registry entry:
+# a field that ever synthesizes section="unknown" is rendered by the frontend's
+# trailing-group fallback (and the exact-coverage test points the fix at the
+# _FIELD_META gap, not here).
+_SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
+    ConfigSection(
+        "profiles",
+        "Profiles",
+        "Pick a preset tuning bundle that adjusts rule sensitivity and tool"
+        " permissions for a use case.",
+        default_collapsed=False,
+    ),
+    ConfigSection(
+        "anonymization",
+        "PII / Anonymization",
+        "Hide personal information the scanners detect before it travels further.",
+        default_collapsed=False,
+    ),
+    ConfigSection(
+        "fail_mode",
+        "Fail Mode",
+        "Decide what happens to content when a scanner breaks or times out mid-scan.",
+        default_collapsed=False,
+    ),
+    ConfigSection(
+        "tool_guard",
+        "Tool Call Guard",
+        "Inspect the agent's tool calls and rate-limit sub-agent spawns before they run.",
+        default_collapsed=False,
+    ),
+    ConfigSection(
+        "scanning",
+        "Scanning",
+        "Core scan behavior: direction, scanner timeouts, circuit breakers, and"
+        " PII detection scope.",
+        default_collapsed=False,
+    ),
+    ConfigSection(
+        "normalization",
+        "Normalization",
+        "Clean up disguised text (homoglyphs, zero-width, leetspeak, encoded blobs)"
+        " before scanning.",
+        default_collapsed=True,
+    ),
+    ConfigSection(
+        "escalation",
+        "Escalation Tiers",
+        "Risk-score thresholds that tighten enforcement tier by tier as a"
+        " conversation misbehaves.",
+        default_collapsed=True,
+    ),
+    ConfigSection(
+        "frequency",
+        "Frequency Tracking",
+        "How per-conversation risk scores accumulate and decay over time.",
+        default_collapsed=True,
+    ),
+    ConfigSection(
+        "audit",
+        "Audit",
+        "Whether and how much detail every scan records for later review.",
+        default_collapsed=True,
+    ),
+    ConfigSection(
+        "alerting",
+        "Alerting",
+        "Fire warnings on suspicious patterns like rapid-fire scanning or PII"
+        " spikes, with rate limits.",
+        default_collapsed=True,
+    ),
+    ConfigSection(
+        "session",
+        "Session Management",
+        "Limits on how many conversations are tracked, how long they live, and"
+        " new-session rate caps.",
+        default_collapsed=True,
+    ),
+)
+
+
+def generate_section_metadata() -> list[dict[str, Any]]:
+    """Ordered section display metadata for the Config Editor UI.
+
+    Returns a fresh list of fresh dicts each call (defensive copy — the
+    registry source stays immutable). ``order`` is the 0-based render index.
+    """
+    return [
+        {
+            "key": s.key,
+            "label": s.label,
+            "description": s.description,
+            "default_collapsed": s.default_collapsed,
+            "order": i,
+        }
+        for i, s in enumerate(_SECTION_REGISTRY)
+    ]
+
+
 def _derive_type(annotation: Any) -> tuple[str, bool]:
     """Return (type_name, nullable) from a dataclass field annotation."""
     import types as _bt

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -17,7 +17,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from petasos.console._config_meta import generate_config_metadata
+from petasos.console._config_meta import generate_config_metadata, generate_section_metadata
 from petasos.console._ring_buffer import RingBuffer
 from petasos.console._sse import SSEBroadcaster
 from petasos.console._validation import SessionIdError, sanitize_session_id
@@ -140,7 +140,8 @@ class ConsoleHandlers:
     async def get_config(self) -> dict[str, Any]:
         config_dict = self.pipeline.config.to_dict(redact_secrets=True)
         fields = generate_config_metadata()
-        return {"config": config_dict, "fields": fields}
+        sections = generate_section_metadata()
+        return {"config": config_dict, "fields": fields, "sections": sections}
 
     async def update_config(
         self, body: dict[str, Any]
@@ -161,6 +162,7 @@ class ConsoleHandlers:
         result = {
             "config": validated.to_dict(redact_secrets=True),
             "fields": generate_config_metadata(),
+            "sections": generate_section_metadata(),
         }
         if not persisted:
             result["warning"] = "Config applied in memory but failed to persist to disk"

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -144,6 +144,13 @@
 .pet .panel-body { flex: 1; min-height: 0; padding: 12px; }
 .pet .panel-body.flush { padding: 0; overflow: hidden; border-radius: 0 0 calc(var(--r-panel) - 1px) calc(var(--r-panel) - 1px); }
 
+/* ── PET-114: collapsible config sections (collapse affordance only) ── */
+.pet .panel-head.collapsible { cursor: pointer; user-select: none; }
+.pet .panel-head .chevron { transition: transform .15s; }
+.pet .panel:not(.collapsed) .panel-head .chevron { transform: rotate(90deg); }
+.pet .panel.collapsed .panel-body { display: none; }
+.pet .panel-head.collapsible:focus-visible { outline: 2px solid var(--acc); outline-offset: -2px; border-radius: var(--r-panel) var(--r-panel) 0 0; }
+
 /* ── BADGES / PILLS ── */
 .pet .badge { display: inline-flex; align-items: center; gap: 5px; height: 20px; padding: 0 8px; border-radius: var(--r-chip); font-size: 10.5px; font-weight: 700; letter-spacing: .3px; font-family: var(--font-mono); white-space: nowrap; }
 .pet .badge .d { width: 6px; height: 6px; border-radius: 50%; }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -20,6 +20,11 @@
       if (attrs.style) Object.assign(el.style, attrs.style);
       if (attrs.title) el.title = attrs.title;
       if (attrs.tabIndex != null) el.tabIndex = attrs.tabIndex;
+      // PET-114: role / aria-expanded are not plain DOM properties — route them
+      // through setAttribute so the collapsible Panel head exposes them. Additive;
+      // no existing caller sets them.
+      if (attrs.role) el.setAttribute("role", attrs.role);
+      if (attrs.ariaExpanded != null) el.setAttribute("aria-expanded", String(attrs.ariaExpanded));
       if (attrs.type) el.type = attrs.type;
       if (attrs.value != null) el.value = attrs.value;
       if (attrs.placeholder) el.placeholder = attrs.placeholder;
@@ -89,6 +94,9 @@
     flow: "M6 4h0 M6 20h0 M18 12h0 M6 6v12 M6 12h9 M14 9l4 3-4 3",
     caduceus: "M12 3v18 M9 5a3 3 0 006 0 M8 9h8 M9 9c-2 2-2 5 3 6 5-1 5-4 3-6 M7 21h10",
     x: "M6 6l12 12 M18 6L6 18",
+    // PET-114: collapse affordance. Points right (collapsed); CSS rotates it
+    // 90° to point down when the section is expanded.
+    chevron: "M9 6l6 6-6 6",
   };
 
   Pet.Icon = function (name) {
@@ -201,8 +209,27 @@
   };
 
   // ── Panel primitive ──
+  // PET-114 D5: collapsible support is additive and default-off. When
+  // `opts.collapsible` is falsy the builder is behaviorally unchanged, so the
+  // Observability / Playground / About callers are unaffected. Body visibility
+  // is driven solely by the `collapsed` class on the panel (CSS rule) — there is
+  // no imperative body.style.display write, so there is exactly one hide mechanism.
   Pet.Panel = function (opts) {
-    var head = Pet.h("div", { className: "panel-head" });
+    var collapsible = !!opts.collapsible;
+    var collapsed = collapsible && !!opts.collapsed;
+
+    var headAttrs = { className: "panel-head" + (collapsible ? " collapsible" : "") };
+    if (collapsible) {
+      headAttrs.role = "button";
+      headAttrs.tabIndex = 0;
+      headAttrs.ariaExpanded = !collapsed;
+    }
+    var head = Pet.h("div", headAttrs);
+    if (collapsible) {
+      // Leading chevron in an `.ic` flex slot so it inherits the head's vertical
+      // centering; the `chevron` class is the CSS rotation hook.
+      head.appendChild(Pet.h("span", { className: "ic chevron" }, Pet.Icon("chevron")));
+    }
     if (opts.icon) {
       var ic = Pet.h("span", { className: "ic" }, Pet.Icon(opts.icon));
       head.appendChild(ic);
@@ -223,8 +250,32 @@
       if (Array.isArray(opts.content)) opts.content.forEach(function (c) { if (c) body.appendChild(c); });
       else body.appendChild(opts.content);
     }
-    var panel = Pet.h("div", { className: "panel" }, head, body);
+    var panel = Pet.h("div", { className: "panel" + (collapsed ? " collapsed" : "") }, head, body);
     if (opts.style) Object.assign(panel.style, opts.style);
+
+    if (collapsible) {
+      // Imperative live-DOM mutation, not a re-render: flip the flag, drive the
+      // `collapsed` class on the panel, rewrite aria-expanded on the live head.
+      var applyState = function () {
+        panel.className = "panel" + (collapsed ? " collapsed" : "");
+        head.setAttribute("aria-expanded", String(!collapsed));
+      };
+      var toggle = function () {
+        collapsed = !collapsed;
+        applyState();
+        if (typeof opts.onToggle === "function") opts.onToggle(collapsed);
+      };
+      head.addEventListener("click", toggle);
+      head.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); }
+      });
+      // Programmatic handle for the apply-error reveal (§3f): expand/collapse
+      // WITHOUT firing onToggle (a programmatic expansion is not a user choice).
+      panel.petSetCollapsed = function (c) {
+        collapsed = !!c;
+        applyState();
+      };
+    }
     return panel;
   };
 
@@ -242,6 +293,11 @@
     profiles: [],
     about: null,
     armed: true,  // PET-111: master Equipped/Unequipped bit; corrected by the mount fetch
+    // PET-114: per-session collapse choices { sectionKey: bool }. Written SOLELY
+    // by an onToggle (an explicit user collapse/expand) or the apply-error reveal,
+    // never seeded on render — so an upgrade from a stale all-expanded payload
+    // re-applies each section's real default_collapsed for untouched sections.
+    sectionCollapsed: {},
   };
 
   // ── API client ──
@@ -948,6 +1004,80 @@
     container.appendChild(wrapper);
   };
 
+  // PET-114: pure builder — turns the flat field list + registry section metadata
+  // into an ordered array of groups, each carrying a real boolean default_collapsed:
+  //   [ { key, label, default_collapsed, fields: [field, …] }, … ]
+  // Testable without the network (mirrors Pet.scannerHealthRows / mergeScanHistory).
+  // Degrades gracefully (D6): a stale backend with no `sections` falls back to
+  // field-appearance order, all expanded; a field whose section is absent from the
+  // registry (forward-compat new field) lands in a trailing expanded group keyed by
+  // its raw section — never silently dropped.
+  Pet.groupConfigSections = function (fields, sections) {
+    if (!Array.isArray(fields) || fields.length === 0) return [];
+
+    // Group fields by section, preserving field order and first-appearance order.
+    var bySection = {};
+    var appearance = [];
+    for (var i = 0; i < fields.length; i++) {
+      var f = fields[i];
+      if (!f || typeof f !== "object") continue;
+      var key = (f.section == null) ? "unknown" : f.section;
+      if (!Object.prototype.hasOwnProperty.call(bySection, key)) {
+        bySection[key] = [];
+        appearance.push(key);
+      }
+      bySection[key].push(f);
+    }
+
+    var groups = [];
+    var used = {};
+    if (Array.isArray(sections) && sections.length > 0) {
+      // Registry path: emit one group per registry entry in `order` (sort on the
+      // explicit value rather than trusting array order across the wire); skip
+      // registry entries with zero matching fields.
+      var ordered = sections.slice().sort(function (a, b) {
+        return ((a && a.order) || 0) - ((b && b.order) || 0);
+      });
+      ordered.forEach(function (s) {
+        if (!s || s.key == null) return;
+        var gk = s.key;
+        if (!Object.prototype.hasOwnProperty.call(bySection, gk)) return;
+        groups.push({
+          key: gk,
+          label: (s.label != null) ? s.label : gk,
+          default_collapsed: Boolean(s.default_collapsed),
+          fields: bySection[gk],
+        });
+        used[gk] = true;
+      });
+    }
+    // Trailing groups: any section not emitted above (unknown registry, or stale
+    // backend with no/empty sections), in field first-appearance order, expanded.
+    appearance.forEach(function (gk) {
+      if (used[gk]) return;
+      groups.push({ key: gk, label: gk, default_collapsed: false, fields: bySection[gk] });
+    });
+    return groups;
+  };
+
+  // PET-114 §3f: for each errored field, expand its owning section panel so the
+  // inline error is visible, and persist the expansion as a user-visible choice.
+  // Pure w.r.t. the DOM handles passed in; returns the set of section keys
+  // revealed. A field with no panel / unknown section is a safe no-op.
+  Pet.revealFieldSections = function (errorFields, fieldSection, panelsBySection) {
+    var revealed = {};
+    (errorFields || []).forEach(function (name) {
+      var sec = fieldSection[name];
+      var panel = sec && panelsBySection[sec];
+      if (panel && typeof panel.petSetCollapsed === "function") {
+        panel.petSetCollapsed(false);             // imperative expand (no onToggle)
+        Pet.state.sectionCollapsed[sec] = false;  // next re-render keeps it open
+        revealed[sec] = true;
+      }
+    });
+    return revealed;
+  };
+
   Pet.renderConfig = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "12px", height: "100%" } });
@@ -975,14 +1105,24 @@
       Pet.state.configFields = d.fields;
       formArea.innerHTML = "";
 
-      var sections = {};
-      d.fields.forEach(function (f) {
-        if (!sections[f.section]) sections[f.section] = [];
-        sections[f.section].push(f);
-      });
+      var groups = Pet.groupConfigSections(d.fields, d.sections);
+      // Declared up front (not inside the loop) so the empty path leaves them
+      // safe-to-index {} objects for revealFieldSections (§3e).
+      var fieldSection = {};
+      var panelsBySection = {};
+      d.fields.forEach(function (f) { fieldSection[f.name] = f.section; });
 
-      Object.keys(sections).forEach(function (section) {
-        var fields = sections[section];
+      if (groups.length === 0) {
+        // Expected-degraded, never-throw (PET-99): no fields, or a registry/field
+        // mismatch. Render a neutral panel rather than a blank area.
+        formArea.appendChild(Pet.Panel({
+          icon: "sliders", title: "Configuration",
+          content: Pet.h("div", { className: "mono", style: { fontSize: "12px", color: "var(--tx-faint)", padding: "8px" } }, "No configurable fields."),
+        }));
+      }
+
+      groups.forEach(function (group) {
+        var fields = group.fields;
         var fieldEls = fields.map(function (f) {
           var val = d.config[f.name];
           var control;
@@ -1043,9 +1183,19 @@
           );
         });
 
+        // Seed rule (§3b): read the user-choice map only if the key is present;
+        // otherwise the registry/builder default. Never write the map here.
+        var collapsed = Object.prototype.hasOwnProperty.call(Pet.state.sectionCollapsed, group.key)
+          ? Pet.state.sectionCollapsed[group.key]   // user chose
+          : group.default_collapsed;                 // registry/builder default
         var sectionPanel = Pet.Panel({
-          icon: "sliders", title: section, content: Pet.h("div", {}, fieldEls),
+          icon: "sliders", title: group.label,
+          collapsible: true, collapsed: collapsed,
+          onToggle: function (c) { Pet.state.sectionCollapsed[group.key] = c; },
+          content: Pet.h("div", {}, fieldEls),
         });
+        sectionPanel.dataset.section = group.key;
+        panelsBySection[group.key] = sectionPanel;
         formArea.appendChild(sectionPanel);
       });
 
@@ -1068,6 +1218,13 @@
                   if (!el || typeof el !== "object") return { field: "?", message: String(el) };
                   return { field: el.field || el.name || el.path || "?", message: el.message || el.msg || el.detail || String(el) };
                 });
+                // §3f: expand any default-collapsed section that owns an errored
+                // field BEFORE the .pet-field-err nodes are appended, so the
+                // inline error lands in a visible (un-hidden) body. Synchronous
+                // class removal in petSetCollapsed un-hides it this same tick.
+                Pet.revealFieldSections(
+                  details.map(function (e) { return e.field; }), fieldSection, panelsBySection
+                );
                 details.forEach(function (err) {
                   if (err.field === "?") return;
                   var fieldEl = null;

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1110,7 +1110,13 @@
       // safe-to-index {} objects for revealFieldSections (§3e).
       var fieldSection = {};
       var panelsBySection = {};
-      d.fields.forEach(function (f) { fieldSection[f.name] = f.section; });
+      // never-throw (PET-99): skip a malformed entry rather than throwing on
+      // f.name before the empty-guard / recovery panel can render — mirrors the
+      // guard groupConfigSections already applies to the same d.fields.
+      d.fields.forEach(function (f) {
+        if (!f || typeof f !== "object" || f.name == null) return;
+        fieldSection[f.name] = f.section;
+      });
 
       if (groups.length === 0) {
         // Expected-degraded, never-throw (PET-99): no fields, or a registry/field

--- a/tests/js/config-sections.test.mjs
+++ b/tests/js/config-sections.test.mjs
@@ -1,0 +1,343 @@
+// Unit tests for PET-114 — collapsible, grouped config sections.
+//
+// Covers the three new JS surfaces in petasos/console/static/petasos.js:
+//   1. Pet.groupConfigSections(fields, sections) — pure registry-driven grouper
+//      (order, labels, skip-empty, unknown-section trailing group, stale-backend
+//      fallback, empty input).
+//   2. Pet.Panel collapsible support — chevron + role/tabIndex/aria-expanded,
+//      click/Enter/Space toggle (live-DOM mutation), petSetCollapsed handle.
+//   3. Pet.revealFieldSections — expands the owning section of an errored field.
+//
+// Collapse is the project's first *interactive* JS unit under test, so this file
+// ships its OWN extended DOM shim: the scanner-health `makeNode` has no
+// addEventListener/setAttribute/dataset/createElementNS. Here addEventListener
+// records handlers into a per-node map that a `fire()` helper invokes, and
+// setAttribute writes into a `node.attributes` object the assertions read.
+//
+// Zero npm dependencies: Node's built-in test runner + assert + node:vm,
+// evaluating the real shipped petasos.js. Run with:
+//   node --test tests/js/config-sections.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+// Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
+// returned from the node:vm sandbox carry the sandbox realm's Object/Array
+// prototypes, so assert/strict's prototype-checking deepStrictEqual rejects them
+// even when structurally identical. Structural comparisons use this; primitive
+// comparisons keep the strict `assert`.
+import assertLoose from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Extended interactive DOM shim ──────────────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    style: {},
+    dataset: {},
+    attributes: {},
+    handlers: {},
+    className: "",
+    title: "",
+    tabIndex: undefined,
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    setAttribute(k, v) {
+      this.attributes[k] = String(v);
+    },
+    getAttribute(k) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
+    },
+    addEventListener(type, fn) {
+      (this.handlers[type] = this.handlers[type] || []).push(fn);
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      // Permissive (unlike scanner-health's throwing setter): replace children
+      // with a single text node so the getter stays consistent.
+      const t = makeNode(3);
+      t.nodeValue = String(v);
+      this.childNodes = [t];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createElementNS(ns, tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    el.namespaceURI = ns;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ───────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function findEl(node, pred) {
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (pred(child)) return child;
+      const found = findEl(child, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+const hasClass = (el, c) => (el.className || "").split(/\s+/).includes(c);
+
+function fire(node, type, evt) {
+  const hs = (node.handlers && node.handlers[type]) || [];
+  hs.forEach((fn) => fn(evt || { preventDefault() {} }));
+}
+
+// Build a collapsible panel and surface its head + an onToggle spy.
+function collapsiblePanel(collapsed) {
+  const calls = [];
+  const panel = Pet.Panel({
+    icon: "sliders",
+    title: "T",
+    collapsible: true,
+    collapsed: collapsed,
+    onToggle: function (c) {
+      calls.push(c);
+    },
+    content: Pet.h("div", {}, "body"),
+  });
+  const head = panel.childNodes[0];
+  return { panel, head, calls };
+}
+
+// Registry + fields fixtures for the grouper.
+function registry() {
+  // Deliberately NOT in array order — the grouper must sort on `order`.
+  return [
+    { key: "alerting", label: "Alerting", default_collapsed: true, order: 9 },
+    { key: "profiles", label: "Profiles", default_collapsed: false, order: 0 },
+    { key: "scanning", label: "Scanning", default_collapsed: false, order: 4 },
+  ];
+}
+function scrambledFields() {
+  return [
+    { name: "a1", section: "alerting" },
+    { name: "p1", section: "profiles" },
+    { name: "a2", section: "alerting" },
+    { name: "s1", section: "scanning" },
+  ];
+}
+
+// ── Loader guard ─────────────────────────────────────────────────────────────
+test("loader: petasos.js exports the PET-114 surfaces", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.groupConfigSections, "function");
+  assert.equal(typeof Pet.revealFieldSections, "function");
+  assert.equal(typeof Pet.Panel, "function");
+});
+
+// ── groupConfigSections ──────────────────────────────────────────────────────
+test("groupConfigSections: registry order + labels + booleans", () => {
+  const groups = Pet.groupConfigSections(scrambledFields(), registry());
+  assertLoose.deepEqual(
+    groups.map((g) => g.key),
+    ["profiles", "scanning", "alerting"]
+  );
+  assertLoose.deepEqual(
+    groups.map((g) => g.label),
+    ["Profiles", "Scanning", "Alerting"]
+  );
+  assertLoose.deepEqual(
+    groups.map((g) => g.default_collapsed),
+    [false, false, true]
+  );
+  // Field order preserved within a group.
+  assertLoose.deepEqual(
+    groups.find((g) => g.key === "alerting").fields.map((f) => f.name),
+    ["a1", "a2"]
+  );
+});
+
+test("groupConfigSections: default_collapsed is coerced to a real boolean", () => {
+  const groups = Pet.groupConfigSections(
+    [{ name: "p1", section: "profiles" }],
+    [{ key: "profiles", label: "Profiles", default_collapsed: 1, order: 0 }]
+  );
+  assert.equal(groups[0].default_collapsed, true);
+  assert.equal(typeof groups[0].default_collapsed, "boolean");
+});
+
+test("groupConfigSections: skips registry sections with no fields", () => {
+  const reg = registry().concat([
+    { key: "session", label: "Session", default_collapsed: true, order: 10 },
+  ]);
+  const groups = Pet.groupConfigSections(scrambledFields(), reg);
+  assert.ok(!groups.some((g) => g.key === "session"), "empty registry section must be skipped");
+});
+
+test("groupConfigSections: unknown-section field is a trailing expanded group", () => {
+  const fields = scrambledFields().concat([{ name: "x1", section: "future_thing" }]);
+  const groups = Pet.groupConfigSections(fields, registry());
+  const last = groups[groups.length - 1];
+  assert.equal(last.key, "future_thing");
+  assert.equal(last.label, "future_thing"); // label === key
+  assert.equal(last.default_collapsed, false); // expanded — never dropped
+  assertLoose.deepEqual(last.fields.map((f) => f.name), ["x1"]);
+});
+
+test("groupConfigSections: stale-backend fallback (no sections)", () => {
+  for (const stale of [null, undefined, [], "nope", 7]) {
+    const groups = Pet.groupConfigSections(scrambledFields(), stale);
+    // Field first-appearance order: alerting (a1), profiles (p1), scanning (s1).
+    assertLoose.deepEqual(
+      groups.map((g) => g.key),
+      ["alerting", "profiles", "scanning"]
+    );
+    assert.ok(groups.every((g) => g.label === g.key && g.default_collapsed === false));
+  }
+});
+
+test("groupConfigSections: empty/non-array fields return []", () => {
+  assertLoose.deepEqual(Pet.groupConfigSections([], registry()), []);
+  assertLoose.deepEqual(Pet.groupConfigSections(null, registry()), []);
+  assertLoose.deepEqual(Pet.groupConfigSections(undefined, registry()), []);
+  // Empty fields + a registry that matches nothing still collapses to [] —
+  // drives the renderConfig empty-guard.
+  assertLoose.deepEqual(
+    Pet.groupConfigSections([], [{ key: "nomatch", label: "x", default_collapsed: false, order: 0 }]),
+    []
+  );
+});
+
+// ── Pet.Panel collapsible ────────────────────────────────────────────────────
+test("Pet.Panel collapsible: structure (collapsed)", () => {
+  const { panel, head } = collapsiblePanel(true);
+  assert.ok(findEl(head, (el) => hasClass(el, "chevron")), "chevron rendered");
+  assert.ok(hasClass(head, "collapsible"), "head has collapsible class");
+  assert.equal(head.getAttribute("role"), "button");
+  assert.equal(head.tabIndex, 0);
+  assert.equal(head.getAttribute("aria-expanded"), "false");
+  // The panel `collapsed` class is the body-hidden observable (no CSS engine).
+  assert.ok(hasClass(panel, "collapsed"), "panel carries collapsed class");
+});
+
+test("Pet.Panel collapsible: structure (expanded)", () => {
+  const { panel, head } = collapsiblePanel(false);
+  assert.equal(head.getAttribute("aria-expanded"), "true");
+  assert.ok(!hasClass(panel, "collapsed"), "expanded panel lacks collapsed class");
+});
+
+test("Pet.Panel collapsible: click toggles live state + aria + onToggle", () => {
+  const { panel, head, calls } = collapsiblePanel(false);
+  fire(head, "click");
+  assert.ok(hasClass(panel, "collapsed"));
+  assert.equal(head.getAttribute("aria-expanded"), "false");
+  assertLoose.deepEqual(calls, [true]);
+  fire(head, "click");
+  assert.ok(!hasClass(panel, "collapsed"));
+  assert.equal(head.getAttribute("aria-expanded"), "true");
+  assertLoose.deepEqual(calls, [true, false]);
+});
+
+test("Pet.Panel collapsible: Enter key toggles", () => {
+  const { panel, head, calls } = collapsiblePanel(false);
+  let prevented = false;
+  fire(head, "keydown", { key: "Enter", preventDefault() { prevented = true; } });
+  assert.ok(prevented, "Enter calls preventDefault");
+  assert.ok(hasClass(panel, "collapsed"));
+  assert.equal(head.getAttribute("aria-expanded"), "false");
+  assertLoose.deepEqual(calls, [true]);
+});
+
+test("Pet.Panel collapsible: Space key toggles", () => {
+  const { panel, head, calls } = collapsiblePanel(false);
+  let prevented = false;
+  fire(head, "keydown", { key: " ", preventDefault() { prevented = true; } });
+  assert.ok(prevented, "Space calls preventDefault");
+  assert.ok(hasClass(panel, "collapsed"));
+  assertLoose.deepEqual(calls, [true]);
+});
+
+test("Pet.Panel collapsible: other keys do not toggle", () => {
+  const { panel, head, calls } = collapsiblePanel(false);
+  fire(head, "keydown", { key: "Tab", preventDefault() {} });
+  assert.ok(!hasClass(panel, "collapsed"));
+  assertLoose.deepEqual(calls, []);
+});
+
+test("Pet.Panel collapsible: petSetCollapsed expands without firing onToggle", () => {
+  const { panel, head, calls } = collapsiblePanel(true);
+  assert.equal(typeof panel.petSetCollapsed, "function");
+  panel.petSetCollapsed(false);
+  assert.ok(!hasClass(panel, "collapsed"), "collapsed class removed");
+  assert.equal(head.getAttribute("aria-expanded"), "true");
+  assertLoose.deepEqual(calls, [], "programmatic expand must NOT fire onToggle");
+});
+
+test("Pet.Panel non-collapsible: unchanged (regression guard)", () => {
+  const panel = Pet.Panel({ icon: "sliders", title: "x", content: Pet.h("div", {}, "y") });
+  const head = panel.childNodes[0];
+  assert.equal(head.className, "panel-head");
+  assert.ok(!findEl(head, (el) => hasClass(el, "chevron")), "no chevron");
+  assert.equal(head.getAttribute("role"), null);
+  assert.equal(head.getAttribute("aria-expanded"), null);
+  assert.ok(!head.handlers.click, "no click handler");
+  assert.ok(!head.handlers.keydown, "no keydown handler");
+  assert.equal(typeof panel.petSetCollapsed, "undefined");
+});
+
+// ── revealFieldSections ──────────────────────────────────────────────────────
+test("revealFieldSections: expands the owning section of an errored field", () => {
+  let calledWith = "UNSET";
+  const panelsBySection = {
+    escalation: { petSetCollapsed(c) { calledWith = c; } },
+  };
+  const fieldSection = { tier2_threshold: "escalation" };
+  Pet.state.sectionCollapsed = {};
+  const revealed = Pet.revealFieldSections(["tier2_threshold"], fieldSection, panelsBySection);
+  assert.equal(calledWith, false, "petSetCollapsed(false) called");
+  assert.equal(Pet.state.sectionCollapsed.escalation, false, "choice persisted");
+  assertLoose.deepEqual(revealed, { escalation: true });
+});
+
+test("revealFieldSections: unknown / missing-panel field is a safe no-op", () => {
+  Pet.state.sectionCollapsed = {};
+  assert.doesNotThrow(() => Pet.revealFieldSections(["nope"], {}, {}));
+  assertLoose.deepEqual(Pet.revealFieldSections(["nope"], {}, {}), {});
+  // Null error list is also safe.
+  assertLoose.deepEqual(Pet.revealFieldSections(null, {}, {}), {});
+  // A field whose section has no panel entry: no throw, nothing revealed.
+  assertLoose.deepEqual(
+    Pet.revealFieldSections(["f"], { f: "missing_section" }, {}),
+    {}
+  );
+});

--- a/tests/test_config_meta.py
+++ b/tests/test_config_meta.py
@@ -5,7 +5,32 @@ import dataclasses
 import pytest
 
 from petasos.config import _SECRET_FIELDS, PetasosConfig
-from petasos.console._config_meta import _FIELD_META, generate_config_metadata
+from petasos.console._config_meta import (
+    _FIELD_META,
+    _SECTION_REGISTRY,
+    ConfigSection,
+    generate_config_metadata,
+    generate_section_metadata,
+)
+
+# PET-114: canonical section render order — common controls first/open, advanced
+# groups after, collapsed. Pinned here so the order + open-first coupling can't
+# drift silently.
+_EXPECTED_SECTION_ORDER = [
+    "profiles",
+    "anonymization",
+    "fail_mode",
+    "tool_guard",
+    "scanning",
+    "normalization",
+    "escalation",
+    "frequency",
+    "audit",
+    "alerting",
+    "session",
+]
+_ADVANCED_SECTIONS = {"normalization", "escalation", "frequency", "audit", "alerting", "session"}
+_COMMON_SECTIONS = {"profiles", "anonymization", "fail_mode", "tool_guard", "scanning"}
 
 
 def test_every_field_present() -> None:
@@ -132,3 +157,82 @@ def test_help_plain_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     by_name = {m["name"]: m for m in generate_config_metadata()}
     assert by_name["normalize_nfkc"]["help_plain"] == "Technical text only."
+
+
+# ── PET-114: section-level registry metadata ──────────────────────────────────
+
+
+def test_every_field_section_has_registry_entry() -> None:
+    # Brief-required: no field references a section the registry doesn't define
+    # (prevents an orphan field section).
+    registry_keys = {s["key"] for s in generate_section_metadata()}
+    for entry in generate_config_metadata():
+        assert entry["section"] in registry_keys, (
+            f"Field {entry['name']!r} section {entry['section']!r} has no registry entry"
+        )
+
+
+def test_section_registry_frozen_and_ordered() -> None:
+    # Brief-required: registry is immutable and deterministically ordered.
+    # Frozen: instances reject attribute assignment; the registry is a tuple.
+    section = _SECTION_REGISTRY[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        section.label = "mutated"  # type: ignore[misc]
+    assert isinstance(_SECTION_REGISTRY, tuple)
+
+    # Defensive copy: fresh list of fresh dicts each call; mutating one return
+    # value cannot corrupt the source.
+    a = generate_section_metadata()
+    b = generate_section_metadata()
+    assert a == b
+    assert a is not b
+    assert a[0] is not b[0]
+    a[0]["label"] = "MUTATED"
+    assert generate_section_metadata()[0]["label"] != "MUTATED"
+
+    # Ordered: contiguous, 0-based, strictly increasing `order`; key sequence
+    # matches the canonical order; deterministic across calls.
+    sections = generate_section_metadata()
+    assert [s["order"] for s in sections] == list(range(len(sections)))
+    assert [s["key"] for s in sections] == _EXPECTED_SECTION_ORDER
+    assert [s["key"] for s in generate_section_metadata()] == _EXPECTED_SECTION_ORDER
+
+    # Open-first coupling: the open sections are exactly the leading five.
+    assert [s["key"] for s in sections if not s["default_collapsed"]] == [
+        s["key"] for s in sections
+    ][:5]
+
+    # Exact coverage (no drift): registry keys == the in-use field sections —
+    # kills both a missing registry entry and a dead registry entry with no fields.
+    assert {s["key"] for s in generate_section_metadata()} == {
+        f["section"] for f in generate_config_metadata()
+    }
+
+
+def test_advanced_sections_default_collapsed() -> None:
+    # Brief-required: advanced sections carry the collapsed flag; common ones open.
+    by_key = {s["key"]: s for s in generate_section_metadata()}
+    for key in _ADVANCED_SECTIONS:
+        assert by_key[key]["default_collapsed"] is True, f"{key} should default collapsed"
+    for key in _COMMON_SECTIONS:
+        assert by_key[key]["default_collapsed"] is False, f"{key} should default open"
+
+
+def test_section_metadata_entry_shape() -> None:
+    # Every section dict has exactly the expected keys with the expected types.
+    for s in generate_section_metadata():
+        assert set(s.keys()) == {"key", "label", "description", "default_collapsed", "order"}
+        assert isinstance(s["key"], str) and s["key"]
+        assert isinstance(s["label"], str) and s["label"].strip()
+        assert isinstance(s["description"], str) and s["description"].strip()
+        assert isinstance(s["default_collapsed"], bool)
+        assert isinstance(s["order"], int)
+
+
+def test_config_section_is_frozen_slots_dataclass() -> None:
+    # ConfigSection is a frozen, slotted dataclass (the "Frozen exports" invariant).
+    assert dataclasses.is_dataclass(ConfigSection)
+    params = ConfigSection.__dataclass_params__  # type: ignore[attr-defined]
+    assert params.frozen is True
+    # slots=True means no per-instance __dict__.
+    assert not hasattr(ConfigSection("k", "l", "d", default_collapsed=False), "__dict__")

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -41,6 +41,32 @@ async def test_get_config_returns_fields(handlers: ConsoleHandlers) -> None:
     assert "session_secret" not in result["config"]
 
 
+async def test_get_config_returns_sections(handlers: ConsoleHandlers) -> None:
+    # PET-114: /config carries the ordered section registry alongside fields.
+    result = await handlers.get_config()
+    assert "sections" in result
+    sections = result["sections"]
+    assert isinstance(sections, list) and len(sections) > 0
+    for s in sections:
+        assert {"key", "label", "order"} <= set(s.keys())
+    # Sections cover every field's section in the same payload.
+    section_keys = {s["key"] for s in sections}
+    field_sections = {f["section"] for f in result["fields"]}
+    assert field_sections <= section_keys
+
+
+async def test_update_config_returns_sections(handlers: ConsoleHandlers) -> None:
+    # PET-114 Decision 4 symmetry: a valid update result also carries `sections`.
+    result, errors = await handlers.update_config({"fail_mode": "closed"})
+    assert errors is None
+    assert result is not None
+    assert "sections" in result
+    sections = result["sections"]
+    assert isinstance(sections, list) and len(sections) > 0
+    for s in sections:
+        assert {"key", "label", "order"} <= set(s.keys())
+
+
 async def test_metadata_endpoint_carries_help_plain(handlers: ConsoleHandlers) -> None:
     # Regression for PET-88: config metadata carries plain-language help text
     # alongside the technical description for every field.


### PR DESCRIPTION
## Summary
- Adds a **frozen, ordered section registry** in `_config_meta.py` (one data-driven source of truth) and the console rendering that turns the flat Config Editor field list into **collapsible, labeled, ordered groups** — common controls first/open, advanced groups collapsed.
- The five common sections (`profiles`, `anonymization`, `fail_mode`, `tool_guard`, `scanning`) surface first and open; the six advanced sections (`normalization`, `escalation`, `frequency`, `audit`, `alerting`, `session`) render collapsed by default.
- **No config field is added or changed** — purely a presentation/metadata layer. The `/config` payload gains a `sections` key alongside `fields`/`config`.

## Layered defense / graceful degradation
- **Single emission point (Decision 4):** `sections` is added to the `ConsoleHandlers` methods; the standalone FastAPI route and the Hermes plugin bridge both delegate there, so both consumer platforms inherit it at one edit point.
- **Stale backend (Decision 6):** `Pet.groupConfigSections` falls back to field-appearance order, raw-key labels, all-expanded when `sections` is absent; a field whose `section` is not in the registry lands in a trailing expanded group — never silently dropped.
- **Apply-error reveal (§3f):** a validation error on a field in a collapsed section auto-expands the owning panel (via a programmatic `petSetCollapsed` that does not fire `onToggle`) so the inline error is visible.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_config_meta.py` | Adds frozen+slots `ConfigSection`, `Final _SECTION_REGISTRY` (11 sections), `generate_section_metadata()` (fresh defensive copy, explicit `order`) |
| `petasos/console/server.py` | `get_config`/`update_config` results gain a `"sections"` key (Decision 4 symmetry) |
| `petasos/console/static/petasos.js` | chevron icon, `Pet.h` role/aria-expanded passthrough, additive collapsible `Pet.Panel`, pure `Pet.groupConfigSections`, `Pet.revealFieldSections`, `Pet.state.sectionCollapsed`, rewired `renderConfig` |
| `petasos/console/static/petasos.css` | Collapse affordance only — chevron rotation, collapsed-body hide, clickable-head cursor, `:focus-visible` ring |
| `tests/test_config_meta.py` | Registry frozen/ordered, exact coverage, open-first coupling, default-collapse partition, entry shape |
| `tests/test_console_handlers.py` | `sections` present on `get_config`/`update_config` |
| `tests/js/config-sections.test.mjs` | **New** — interactive DOM shim; grouper, collapsible Panel toggle, reveal helper |
| `docs/specs/TODO/PET-114.test-output.txt` | **New** — captured test-command output |

## Test plan
- [x] `python -m pytest tests/test_config_meta.py tests/test_console_handlers.py -v --tb=short` — 59/59 pass (full output: `docs/specs/TODO/PET-114.test-output.txt`)
- [x] `node --test tests/js/config-sections.test.mjs` — 17/17 pass
- [x] Full gate: `python -m pytest tests/ --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 1536 passed, 40 skipped, 1 xfailed; `node --test tests/js/*.test.mjs` — 51/51 pass
- [x] `ruff check .` / `ruff format --check .` clean; `mypy --strict petasos/console/_config_meta.py petasos/console/server.py` clean
- [ ] Manual verification in standalone (`127.0.0.1:8384`) + Hermes plugin mode (screenshots per PET-88 precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PET-114 collapsible, ordered config sections to the Config Editor, including chevron affordance and accessible keyboard/ARIA (role, tabIndex, aria-expanded).
  * Console `/config` and config updates now return `sections` metadata to drive the UI.
  * Section collapse/expand state persists during the session; sections containing errored fields auto-expand.
* **Bug Fixes**
  * Ensured inline error messages remain visible by expanding the owning section before rendering errors.
* **Tests**
  * Added/extended Python and Node tests for section ordering, immutability/defensive output, fallback behavior, UI toggling, and API response shape.
* **Documentation**
  * Updated the PET-114 test-run snapshot with the latest passing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->