### PR TITLE
fix(pet-119): wire profile pii_entities_extra into per-profile Presidio scoping

### DIFF
--- a/.github/workflows/extras-presidio.yml
+++ b/.github/workflows/extras-presidio.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths:
       - "petasos/scanners/presidio.py"
+      - "petasos/pipeline.py" # PET-119: profile→Presidio extras wiring
+      - "petasos/session/profiles/__init__.py" # PET-119: pii_entities_extra source
       - "petasos/config.py"
       - "petasos/console/hermes/plugin_api.py"
       - "tests/test_presidio_scanner.py"

--- a/docs/specs/TODO/PET-119.test-output.txt
+++ b/docs/specs/TODO/PET-119.test-output.txt
@@ -1,0 +1,136 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-119-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1668 items / 1 deselected / 1667 selected
+
+tests\adversarial\config\test_bool_coercion.py ......................... [  1%]
+......                                                                   [  1%]
+tests\adversarial\config\test_config_poisoning.py ............           [  2%]
+tests\adversarial\escalation\test_derive_tier.py ......                  [  2%]
+tests\adversarial\escalation\test_standalone_tier3.py .....              [  3%]
+tests\adversarial\escalation\test_tier3_floor_inline.py ..               [  3%]
+tests\adversarial\frequency\test_rate_limited_sentinel.py ....           [  3%]
+tests\adversarial\frequency\test_session_spoofing.py .....               [  3%]
+tests\adversarial\frequency\test_terminated_state_loss.py .........      [  4%]
+tests\adversarial\frequency\test_ttl_eviction.py ....                    [  4%]
+tests\adversarial\guard\test_tool_smuggling.py ...................       [  5%]
+tests\adversarial\license\test_jwt_attacks.py ...                        [  5%]
+tests\adversarial\license\test_license_hardening.py .................... [  7%]
+...                                                                      [  7%]
+tests\adversarial\normalization\test_unicode_bypass.py ................. [  8%]
+.....                                                                    [  8%]
+tests\adversarial\pipeline\test_callback_isolation.py ...............    [  9%]
+tests\adversarial\pipeline\test_cancel_mid_gather.py ......              [  9%]
+tests\adversarial\pipeline\test_cancel_scan_residual.py .                [ 10%]
+tests\adversarial\pipeline\test_degraded_fail_open.py .................. [ 11%]
+......                                                                   [ 11%]
+tests\adversarial\pipeline\test_env_license_trust.py ...                 [ 11%]
+tests\adversarial\pipeline\test_rt075_chain.py x....                     [ 11%]
+tests\adversarial\pipeline\test_scanner_timeout_breaker.py ............. [ 12%]
+.....                                                                    [ 13%]
+tests\adversarial\profiles\test_suppress_bypass.py ......                [ 13%]
+tests\adversarial\scanner\test_confidence_clamp.py ......                [ 13%]
+tests\adversarial\syntactic\test_binary_nul.py .                         [ 13%]
+tests\adversarial\syntactic\test_command_rules.py ...................... [ 15%]
+........................................................................ [ 19%]
+.....                                                                    [ 19%]
+tests\adversarial\syntactic\test_encoding_evasion.py ............        [ 20%]
+tests\adversarial\syntactic\test_injection_evasion.py .................. [ 21%]
+.....................................                                    [ 23%]
+tests\adversarial\syntactic\test_json_depth_strings.py .                 [ 23%]
+tests\adversarial\types\test_type_validation.py ...................      [ 24%]
+tests\test_alerting.py ................................................. [ 27%]
+..................                                                       [ 28%]
+tests\test_audit.py ..................................                   [ 31%]
+tests\test_benchmarks.py ssssssss                                        [ 31%]
+tests\test_ci_extras_lanes.py ............                               [ 32%]
+tests\test_config.py ..............................................      [ 34%]
+tests\test_config_meta.py ..................                             [ 36%]
+tests\test_console_armed.py ..............................               [ 37%]
+tests\test_console_handlers.py ......................................... [ 40%]
+........                                                                 [ 40%]
+tests\test_console_playground.py ....                                    [ 41%]
+tests\test_console_validation.py ....................................... [ 43%]
+....................                                                     [ 44%]
+tests\test_escalation.py ...............                                 [ 45%]
+tests\test_finding_merge.py ............                                 [ 46%]
+tests\test_formatting.py ....................                            [ 47%]
+tests\test_frequency.py .......................................          [ 49%]
+tests\test_frequency_tombstone.py .................                      [ 50%]
+tests\test_guard.py .................................................... [ 53%]
+..............................                                           [ 55%]
+tests\test_hardening.py ..............                                   [ 56%]
+tests\test_hermes_integration_defaults.py .................              [ 57%]
+tests\test_hermes_smoke.py ssss..                                        [ 57%]
+tests\test_integration_e2e.py ..................                         [ 58%]
+tests\test_license.py ....................                               [ 60%]
+tests\test_lineage.py ...................                                [ 61%]
+tests\test_llama_firewall_scanner.py ................................... [ 63%]
+...........sssssssssssss                                                 [ 64%]
+tests\test_llama_firewall_wrapper.py ss                                  [ 64%]
+tests\test_llm_guard_scanner.py .......................ssssssssss        [ 66%]
+tests\test_llm_guard_wrapper.py ....ssss.......                          [ 67%]
+tests\test_minimal_scanner.py .......................................... [ 70%]
+....................................                                     [ 72%]
+tests\test_normalize.py ................................................ [ 75%]
+.............                                                            [ 76%]
+tests\test_pipeline.py ................................................. [ 79%]
+......                                                                   [ 79%]
+tests\test_pipeline_suppression.py ..........                            [ 80%]
+tests\test_plugin_api_paths.py .......................................   [ 82%]
+tests\test_plugin_api_sse.py ......                                      [ 82%]
+tests\test_plugin_init_logging.py ....                                   [ 83%]
+tests\test_presidio_entity_scoping.py .....................              [ 84%]
+tests\test_presidio_scanner.py ......................................... [ 86%]
+.............                                                            [ 87%]
+tests\test_profiles.py ..............................................    [ 90%]
+tests\test_profiles_retained_ref.py ...                                  [ 90%]
+tests\test_profiles_suppress.py ........                                 [ 90%]
+tests\test_reference_plugin_egress.py ...........................        [ 92%]
+tests\test_ring_buffer.py ........                                       [ 93%]
+tests\test_safe_json.py .........                                        [ 93%]
+tests\test_scanner_init.py ...........                                   [ 94%]
+tests\test_session_integration.py ...................................... [ 96%]
+...........                                                              [ 97%]
+tests\test_sse.py .......                                                [ 97%]
+tests\test_subagent_plugin_wiring.py ............                        [ 98%]
+tests\test_types.py ................                                     [ 99%]
+tests\test_verify.py ............                                        [100%]
+
+============================== warnings summary ===============================
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-119-worktree\petasos\console\server.py:301: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=== 1625 passed, 41 skipped, 1 deselected, 1 xfailed, 68 warnings in 31.79s ===
+
+=== ruff check . ===
+All checks passed!
+
+=== ruff format --check . ===
+116 files already formatted
+
+=== mypy --strict . ===
+Success: no issues found in 116 source files

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -24,6 +24,7 @@ from petasos._types import (
 from petasos.config import PetasosConfig
 from petasos.normalize import normalize
 from petasos.scanners.minimal import _UNSUPPRESSIBLE_RULE_IDS, MinimalScanner
+from petasos.scanners.presidio import PresidioScanner
 from petasos.session.alerting import AlertManager
 from petasos.session.audit import AuditEmitter
 from petasos.session.frequency import FrequencyTracker, FrequencyUpdateResult
@@ -212,12 +213,19 @@ async def _scan_one(
     direction: Direction,
     session_id: str | None,
     timeout: float = _SCANNER_TIMEOUT,
+    extra_entities: Sequence[str] | None = None,
 ) -> ScanResult:
     sname = getattr(scanner, "name", "unknown")
     t0 = time.perf_counter()
     try:
+        # extra_entities is Presidio-only (PET-119); passed conditionally so the
+        # generic Scanner.scan() call stays protocol-conformant under mypy --strict
+        # (no keyword reaches non-Presidio scanners).
+        scan_kwargs: dict[str, Any] = {"direction": direction, "session_id": session_id}
+        if extra_entities is not None:
+            scan_kwargs["extra_entities"] = list(extra_entities)
         return await asyncio.wait_for(
-            scanner.scan(normalized_text, direction=direction, session_id=session_id),
+            scanner.scan(normalized_text, **scan_kwargs),
             timeout=timeout,
         )
     except asyncio.TimeoutError:  # noqa: UP041
@@ -617,7 +625,21 @@ class Pipeline:
         elif self._ml_scanners:
             tasks = [
                 self._scan_with_breaker(
-                    s, normalized_text, direction=direction, session_id=session_id
+                    s,
+                    normalized_text,
+                    direction=direction,
+                    session_id=session_id,
+                    # PET-119: per-profile additive PII opt-ins, Presidio-only. A
+                    # per-call concrete-type check (not a one-time partition like
+                    # the minimal scanner): the extras are profile-dependent and
+                    # recomputed each inspect(), and only PresidioScanner.scan
+                    # accepts the keyword. None on the no-profile/non-Presidio path
+                    # keeps today's exact behavior.
+                    extra_entities=(
+                        active_profile.pii_entities_extra
+                        if active_profile is not None and isinstance(s, PresidioScanner)
+                        else None
+                    ),
                 )
                 for s in self._ml_scanners
             ]
@@ -786,6 +808,7 @@ class Pipeline:
         *,
         direction: Direction,
         session_id: str | None,
+        extra_entities: Sequence[str] | None = None,
     ) -> ScanResult:
         """Run one ML scanner under the consecutive-timeout circuit breaker (PIPE-03).
 
@@ -825,6 +848,7 @@ class Pipeline:
             direction=direction,
             session_id=session_id,
             timeout=self._config.scanner_timeout_seconds,
+            extra_entities=extra_entities,
         )
         self._last_scan_durations[sname] = (time.monotonic() - _t0) * 1000
         if result.error is not None:

--- a/petasos/scanners/presidio.py
+++ b/petasos/scanners/presidio.py
@@ -277,8 +277,16 @@ class PresidioScanner:
         *,
         direction: Direction = "inbound",
         session_id: str | None = None,
+        extra_entities: Sequence[str] | None = None,
     ) -> ScanResult:
         """Scan ``text`` for PII and return a ScanResult (never raises).
