### PR TITLE
feat(pet-113): describe each built-in scanning profile

### DIFF
--- a/docs/specs/TODO/PET-113.test-output.txt
+++ b/docs/specs/TODO/PET-113.test-output.txt
@@ -1,0 +1,68 @@
+=== python -m pytest tests/test_profiles.py tests/test_console_handlers.py ===
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-113-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 80 items
+
+tests\test_profiles.py ........................................          [ 50%]
+tests\test_console_handlers.py ........................................  [100%]
+
+============================= 80 passed in 0.42s ==============================
+PYTEST_EXIT=0
+
+=== ruff check petasos/session/profiles tests/test_profiles.py tests/test_console_handlers.py ===
+All checks passed!
+RUFF_EXIT=0
+
+=== mypy --strict petasos/session/profiles ===
+Success: no issues found in 1 source file
+MYPY_EXIT=0
+
+=== FULL-SUITE CONFIRMATION (pre-PR) ===
+--- python -m pytest --deselect (known Unicode-13 case) ---
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-113-worktree\petasos\console\server.py:295: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ===========================
+FAILED tests/test_console_validation.py::test_default_ignorable_rejected - as...
+1 failed, 1544 passed, 40 skipped, 1 xfailed, 68 warnings in 30.48s
+FULL_PYTEST_EXIT=1
+
+--- ruff format --check . ---
+115 files already formatted
+RUFF_FMT_EXIT=0
+
+--- mypy --strict . ---
+Success: no issues found in 115 source files
+MYPY_ALL_EXIT=0
+
+--- NOTE on the lone full-suite failure ---
+tests/test_console_validation.py::test_default_ignorable_rejected fails with
+`assert 266 >= 267` — local CPython 3.10.6 ships Unicode 13.0.0; the test
+expects Unicode 14.0.0's 267-codepoint sweep. This is the documented
+pre-existing failure (project memory: petasos-local-python-is-310-unicode13),
+in session-id validation and unrelated to PET-113's profile-description change.
+The resolved focused gate (test_profiles + test_console_handlers) is 80/80
+green, with ruff + mypy --strict clean repo-wide.

--- a/petasos/session/profiles/__init__.py
+++ b/petasos/session/profiles/__init__.py
@@ -45,6 +45,7 @@ class ResolvedProfile:
     pii_entities_extra: tuple[str, ...]
     tool_exempt_list: frozenset[str]
     tool_alias_map: MappingProxyType[str, str]
+    description: str = ""
 
     def __post_init__(self) -> None:
         cleaned = _validate_suppress_rules(self.suppress_rules)
@@ -69,6 +70,7 @@ class ResolvedProfile:
             "pii_entities_extra": list(self.pii_entities_extra),
             "tool_exempt_list": sorted(self.tool_exempt_list),
             "tool_alias_map": dict(self.tool_alias_map),
+            "description": self.description,
         }
 
 
@@ -128,6 +130,10 @@ def _parse_profile(data: dict[str, Any]) -> ResolvedProfile:
     _check_structural_overrides(sev_overrides)
     _check_severity_values(sev_overrides)
 
+    desc = data.get("description", "")
+    if not isinstance(desc, str):
+        raise ValueError("description must be a string")
+
     return ResolvedProfile(
         name=data["name"],
         suppress_rules=_validate_suppress_rules(frozenset(data.get("suppress_rules", []))),
@@ -137,6 +143,7 @@ def _parse_profile(data: dict[str, Any]) -> ResolvedProfile:
         pii_entities_extra=tuple(data.get("pii_entities_extra", [])),
         tool_exempt_list=exempt_set,
         tool_alias_map=MappingProxyType(dict(alias_map)),
+        description=desc,
     )
 
 
@@ -215,6 +222,15 @@ def _merge_with_base(
             f"profile 'custom': tool_alias_map targets cannot be exempt keys: {sorted(collisions)}"
         )
 
