### PR TITLE
fix(pet-118): canonicalize tool-name classification to the guard's form

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any
 
 from petasos._types import Severity  # PET-112: dep-light (enum + dataclasses, no ML imports)
+from petasos.normalize import canonicalize_tool_name  # PET-118: dep-light (re + unicodedata)
 
 logger = logging.getLogger("petasos.plugin")
 
@@ -86,9 +87,20 @@ READ_ONLY_TOOLS = frozenset(
     }
 )
 
+# PET-118: derived sibling canonical set. READ_ONLY_TOOLS stays the immutable raw
+# source-of-truth; _READ_ONLY_CANON is canonicalized at MODULE LOAD (not _deferred_init)
+# because _is_dangerous runs in _fallback_pre_tool_call during the init window, before
+# _deferred_init completes. The same `if c` empty-drop the egress init uses applies here:
+# a name that canonicalizes away (a future homoglyph-only / prefix-only constant) never
+# enters the set, so _is_dangerous("") stays True (fail-secure) unconditionally — no
+# `assert`, which `python -O` / PYTHONOPTIMIZE would strip. Every current entry is plain
+# ASCII and canonicalizes non-empty, so the filter is a no-op today, a regression guard
+# tomorrow.
+_READ_ONLY_CANON = frozenset(c for c in (canonicalize_tool_name(t) for t in READ_ONLY_TOOLS) if c)
+
 
 def _is_dangerous(tool_name: str) -> bool:
-    return tool_name not in READ_ONLY_TOOLS
+    return canonicalize_tool_name(tool_name) not in _READ_ONLY_CANON
 
 
 # ---------------------------------------------------------------------------
@@ -127,14 +139,15 @@ def _worst(findings):
     return min(findings, key=lambda f: (_SEVERITY_RANK.get(f.severity, 999), -f.confidence))
 
 
-# Resolved in _deferred_init from config.egress_sink_tools; raw membership mirrors
-# _is_dangerous. Written once under _init_lock before _initialized flips; read lock-free in
-# _pre_tool_call (which only runs post-init). Atomic name rebind — no torn read under the GIL.
+# Resolved in _deferred_init from config.egress_sink_tools, canonicalized once at init
+# (PET-118); canonical membership mirrors _is_dangerous. Written once under _init_lock
+# before _initialized flips; read lock-free in _pre_tool_call (which only runs post-init).
+# Atomic name rebind — no torn read under the GIL.
 _egress_sink_tools: frozenset[str] = frozenset()
 
 
 def _is_egress_sink(tool_name: str) -> bool:
-    return tool_name in _egress_sink_tools
+    return canonicalize_tool_name(tool_name) in _egress_sink_tools
 
 
 # ---------------------------------------------------------------------------
@@ -394,10 +407,19 @@ def _deferred_init() -> None:
             # binds a function-local and leaves the module frozenset empty forever,
             # silently disabling egress PII blocking.
             global _egress_sink_tools
-            _egress_sink_tools = frozenset(config.egress_sink_tools)
+            # PET-118: canonicalize once here through the SAME shared primitive the guard
+            # uses, mirroring the delegate_tool_names template (canonicalize, drop names
+            # that normalize away via `if c`, warn when the resolved set is empty). A name
+            # that is purely a namespace prefix (e.g. "mcp__acme__") passes config
+            # validation but canonicalizes to "" — the `if c` filter drops it so the set
+            # never contains "" (no false match in _is_egress_sink).
+            _egress_sink_tools = frozenset(
+                c for c in (canonicalize_tool_name(t) for t in config.egress_sink_tools) if c
+            )
             if not _egress_sink_tools:
                 logger.warning(
-                    "egress_sink_tools is empty — PII will not be blocked on any egress tool"
+                    "egress_sink_tools is empty (or all names canonicalized away) — "
+                    "PII will not be blocked on any egress tool"
                 )
 
             scanner_names = [s.name for s in scanners]