+
+        ``extra_entities`` (PET-119) is an *additive* per-call opt-in list, unioned
+        on top of the scanner's constructed base set (``self._entities``) for this
+        call only. It lets a caller (the pipeline, per active profile) widen the
+        detected entity set without rebuilding the scanner; ``self._entities`` is
+        never mutated, so concurrent scans on different profiles cannot race
+        (Decision 6). ``None``/empty preserves today's behavior exactly.
 
         Cancellation residual (SCAN-03): analysis runs in a worker thread via
         ``asyncio.to_thread``. Cancelling the awaiting task frees the event loop
@@ -289,7 +297,8 @@ class PresidioScanner:
         start_time = time.perf_counter()
         try:
             self._ensure_loaded()
-            findings = await asyncio.to_thread(self._scan_sync, text)
+            effective = self._effective_entities(extra_entities)
+            findings = await asyncio.to_thread(self._scan_sync, text, effective)
             elapsed = (time.perf_counter() - start_time) * 1000
             return ScanResult(
                 scanner_name=self.name,
@@ -316,10 +325,25 @@ class PresidioScanner:
                 error=msg,
             )
 
-    def _scan_sync(self, text: str) -> list[ScanFinding]:
+    def _effective_entities(self, extra_entities: Sequence[str] | None) -> list[str]:
+        """Additive, order-preserving dedup of ``extra_entities`` over the base set.
+
+        Returns the scanner's own ``self._entities`` unchanged when there are no
+        extras (the default/no-profile path — byte-for-byte today's behavior).
+        Otherwise unions the per-call extras on top via ``resolve_presidio_entities``
+        (the same order-preserving ``dict.fromkeys`` dedup the config path uses), so
+        a config/profile overlap cannot double-fire. ``self._entities`` is always
+        non-empty (>= DEFAULT_PRESIDIO_ENTITIES), so the empty-set guard never trips.
+        ``self._entities`` is **not** mutated (Decision 6 concurrency invariant). PET-119.
+        """
+        if not extra_entities:
+            return self._entities
+        return resolve_presidio_entities(tuple(self._entities), tuple(extra_entities))
+
+    def _scan_sync(self, text: str, entities: list[str] | None = None) -> list[ScanFinding]:
         results = self._analyzer.analyze(
             text=text,
-            entities=self._entities,
+            entities=self._entities if entities is None else entities,
             language=self._language,
             score_threshold=self._score_threshold,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,13 @@ NONSKIPPING_LANES: tuple[NonSkippingLane, ...] = (
         "TestPresidioTightenedDefault",
         "extras-presidio",
     ),
+    NonSkippingLane(
+        "presidio",
+        "PETASOS_REQUIRE_PRESIDIO",
+        "presidio_analyzer",
+        "TestProfilePresidioScoping",  # PET-119 profile→Presidio wiring contract
+        "extras-presidio",
+    ),
 )
 
 