+    # A custom profile is not `general`; default to "" rather than inheriting the
+    # base's description, which would mislabel it in the selector.
+    description = ""
+    if "description" in overrides:
+        val = overrides["description"]
+        if not isinstance(val, str):
+            raise ValueError("description must be a string")
+        description = val
+
     return ResolvedProfile(
         name="custom",
         suppress_rules=suppress,
@@ -224,6 +240,7 @@ def _merge_with_base(
         pii_entities_extra=pii,
         tool_exempt_list=exempt,
         tool_alias_map=MappingProxyType(alias),
+        description=description,
     )
 
 

--- a/petasos/session/profiles/admin.json
+++ b/petasos/session/profiles/admin.json
@@ -1,5 +1,6 @@
 {
   "name": "admin",
+  "description": "Strictest posture. Tightens escalation tiers (10/20/35) so risk trips fast and scans for the full PII set including credit cards and IBANs. For: privileged or admin agents and compliance-sensitive deployments where early lockdown beats convenience.",
   "suppress_rules": [],
   "severity_overrides": {},
   "confidence_floor": 0.0,

--- a/petasos/session/profiles/code_generation.json
+++ b/petasos/session/profiles/code_generation.json
@@ -1,5 +1,6 @@
 {
   "name": "code_generation",
+  "description": "Tuned for coding agents. Suppresses encoding and shell-command rules that fire constantly on legitimate code (base64, homoglyphs, pipe-to-shell, decode/fetch-exec, recursive deletes) and raises the confidence floor to 0.6 to cut false positives. For: code-writing and dev-tooling agents. Trade-off: weaker defense against command-injection payloads.",
   "suppress_rules": [
     "petasos.syntactic.encoding.invisible-chars",
     "petasos.syntactic.encoding.base64-in-text",

--- a/petasos/session/profiles/customer_service.json
+++ b/petasos/session/profiles/customer_service.json
@@ -1,5 +1,6 @@
 {
   "name": "customer_service",
+  "description": "Hardened against prompt injection for user-facing chat. Promotes the common injection openers (ignore/disregard, role-reassignment, new-instruction, and system-override patterns) to critical and watches conversations for personal data such as names and phone numbers. For: support and chat agents handling untrusted end-user input.",
   "suppress_rules": [],
   "severity_overrides": {
     "petasos.syntactic.injection.ignore-previous": "critical",

--- a/petasos/session/profiles/general.json
+++ b/petasos/session/profiles/general.json
@@ -1,5 +1,6 @@
 {
   "name": "general",
+  "description": "Balanced default. Runs every rule and scanner at standard sensitivity with no suppressions or overrides - the safe starting point when no other preset clearly fits. For: general-purpose agents and first-time setup.",
   "suppress_rules": [],
   "severity_overrides": {},
   "confidence_floor": 0.0,

--- a/petasos/session/profiles/research.json
+++ b/petasos/session/profiles/research.json
@@ -1,5 +1,6 @@
 {
   "name": "research",
+  "description": "Low-friction for long research and browsing sessions. Suppresses encoding-obfuscation rules that trip on quoted web content, raises the confidence floor to 0.7, and relaxes escalation tiers (25/45/70) so deep multi-step sessions are not cut short. For: research and retrieval agents working over large external corpora.",
   "suppress_rules": [
     "petasos.syntactic.encoding.invisible-chars",
     "petasos.syntactic.encoding.base64-in-text",

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -121,6 +121,14 @@ async def test_get_profiles(handlers: ConsoleHandlers) -> None:
     assert "general" in names
 
 
+async def test_profile_metadata_surfaced(handlers: ConsoleHandlers) -> None:
+    # Regression for PET-113: the /profiles endpoint surfaces a non-empty
+    # description for every profile (flows through ResolvedProfile.to_dict).
+    result = await handlers.get_profiles()
+    for p in result["profiles"]:
+        assert p.get("description", "").strip(), f"{p['name']} missing description"
+
+
 async def test_get_about(handlers: ConsoleHandlers) -> None:
     result = await handlers.get_about()
     assert result["version"] == "0.1.0"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -329,3 +329,49 @@ class TestStructuralOverrideProtection:
         prefix = "petasos.syntactic.structural."
         for rule_id in _STRUCTURAL_RULE_IDS:
             assert rule_id.startswith(prefix), f"{rule_id} does not start with {prefix}"
+
+
+# ---------------------------------------------------------------------------
+# PET-113: Built-in profile descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestProfileDescriptions:
+    def test_builtin_profiles_have_descriptions(self) -> None:
+        # Regression for PET-113: every built-in profile exposes a renderable,
+        # non-empty description (catches "" / whitespace-only and a regression to
+        # str(None) coercion), and the new field is frozen like the rest.
+        resolver = ProfileResolver()
+        for name in _BUILTIN_NAMES:
+            p = resolver.resolve(name)
+            assert p.description.strip(), f"{name} has empty description"
+            assert p.description != "None", f"{name} description is str(None) garbage"
+            with pytest.raises(AttributeError):
+                p.description = "x"  # type: ignore[misc]
+
+    def test_profile_description_roundtrips(self) -> None:
+        # Regression for PET-113: description survives to_dict -> _parse_profile and
+        # every branch of the resolved validation policy (Decision 5) holds.
+        resolver = ProfileResolver()
+        p = resolver.resolve("admin")
+        assert _parse_profile(p.to_dict()).description == p.description
+
+        # missing key -> "" (back-compat)
+        assert _parse_profile({"name": "x"}).description == ""
+
+        # present-but-non-string raises on the JSON path (None and 123 are
+        # distinct isinstance branches)
+        with pytest.raises(ValueError, match="must be a string"):
+            _parse_profile({"name": "x", "description": None})
+        with pytest.raises(ValueError, match="must be a string"):
+            _parse_profile({"name": "x", "description": 123})
+
+        # custom dict-merge override present
+        assert resolver.resolve({"description": "mine"}).description == "mine"
+
+        # custom override non-string raises on the merge path
+        with pytest.raises(ValueError, match="must be a string"):
+            resolver.resolve({"description": 123})
+
+        # custom override absent does not inherit general's copy (Decision 2)
+        assert resolver.resolve({"confidence_floor": 0.8}).description == ""


### PR DESCRIPTION
## Summary
- Adds an additive, back-compatible `description` field to each of the five built-in scanning profiles — a short "purpose + what it changes + who it's for" string.
- The field lives in each profile JSON and on `ResolvedProfile`, round-trips through `to_dict`/`_parse_profile`, and is surfaced verbatim by the existing `/profiles` endpoint (no handler edit). Single source of truth, frontend-bindable.
- No behavior, no enforcement, and no frozen-export guarantees change. `agent_owner` preset is deferred to a PET-112 follow-up (Decision 4).

## Two-door validation
Both entry points apply one identical policy (spec Decision 5):
- `_parse_profile` (JSON path) and `_merge_with_base` (custom dict path) validate with `isinstance(val, str)` and raise `ValueError("description must be a string")` on a non-string value — never coerced (a naive `str()` would turn JSON `null` into the literal `"None"` and surface it to the selector).
- A *missing* key defaults to `""` (back-compat). A custom merge profile with no `description` resolves to `""`, **not** the `general` base's copy — inheriting it would mislabel the custom profile.

## Files changed

| File | Change |
|------|--------|
| `petasos/session/profiles/__init__.py` | Adds immutable `description: str = ""` final field to `ResolvedProfile`; emits it in `to_dict`; validated parse in `_parse_profile`; validated, non-inheriting carry in `_merge_with_base` |
| `petasos/session/profiles/general.json` | Adds ASCII-only `description` (written from actual config) |
| `petasos/session/profiles/customer_service.json` | Adds `description` |
| `petasos/session/profiles/code_generation.json` | Adds `description` |
| `petasos/session/profiles/research.json` | Adds `description` |
| `petasos/session/profiles/admin.json` | Adds `description` |
| `tests/test_profiles.py` | Adds `test_builtin_profiles_have_descriptions` + `test_profile_description_roundtrips` |
| `tests/test_console_handlers.py` | Adds `test_profile_metadata_surfaced` (endpoint surfacing) |

## Test plan
- [x] `python -m pytest tests/test_profiles.py tests/test_console_handlers.py` — 80/80 pass (full output: `docs/specs/TODO/PET-113.test-output.txt`)
- [x] `ruff check petasos/session/profiles tests/test_profiles.py tests/test_console_handlers.py` — clean
- [x] `mypy --strict petasos/session/profiles` — clean
- [x] Full-suite confirmation: `python -m pytest` — 1544 passed, 40 skipped, 1 xfailed; lone failure is the documented pre-existing Unicode-13 case (`test_default_ignorable_rejected`, `assert 266 >= 267`), unrelated to this change
- [x] `ruff format --check .` (115 files) + `mypy --strict .` (115 files) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session profiles now include descriptive metadata explaining their purpose and tuning.

* **Documentation**
  * Updated all built-in profile descriptions to clarify behavior, configuration parameters, and recommended use cases across admin, code generation, customer service, general, and research modes.

* **Tests**
  * Added validation tests for profile descriptions, including immutability and serialization integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->