--- a/docs/specs/TODO/PET-118.test-output.txt
+++ b/docs/specs/TODO/PET-118.test-output.txt
@@ -1,0 +1,78 @@
+PET-118 — Canonicalize tool-name classification to the guard's form
+Verify-first verdict: EXPLOITABLE — implemented (see spec ## Verify-first answer).
+Plane comment id (PET-118): 082da57b-ad08-475c-a061-06078e9e39fb
+Residual follow-up: PET-121 (align Petasos canonical form to Hermes dispatch grammar).
+Interpreter: Python 3.10.6 | pytest 9.0.3
+Date: 2026-06-14
+
+================================================================
+# Focused test command (spec ## Test command)
+python -m pytest tests/test_reference_plugin_egress.py tests/test_guard.py tests/test_normalize.py tests/adversarial/guard/test_tool_smuggling.py -q
+================================================================
+........................................................................ [ 38%]
+........................................................................ [ 76%]
+.............................................                            [100%]
+189 passed in 1.44s
+focused exit: 0
+
+================================================================
+# Full gate before PR (per CLAUDE.md Build & Run)
+# Pre-existing 3.10/Unicode-13 failure deselected: tests/test_console_validation.py::test_default_ignorable_rejected
+#   (assert 266>=267 — Unicode 14 expected; unrelated to PET-118, see memory note)
+================================================================
+$ python -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected
+........................................................................ [  4%]
+........................................................................ [  8%]
+..................................................x..................... [ 13%]
+........................................................................ [ 17%]
+........................................................................ [ 21%]
+........................................................................ [ 26%]
+........................................................................ [ 30%]
+.............ssssssss................................................... [ 35%]
+........................................................................ [ 39%]
+........................................................................ [ 43%]
+........................................................................ [ 48%]
+........................................................................ [ 52%]
+........................................................................ [ 56%]
+.....................ssss............................................... [ 61%]
+.......................................................ssssssssssssss... [ 65%]
+....................ssssssssss....ssss.................................. [ 70%]
+........................................................................ [ 74%]
+........................................................................ [ 78%]
+........................................................................ [ 83%]
+........................................................................ [ 87%]
+........................................................................ [ 91%]
+........................................................................ [ 96%]
+.............................................................            [100%]
+============================== warnings summary ===============================
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-118-worktree\petasos\console\server.py:291: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1604 passed, 40 skipped, 1 deselected, 1 xfailed, 68 warnings in 27.70s
+full pytest exit: 0
+$ python -m ruff check .
+All checks passed!
+$ python -m ruff format --check .
+116 files already formatted
+$ python -m mypy --strict .
+Success: no issues found in 116 source files

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -157,9 +157,10 @@ class PetasosConfig:
     delegate_tool_names: tuple[str, ...] = ("delegate_task",)
     # Tool names treated as egress sinks (outbound content: email/social/HTTP/webhook/
     # clipboard-out). The PII-finding block applies ONLY to these tools; internal tools
-    # (write_file/terminal/execute_code/edit) are exempt. Stored RAW; matched raw by the
-    # plugin, mirroring READ_ONLY_TOOLS/_is_dangerous. Best-effort default names — operators
-    # must align to their host's tool registry (frontend-bindable, PET-112).
+    # (write_file/terminal/execute_code/edit) are exempt. Stored RAW; canonicalized by the
+    # plugin before matching (PET-118), mirroring READ_ONLY_TOOLS/_is_dangerous. Best-effort
+    # default names — operators must align to their host's tool registry (frontend-bindable,
+    # PET-112).
     egress_sink_tools: tuple[str, ...] = (
         "send_email",
         "send_message",
@@ -403,8 +404,9 @@ class PetasosConfig:
                 raise ValueError(
                     f"delegate_tool_names entries must be non-empty strings, got {tool_name!r}"
                 )
-        # egress_sink_tools (PET-112): RAW tool names matched by the plugin's
-        # _is_egress_sink. Mirrors the delegate_tool_names template — bare-str reject
+        # egress_sink_tools (PET-112): RAW tool names, canonicalized by the plugin's
+        # _is_egress_sink before matching (PET-118). Mirrors the delegate_tool_names
+        # template — bare-str reject
         # (tuple("send_email") would char-explode and silently empty the set),
         # list→tuple coerce, per-entry non-empty check — but an EMPTY tuple is allowed
         # (an operator may disable egress PII blocking entirely; the plugin warns).

--- a/petasos/normalize.py
+++ b/petasos/normalize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unicodedata
 
 from petasos._types import NormalizedText
@@ -151,6 +152,29 @@ _HOMOGLYPH_TABLE = str.maketrans(
         "ɡ": "g",
     }
 )
+
+# Relocated from petasos/session/guard.py (PET-118): single definition, shared by
+# ToolCallGuard's normalizer and the reference plugin's classification. Strips a
+# SINGLE leading namespace prefix — `mcp__<ns>__` or `hermes__`. Co-located with
+# _HOMOGLYPH_TABLE because canonicalize_tool_name composes both.
+_NAMESPACE_PREFIX_RE = re.compile(r"^(?:mcp__[a-zA-Z0-9_]+?__|hermes__)")
+
+
+def canonicalize_tool_name(name: str) -> str:
+    """Alias-free canonical form for tool-name matching. Shared by ToolCallGuard's
+    normalizer (under its alias layer) and the reference plugin's classification, so
+    the two never diverge. Pure: no profile/alias dependency.
+
+    Strips a SINGLE leading namespace prefix (matching the guard's existing behavior,
+    D-EQUIV / D6) — not a fixed-point loop. Stacked/alternate prefix shapes are a D6
+    coverage item gated on the verified Hermes grammar (D-VERIFY)."""
+    name = name.strip()
+    name = unicodedata.normalize("NFKC", name)
+    name = name.translate(_HOMOGLYPH_TABLE)
+    name = name.casefold()
+    name = _NAMESPACE_PREFIX_RE.sub("", name)
+    return name.strip()
+
 
 # Leet-fold tables (PET-97). Common ASCII digit/symbol→letter substitutions,
 # decoded onto match-only candidate views — never onto ``normalized`` itself:

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import logging
-import re
 import threading
 import time
-import unicodedata
 from collections import deque
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
-from petasos.normalize import _HOMOGLYPH_TABLE
+# PET-118: canonicalize_tool_name is the shared alias-free primitive used by
+# _normalize_tool_name below. _NAMESPACE_PREFIX_RE's single definition now lives in
+# normalize.py; the redundant `as` alias re-exports it explicitly (for --strict mypy's
+# no-implicit-reexport and for tests) so existing
+# `from petasos.session.guard import _NAMESPACE_PREFIX_RE` imports keep resolving.
+from petasos.normalize import _NAMESPACE_PREFIX_RE as _NAMESPACE_PREFIX_RE
+from petasos.normalize import canonicalize_tool_name
 from petasos.session._safe_json import safe_json_dumps
 from petasos.session.escalation import derive_tier, evaluate_tier, max_tier
 
@@ -38,8 +42,6 @@ DEFAULT_TOOL_ALIASES: MappingProxyType[str, str] = MappingProxyType(
         "http_request": "browser",
     }
 )