--- a/tests/test_presidio_entity_scoping.py
+++ b/tests/test_presidio_entity_scoping.py
@@ -8,12 +8,19 @@ conftest non-skipping-lane guard pins for ``extras-presidio`` (D4).
 
 from __future__ import annotations
 
+import asyncio
 import math
+from typing import Any
 
 import pytest
 
 from petasos.config import PetasosConfig
-from petasos.scanners.minimal import _STRUCTURAL_RULE_IDS, _UNSUPPRESSIBLE_RULE_IDS
+from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import (
+    _STRUCTURAL_RULE_IDS,
+    _UNSUPPRESSIBLE_RULE_IDS,
+    MinimalScanner,
+)
 from petasos.scanners.presidio import (
     DEFAULT_PRESIDIO_ENTITIES,
     NOISY_OPT_IN_ENTITIES,
@@ -235,3 +242,178 @@ class TestPresidioTightenedDefault:
         assert any("credit_card" in r for r in rule_ids), rule_ids
         assert any("email" in r for r in rule_ids), rule_ids
         assert any("phone" in r for r in rule_ids), rule_ids
+
+
+# ---------------------------------------------------------------------------
+# PET-119: profile.pii_entities_extra → per-profile Presidio scoping
+#
+# These pins make the field load-bearing: each fails if a profile-set PII entity
+# silently no-ops again. The scan-level and pipeline-level rows are backend-free
+# (a recording fake stands in for the analyzer); the real-backend contract lives
+# in TestProfilePresidioScoping below.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAnalyzer:
+    """Backend-free stand-in for presidio's AnalyzerEngine. Records the exact
+    ``entities`` list ``analyzer.analyze`` is handed, with no spaCy dependency, so
+    the per-call effective-entity computation can be asserted on every lane."""
+
+    def __init__(self) -> None:
+        self.entities: list[str] | None = None
+
+    def analyze(
+        self,
+        *,
+        text: str,
+        entities: list[str],
+        language: str,
+        score_threshold: float,
+    ) -> list[Any]:
+        self.entities = list(entities)
+        return []
+
+
+def _recording_scanner(**kw: Any) -> tuple[PresidioScanner, _RecordingAnalyzer]:
+    s = PresidioScanner(**kw)
+    rec = _RecordingAnalyzer()
+    s._analyzer = rec
+    s._loaded = True
+    return s, rec
+
+
+class _RecordingPresidio(PresidioScanner):
+    """PresidioScanner subclass wired to a recording analyzer so the pipeline's
+    ``isinstance(s, PresidioScanner)`` Presidio special-case holds (the extras are
+    only threaded to scanners that are PresidioScanner instances)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._rec = _RecordingAnalyzer()
+        self._analyzer = self._rec
+        self._loaded = True
+
+
+# --- scan() additive channel (backend-free) --------------------------------
+
+
+def test_scan_no_extra_uses_base() -> None:
+    # Negative pin: no extras (omitted / None / empty) records exactly the base set.
+    for extra in (None, ()):
+        scanner, rec = _recording_scanner()
+        asyncio.run(scanner.scan("text", extra_entities=extra))
+        assert rec.entities == list(DEFAULT_PRESIDIO_ENTITIES)
+    scanner, rec = _recording_scanner()
+    asyncio.run(scanner.scan("text"))  # keyword omitted entirely
+    assert rec.entities == list(DEFAULT_PRESIDIO_ENTITIES)
+
+
+def test_scan_extra_entities_additive() -> None:
+    scanner, rec = _recording_scanner()
+    asyncio.run(scanner.scan("text", extra_entities=("PERSON",)))
+    assert rec.entities == [*DEFAULT_PRESIDIO_ENTITIES, "PERSON"]
+
+
+def test_scan_extra_entities_dedup() -> None:
+    # EMAIL_ADDRESS is already in the base — the additive union must not duplicate it.
+    scanner, rec = _recording_scanner()
+    asyncio.run(scanner.scan("text", extra_entities=("EMAIL_ADDRESS",)))
+    assert rec.entities == list(DEFAULT_PRESIDIO_ENTITIES)
+    assert rec.entities.count("EMAIL_ADDRESS") == 1
+
+
+def test_scan_does_not_mutate_self_entities() -> None:
+    # Decision 6 concurrency invariant: the effective list is a per-call local;
+    # self._entities is read-only after construction.
+    scanner, rec = _recording_scanner()
+    asyncio.run(scanner.scan("text", extra_entities=("PERSON",)))
+    assert scanner._entities == list(DEFAULT_PRESIDIO_ENTITIES)
+    assert "PERSON" not in scanner._entities
+
+
+def test_scan_unknown_extra_threads_through() -> None:
+    # Presidio is the filter — the wiring must not silently drop unknown names, or a
+    # regression could hide behind a swallowed entity (Design note, edge-cases/F-2).
+    scanner, rec = _recording_scanner()
+    asyncio.run(scanner.scan("text", extra_entities=("NOT_A_REAL_ENTITY",)))
+    assert rec.entities == [*DEFAULT_PRESIDIO_ENTITIES, "NOT_A_REAL_ENTITY"]
+
+
+# --- pipeline threading (backend-free) -------------------------------------
+
+
+def test_pipeline_passes_profile_extras_to_presidio() -> None:
+    rec_presidio = _RecordingPresidio()
+    pipeline = Pipeline([MinimalScanner(), rec_presidio])
+    asyncio.run(pipeline.inspect("benign text", profile="customer_service"))
+    # customer_service extras = [PERSON, EMAIL_ADDRESS, PHONE_NUMBER]; EMAIL_ADDRESS
+    # and PHONE_NUMBER are already in the base, so the order-preserving union adds
+    # only PERSON.
+    assert rec_presidio._rec.entities == [*DEFAULT_PRESIDIO_ENTITIES, "PERSON"]
+
+
+def test_pipeline_no_profile_uses_base() -> None:
+    # Negative pin at the pipeline layer: no active profile -> keyword omitted ->
+    # base set; no profile leakage.
+    rec_presidio = _RecordingPresidio()
+    pipeline = Pipeline([MinimalScanner(), rec_presidio])
+    asyncio.run(pipeline.inspect("benign text"))
+    assert rec_presidio._rec.entities == list(DEFAULT_PRESIDIO_ENTITIES)
+
+
+def test_pipeline_general_profile_empty_extras_uses_base() -> None:
+    # Empty-extras pin (edge-cases/F-1): general's pii_entities_extra == [] makes the
+    # keyword present-but-empty, which must collapse to the base — structurally
+    # distinct from the no-profile branch (keyword omitted) and the most common live
+    # path whenever general is active.
+    rec_presidio = _RecordingPresidio()
+    pipeline = Pipeline([MinimalScanner(), rec_presidio])
+    asyncio.run(pipeline.inspect("benign text", profile="general"))
+    assert rec_presidio._rec.entities == list(DEFAULT_PRESIDIO_ENTITIES)
+
+
+# ---------------------------------------------------------------------------
+# Real-backend contract — non-skipping on the extras-presidio lane (PET-119)
+# ---------------------------------------------------------------------------
+
+
+@requires_presidio
+class TestProfilePresidioScoping:
+    """The load-bearing contract: a profile opt-in (PERSON) that is NOT in the config
+    default fires under that profile and not under one without it. This is the exact
+    assertion PET-117 declined to add (it would false-green while the field was inert);
+    it fails if the profile→Presidio wiring ever regresses."""
+
+    # NER-friendly corpus: a full name with a title + a "Customer name:" cue scores
+    # PERSON comfortably above the 0.35 default threshold on en_core_web_lg. Phrasing
+    # is pinned, not deferred — PERSON is spaCy-NER, not a deterministic pattern
+    # recognizer, so a bare "John Smith" can fall below threshold and flake.
+    _CORPUS = "Customer name: Dr. Margaret Thompson called about her account."
+
+    def _pipeline(self) -> Pipeline:
+        return Pipeline([MinimalScanner(), PresidioScanner()])
+
+    def test_person_fires_under_customer_service_not_general(self) -> None:
+        pipeline = self._pipeline()
+
+        cs = asyncio.run(pipeline.inspect(self._CORPUS, profile="customer_service"))
+        assert cs.errors == ()
+        person = [f for f in cs.findings if f.rule_id == "petasos.presidio.person"]
+        assert person, f"expected a PERSON finding under customer_service, got {cs.findings}"
+        # Buffer above the 0.35 threshold so a marginal future model regression fails
+        # loudly rather than flaking.
+        assert max(f.confidence for f in person) > 0.45
+
+        general = asyncio.run(pipeline.inspect(self._CORPUS, profile="general"))
+        assert general.errors == ()
+        assert not any(f.rule_id == "petasos.presidio.person" for f in general.findings), (
+            f"PERSON must not fire under general (no opt-in), got {general.findings}"
+        )
+
+    def test_admin_person_fires(self) -> None:
+        pipeline = self._pipeline()
+        admin = asyncio.run(pipeline.inspect(self._CORPUS, profile="admin"))
+        assert admin.errors == ()
+        assert any(f.rule_id == "petasos.presidio.person" for f in admin.findings), (
+            f"expected a PERSON finding under admin, got {admin.findings}"
+        )


### PR DESCRIPTION
## Summary
- Makes `profile.pii_entities_extra` actually drive Presidio detection. The field was parsed, validated, merged, and serialized for frontend binding but had **no scan-time consumer** — operators could set it and observe no effect (dead config).
- Wires it as an **additive, per-profile opt-in** on top of the config-resolved entity set, computed per scan and passed as a call argument. `self._entities` is never mutated, so concurrent scans on different profiles cannot race (Decision 6).
- No-profile / default path is **byte-for-byte unchanged** (PET-109's tightened band and noise posture preserved).

## Two opt-in surfaces (config base + profile additive)
PET-109 made the noisy entities opt-in via the **config** `presidio_entities_extra` (global base). This adds the **profile** `pii_entities_extra` as a *second* additive channel, unioned on top per profile via the same `resolve_presidio_entities` order-preserving dedup — so a config/profile overlap (e.g. both list `URL`) cannot double-fire. Detection on the default/no-profile path is unaffected.

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/presidio.py` | Adds additive `extra_entities` keyword to `scan()`, `_effective_entities()` union helper, and a per-call `entities` arg on `_scan_sync()`. `self._entities` read-only. |
| `petasos/pipeline.py` | Wires Stage-4 fan-out to pass the active profile's `pii_entities_extra` to the Presidio scanner only (`isinstance` check); threads it through `_scan_with_breaker` / `_scan_one` via a conditional kwargs dict (non-Presidio scanners stay protocol-conformant under mypy --strict). |
| `tests/test_presidio_entity_scoping.py` | Adds backend-free scan/pipeline pins + the real-backend `TestProfilePresidioScoping` contract. |
| `tests/conftest.py` | Arms `TestProfilePresidioScoping` in `NONSKIPPING_LANES` under `PETASOS_REQUIRE_PRESIDIO`. |
| `.github/workflows/extras-presidio.yml` | Widens the `paths:` trigger to `pipeline.py` + `profiles/__init__.py` (the wiring files). |

## Layered defense (recurrence prevention)
The load-bearing `PERSON`-under-`customer_service`-vs-`general` real-backend test is the exact assertion PET-117 declined to add (it would have false-greened while the field was inert). Backstopped by backend-free pins: additive, dedup, no-mutation, unknown-threads-through, and negative pins for both the no-profile branch (keyword omitted) and the empty-extras branch (`general`, keyword present-but-empty).

## Test plan
- [x] `python -m pytest tests/ -k "not test_default_ignorable_rejected"` — 1625 passed, 41 skipped, 1 deselected, 1 xfailed (full output: docs/specs/TODO/PET-119.test-output.txt)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 116 files already formatted
- [x] `mypy --strict .` — Success, no issues in 116 source files
- [x] Real-backend contract ran non-skipping locally (presidio + `en_core_web_lg` present): PERSON fires under `customer_service`/`admin` with confidence > 0.45, not under `general`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Presidio scanner now supports per-profile custom PII entity configurations that additively merge with base entities for flexible detection.

* **Tests**
  * Added comprehensive test coverage for profile-based entity scoping and scanner behavior.

* **Chores**
  * Updated CI workflows to track additional Presidio configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->