-
-_NAMESPACE_PREFIX_RE = re.compile(r"^(?:mcp__[a-zA-Z0-9_]+?__|hermes__)")
 
 _MAX_PARAM_TEXT_LEN = 1_000_000
 
@@ -285,11 +287,11 @@ class ToolCallGuard:
         )
 
     def _normalize_tool_name(self, tool_name: str) -> str:
-        name = tool_name.strip()
-        name = unicodedata.normalize("NFKC", name)
-        name = name.translate(_HOMOGLYPH_TABLE)
-        name = name.casefold()
-        name = _NAMESPACE_PREFIX_RE.sub("", name)
+        # PET-118: canonicalize (strip→NFKC→homoglyph→casefold→ns-strip→strip) is the
+        # alias-free shared primitive; alias resolution below layers on top of it. The
+        # plugin's classification reuses canonicalize_tool_name WITHOUT this alias layer,
+        # so the two normalizers never diverge (D-CANON / D-EQUIV).
+        name = canonicalize_tool_name(tool_name)
         if self._profile and self._profile.tool_alias_map:
             combined = {**DEFAULT_TOOL_ALIASES, **self._profile.tool_alias_map}
         else:

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -9,6 +9,7 @@ import pytest
 
 from petasos._types import ScanFinding, Severity
 from petasos.config import PetasosConfig
+from petasos.normalize import canonicalize_tool_name
 from petasos.pipeline import Pipeline
 from petasos.session.frequency import FrequencyTracker, SessionState
 from petasos.session.guard import (
@@ -180,6 +181,51 @@ class TestToolNameNormalization:
         result = await g.evaluate("hermes__", {}, "s1")
         assert result.allowed is False
         assert "empty after normalization" in result.reason
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("READ_FILE", "read"),
+            ("mcp__plane__list_projects", "list_projects"),
+            ("hermes__terminal", "exec"),
+            ("mcp__mcp__tool", "tool"),
+            ("bash", "exec"),
+            ("file_read", "read"),
+            ("web_fetch", "browser"),
+            ("  read_file  ", "read"),
+            ("mcp__server_2__tool", "tool"),
+            ("BASH", "exec"),
+            ("mcp__server__bаsh", "exec"),  # Cyrillic 'а' homoglyph
+            ("", ""),
+            ("   ", ""),
+            ("http_request ", "browser"),  # trailing NBSP: D-EQUIV no-op-strip pin
+        ],
+    )
+    async def test_normalize_tool_name_equivalence_pin(
+        self, valid_key: str, raw: str, expected: str
+    ) -> None:
+        # Regression for PET-118: the canonicalize_tool_name + alias_resolve refactor of
+        # _normalize_tool_name is byte-for-byte equivalent for existing callers (D-EQUIV).
+        g = _guard(key=valid_key)
+        assert g._normalize_tool_name(raw) == expected
+
+    async def test_normalize_guard03_equivalence_after_refactor(self, valid_key: str) -> None:
+        # PET-118 D-EQUIV: the GUARD-03 exempt-redirect block stays in the alias layer,
+        # unchanged by the refactor — a profile alias onto an exempt target is neutralized.
+        p = _profile(
+            tool_alias_map=MappingProxyType({"sneaky": "read"}),
+            tool_exempt_list=frozenset({"read"}),
+        )
+        g = _guard(profile=p, key=valid_key)
+        assert g._normalize_tool_name("sneaky") == "sneaky"
+
+    async def test_classification_canonical_distinct_from_alias(self, valid_key: str) -> None:
+        # PET-118 D-CANON: the web_search -> browser alias collapse lives ONLY in the guard's
+        # alias layer; the shared canonical primitive never applies it.
+        assert canonicalize_tool_name("web_search") == "web_search"
+        assert canonicalize_tool_name("web_search") != "browser"
+        g = _guard(key=valid_key)
+        assert g._normalize_tool_name("web_search") == "browser"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -8,6 +8,7 @@ from petasos.normalize import (
     INVISIBLE_NON_CF,
     RTL_OVERRIDES,
     _is_strippable,
+    canonicalize_tool_name,
     normalize,
 )
 
@@ -470,3 +471,37 @@ class TestLeetFold:
         assert once.normalized == text
         twice = normalize(once.normalized)
         assert twice.normalized == once.normalized
+
+
+class TestCanonicalizeToolName:
+    """PET-118: the alias-free canonical primitive shared by the guard's normalizer and
+    the reference plugin's classification."""
+
+    def test_canonicalize_strips_namespace_and_case(self) -> None:
+        for raw in ("mcp__acme__Send_Email", "HERMES__Send_Email", "SEND_EMAIL"):
+            assert canonicalize_tool_name(raw) == "send_email"
+
+    def test_canonicalize_folds_homoglyph(self) -> None:
+        # Cyrillic 'е' (U+0435) -> ASCII 'e' via _HOMOGLYPH_TABLE (explicit-char mapping,
+        # Unicode-version-independent). NOTE: the 2nd char below is Cyrillic 'е', not ASCII.
+        assert canonicalize_tool_name("sеnd_email") == "send_email"
+
+    def test_canonicalize_is_alias_free(self) -> None:
+        # These all collapse to `browser` under the guard's alias layer; canonicalize must
+        # NOT apply aliases (D-CANON), so each maps to itself.
+        assert canonicalize_tool_name("web_search") == "web_search"
+        assert canonicalize_tool_name("http_request") == "http_request"
+        assert canonicalize_tool_name("web_fetch") == "web_fetch"
+
+    def test_canonicalize_single_strip(self) -> None:
+        # Deliberate SINGLE namespace strip (D6) — not a fixed-point loop.
+        assert canonicalize_tool_name("mcp__mcp__tool") == "tool"  # inner mcp = server seg
+        assert (
+            canonicalize_tool_name("mcp__acme__mcp__evil__send_email") == "mcp__evil__send_email"
+        )
+        # Identity on an already-canonical name keeps the contract unambiguous.
+        assert canonicalize_tool_name("send_email") == "send_email"
+
+    def test_canonicalize_empty_and_prefix_only(self) -> None:
+        for raw in ("", "   ", "mcp__acme__"):
+            assert canonicalize_tool_name(raw) == ""

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -30,6 +30,7 @@ from petasos import (
     Severity,
     ToolCallGuard,
 )
+from petasos.normalize import canonicalize_tool_name
 
 if TYPE_CHECKING:
     import types
@@ -162,6 +163,98 @@ def test_pii_finding_blocks_egress_tool(monkeypatch: pytest.MonkeyPatch) -> None
     )
     assert out_high is not None and out_high["action"] == "block"
     assert out_high["message"].startswith("Security finding (PII, HIGH)")
+
+
+# ---------------------------------------------------------------------------
+# PET-118: classification canonicalizes to the guard's shared form
+# ---------------------------------------------------------------------------
+
+# Egress set holding only the canonical form of "send_email" (already canonical) — the
+# variant tests prove a namespaced/cased/homoglyph name still matches it.
+_SEND_EMAIL_CANON = frozenset({canonicalize_tool_name("send_email")})
+
+
+def test_namespaced_egress_variant_still_pii_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-118: a namespaced / cased / homoglyph variant of a configured egress
+    # tool still trips branch-3 PII-egress blocking (canonical membership, not raw match).
+    variants = (
+        "mcp__acme__Send_Email",  # namespace prefix + mixed case
+        "SEND_EMAIL",  # upper case
+        "sеnd_email",  # Cyrillic 'е' (U+0435) homoglyph -> folds to ASCII 'e'
+    )
+    for variant in variants:
+        out = _drive(
+            monkeypatch,
+            variant,
+            _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+            egress=_SEND_EMAIL_CANON,
+        )
+        assert out is not None and out["action"] == "block", f"{variant!r} should block"
+        assert out["message"].startswith("Security finding (PII, CRITICAL)")
+
+
+def test_namespaced_readonly_variant_not_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PET-118: case/homoglyph/single-`__`-namespace variants of READ_ONLY members canonicalize
+    # back into the read-only set -> not dangerous -> no false-positive quarantine.
+    ref = _import_reference_plugin()
+    # (a) bare double-`__` namespace over a bare read-only member (web_search).
+    assert ref._is_dangerous("mcp__vigil__web_search") is False
+    # (b) a case variant of an actual single-underscore mcp_* member.
+    assert ref._is_dangerous("MCP_VIGIL_HARBOR_MEMORY_SEARCH") is False
+    # _pre_tool_call short-circuits to None at the read-only gate, even with CRITICAL PII.
+    out = _drive(
+        monkeypatch,
+        "mcp__vigil__web_search",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+    )
+    assert out is None
+
+
+def test_readonly_wireform_limitation() -> None:
+    # PET-118 D-READONLY-FORMS (honest pin): the hyphenated double-`__` wire form does NOT
+    # canonicalize onto the stored single-underscore member, so it currently reads dangerous.
+    # Deferred to the D-VERIFY follow-up (PET-121); update this test if the stored forms align.
+    ref = _import_reference_plugin()
+    assert ref._is_dangerous("mcp__vigil-harbor__memory_search") is True
+
+
+def test_alias_collapse_does_not_reclassify(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PET-118 D-CANON: classification skips the guard's alias layer. web_search aliases to
+    # `browser` alongside http_request/web_fetch, but classification must NOT pull web_search
+    # into the egress set nor out of read-only.
+    ref = _import_reference_plugin()
+    egress_canon = frozenset(canonicalize_tool_name(t) for t in PetasosConfig().egress_sink_tools)
+    assert "http_request" in egress_canon  # sanity: the alias sibling IS a default egress sink
+    monkeypatch.setattr(ref, "_egress_sink_tools", egress_canon)
+    assert ref._is_egress_sink("web_search") is False
+    assert ref._is_dangerous("web_search") is False
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "send_email",
+        "SEND_EMAIL",
+        "mcp__acme__send_email",
+        "sеnd_email",  # Cyrillic 'е' homoglyph
+        "web_search",
+        "mcp__vigil__web_search",
+        "read_file",
+        "write_file",
+        "",
+    ],
+)
+def test_classification_shares_guard_canonical_form(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    # PET-118: _is_egress_sink / _is_dangerous agree exactly with canonical membership — no
+    # divergent normalizer hides between the classifier and canonicalize_tool_name.
+    ref = _import_reference_plugin()
+    egress_canon = frozenset(canonicalize_tool_name(t) for t in PetasosConfig().egress_sink_tools)
+    monkeypatch.setattr(ref, "_egress_sink_tools", egress_canon)
+    canon = canonicalize_tool_name(raw)
+    assert ref._is_egress_sink(raw) == (canon in egress_canon)
+    assert ref._is_dangerous(raw) == (canon not in ref._READ_ONLY_CANON)
 
 
 # ---------------------------------------------------------------------------
@@ -400,14 +493,19 @@ def test_deferred_init_populates_egress_set(monkeypatch: pytest.MonkeyPatch) -> 
     _prep_init(ref, monkeypatch)
     monkeypatch.setattr(ref, "_config", {"egress_sink_tools": ["send_email"]})
     ref._deferred_init()
-    assert ref._egress_sink_tools == frozenset({"send_email"})
+    # PET-118: the set is now the CANONICALIZED config (equal to the literals today because
+    # the defaults are already canonical, but the assertion states the post-PET-118 contract
+    # and catches a future non-canonical default).
+    assert ref._egress_sink_tools == frozenset(canonicalize_tool_name(t) for t in ["send_email"])
 
     # Default config → the non-empty default set (catches the F-4 global-shadow bug).
     ref2 = _import_reference_plugin()
     _prep_init(ref2, monkeypatch)
     monkeypatch.setattr(ref2, "_config", {})
     ref2._deferred_init()
-    assert ref2._egress_sink_tools == frozenset(PetasosConfig().egress_sink_tools)
+    assert ref2._egress_sink_tools == frozenset(
+        canonicalize_tool_name(t) for t in PetasosConfig().egress_sink_tools
+    )
     assert len(ref2._egress_sink_tools) > 0
 
 


### PR DESCRIPTION
## Summary
- Closes a PII-egress bypass: a namespaced / cased / homoglyph variant of a configured egress tool satisfied `ToolCallGuard` (which evaluates a *normalized* name) while evading the reference plugin's *raw*-name classification, so PET-112's PII-egress block (branch 3 of `_pre_tool_call`) never fired and **PII could leave through the variant-named egress tool**.
- Classification (`_is_egress_sink` / `_is_dangerous`) and the guard's `_normalize_tool_name` now route through **one** shared, alias-free canonical primitive `canonicalize_tool_name`; `_NAMESPACE_PREFIX_RE` has a single definition (in `normalize.py`).
- Configured tool-name sets are canonicalized once at init/load (`READ_ONLY_TOOLS` at module load, `egress_sink_tools` at `_deferred_init`), with a fail-secure `if c` empty-drop on both axes.

## Verify-first gate (D-VERIFY)
This change is exploitability-gated. The recorded verdict is **EXPLOITABLE — implement** (spec `## Verify-first answer`; Plane comment `082da57b-ad08-475c-a061-06078e9e39fb`): the Hermes `pre_tool_call` hook receives the **raw** model-emitted name, and Hermes resolves cased/namespaced variants to the real tool before dispatch (PR #15124), so PET-112's rationale (b) is false. PET-118 closes the **case / NFKC / homoglyph / zero-width / whitespace** subset of variants of the configured wire name; the **CamelCase / `_tool`-suffix / single-vs-double-underscore** residual is filed as the follow-up **PET-121**.

## Layered defense (D-CANON)
`canonicalize_tool_name` is deliberately **alias-free**. `http_request` (a default egress sink) and `web_search` (read-only) both alias to `browser` in the guard; reusing the guard's *full* normalizer for classification would register `web_search` as an egress sink and dissolve the read-only/egress boundary. The alias layer stays inside `ToolCallGuard._normalize_tool_name`; classification uses only the canonical prefix.

## Files changed

| File | Change |
|------|--------|
| `petasos/normalize.py` | Adds `canonicalize_tool_name` + relocates `_NAMESPACE_PREFIX_RE` (single source of truth) |
| `petasos/session/guard.py` | Refactors `_normalize_tool_name` to `alias_resolve(canonicalize_tool_name(...))` (byte-for-byte equivalent, D-EQUIV); re-exports `_NAMESPACE_PREFIX_RE` |
| `docs/deployment/reference_plugin/__init__.py` | Canonicalizes incoming names + `_READ_ONLY_CANON` (module-load) + `_egress_sink_tools` (`_deferred_init`), fail-secure `if c` drop |
| `petasos/config.py` | Comment-only: "matched raw" → "canonicalized by the plugin" (×2); logic unchanged |
| `tests/test_normalize.py` | Unit tests for `canonicalize_tool_name` |
| `tests/test_guard.py` | Equivalence pin (+ trailing-NBSP) and alias-collapse-vs-canonical assertions |
| `tests/test_reference_plugin_egress.py` | Namespaced/cased/homoglyph egress + read-only variant regressions; tightened egress-init assertion |

## Test plan
- [x] `python -m pytest tests/test_reference_plugin_egress.py tests/test_guard.py tests/test_normalize.py tests/adversarial/guard/test_tool_smuggling.py -q` — 189/189 pass (full output: `docs/specs/TODO/PET-118.test-output.txt`)
- [x] `python -m pytest -q` — 1604 passed, 40 skipped, 1 xfailed (pre-existing 3.10/Unicode-13 `test_default_ignorable_rejected` deselected — `assert 266>=267`, unrelated to this change)
- [x] `ruff check .` — clean (no F401 from the moved/re-exported imports)
- [x] `ruff format --check .` — clean
- [x] `mypy --strict .` — clean (explicit `as` re-export satisfies `--no-implicit-reexport`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a shared tool-name canonicalization helper (trimming, Unicode normalization, homoglyph handling, and single-pass namespace-prefix stripping).

* **Refactor**
  * Updated security gating so dangerous/read-only/egress-sink classification consistently uses canonical tool-name membership (including canonicalized config-derived egress sinks).

* **Tests**
  * Expanded coverage for canonicalization equivalence, alias-layer behavior, and PET-118 egress/danger consistency; updated assertions around deferred initialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->