### PR TITLE
fix(pet-121): mirror Hermes CamelCase / _tool dispatch shapes in canonicalize_tool_name

### DIFF
--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -318,6 +318,44 @@ petasos:
 | `session_ttl_seconds` | 3600.0 | 1-hour TTL matches typical chat session |
 | Normalization toggles | all `true` | No reason to disable any |
 
+### Tool-name canonicalization vs Hermes dispatch
+
+The `pre_tool_call` hook (where the guard runs) sees the **raw model-emitted tool
+name**. Hermes resolves that raw name to a registered tool *after* the hook fires,
+trying a candidate set — lowercase, separator-normalized, CamelCase→snake,
+`_tool`/`-tool` suffix-stripped — and finally a fuzzy (`difflib`) fallback. Petasos
+canonicalizes both your configured names and the incoming name through one shared
+function so a `SendEmail` / `SEND_EMAIL` / `send_email_tool` variant of a configured
+egress tool is still matched. Two operator-facing consequences:
+
+- **List MCP tools by their full single-underscore wire name (D-NS).** Hermes
+  namespaces MCP tools as `mcp_<server>_<tool>` (e.g. `mcp_acme_send_email`), where
+  `_` is *both* the separator and a legal character inside server/tool names — so the
+  boundary is not recoverable without the registry. Petasos therefore does **not**
+  heuristically strip the single-underscore `mcp_` prefix (a greedy strip would
+  mis-segment real names and add false matches). Configure the **full wire name** in
+  both `egress_sink_tools` and your read-only set:
+
+  ```yaml
+  # Right — full single-underscore wire name; its case/CamelCase/_tool variants
+  #         all canonicalize onto this entry.
+  egress_sink_tools:
+    - mcp_acme_send_email
+  # Wrong — bare name; the namespaced wire name will NOT match it.
+  #   - send_email
+  ```
+
+  (The double-underscore `mcp__<server>__` / `hermes__` prefix *is* stripped — that
+  is the OpenClaw / Claude-Code convention, harmless-but-inert for Hermes.)
+
+- **Bound or disable Hermes's fuzzy fallback host-side (D-FUZZY).** Hermes's
+  `difflib.get_close_matches(..., cutoff=0.7)` last resort can map a name no
+  deterministic canonicalizer can reproduce (e.g. `snd_eml` → `send_email`). Petasos
+  deliberately does **not** mirror fuzzy resolution. If your Hermes build allows it,
+  bound or disable the fuzzy tool-name fallback so a fuzzily-resolved variant cannot
+  reach a real egress/dangerous tool without an exact/deterministic match the guard
+  also sees.
+
 ## 6. Restart and verify
 
 **Full app restart required.** Plugin discovery runs at app startup, not

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -333,8 +333,12 @@ egress tool is still matched. Two operator-facing consequences:
   `_` is *both* the separator and a legal character inside server/tool names — so the
   boundary is not recoverable without the registry. Petasos therefore does **not**
   heuristically strip the single-underscore `mcp_` prefix (a greedy strip would
-  mis-segment real names and add false matches). Configure the **full wire name** in
-  both `egress_sink_tools` and your read-only set:
+  mis-segment real names and add false matches). Use the **full wire name** wherever
+  you name the tool — but note these are two separate mechanisms, not two config
+  steps. `egress_sink_tools` is an operator knob in `config.yaml` (below). The
+  read-only set is *code*: the plugin's `READ_ONLY_TOOLS` constant, canonicalized at
+  load into `_READ_ONLY_CANON`, which `_is_dangerous()` consults directly — customize
+  it by editing the plugin, not `config.yaml`.
 
   ```yaml
   # Right — full single-underscore wire name; its case/CamelCase/_tool variants

--- a/docs/specs/TODO/PET-121.test-output.txt
+++ b/docs/specs/TODO/PET-121.test-output.txt
@@ -1,0 +1,30 @@
+PET-121 — test gate evidence
+Branch: fix/pet-121-canonicalize-hermes-dispatch  (base origin/master 3f79bdb)
+Interpreter: Python 3.10.6
+Date: 2026-06-14
+
+================================================================
+Primary gate (spec § Test command):
+python -m pytest tests/test_normalize.py tests/test_guard.py tests/test_reference_plugin_egress.py tests/adversarial/guard/test_tool_smuggling.py -q
+================================================================
+........................................................................ [ 32%]
+........................................................................ [ 65%]
+........................................................................ [ 98%]
+....                                                                     [100%]
+220 passed in 1.45s
+
+================================================================
+Full suite (deselect pre-existing Unicode-13 test_default_ignorable_rejected on local 3.10):
+python -m pytest -q -k 'not test_default_ignorable_rejected'
+================================================================
+1656 passed, 41 skipped, 1 deselected, 1 xfailed, 68 warnings in 28.17s
+
+================================================================
+Static gates:
+================================================================
+$ ruff check .
+All checks passed!
+$ ruff format --check .
+116 files already formatted
+$ mypy --strict .
+Success: no issues found in 116 source files

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -160,7 +160,12 @@ class PetasosConfig:
     # (write_file/terminal/execute_code/edit) are exempt. Stored RAW; canonicalized by the
     # plugin before matching (PET-118), mirroring READ_ONLY_TOOLS/_is_dangerous. Best-effort
     # default names — operators must align to their host's tool registry (frontend-bindable,
-    # PET-112).
+    # PET-112). PET-121 (D-NS): an MCP-namespaced egress tool must be listed by its FULL
+    # single-underscore wire name (e.g. mcp_acme_send_email), not a bare name — the
+    # single-underscore mcp_ prefix is ambiguous (the separator is also a legal name char)
+    # and is deliberately NOT stripped; canonicalization then closes the case/homoglyph/
+    # CamelCase/_tool variants OF THAT configured wire name. See docs/deployment/
+    # hermes-desktop.md ("Tool-name canonicalization vs Hermes dispatch").
     egress_sink_tools: tuple[str, ...] = (
         "send_email",
         "send_message",

--- a/petasos/normalize.py
+++ b/petasos/normalize.py
@@ -159,20 +159,56 @@ _HOMOGLYPH_TABLE = str.maketrans(
 # _HOMOGLYPH_TABLE because canonicalize_tool_name composes both.
 _NAMESPACE_PREFIX_RE = re.compile(r"^(?:mcp__[a-zA-Z0-9_]+?__|hermes__)")
 
+# PET-121: split at a TRUE camel boundary only — a lowercase/digit immediately followed
+# by an uppercase. Boundary-guarded, NOT Hermes's naive `(?<!^)(?=[A-Z])` (which mangles
+# all-caps/snake-with-capital names: SEND_EMAIL -> s_e_n_d__e_m_a_i_l). Hermes survives its
+# own naive split because it is one candidate in a registry-guarded set; Petasos emits a
+# SINGLE canonical form and has no registry, so it must reproduce Hermes's *resolved
+# outcome* for snake tools without mangling (D-CAMEL).
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+def _strip_tool_suffix(name: str) -> str:
+    """PET-121 (D-SUFFIX): strip a trailing ``_tool`` / ``-tool``, looped twice to mirror
+    Hermes's ``range(2)`` (``TodoTool_tool`` -> ``todo``). The empty-guard never strips to
+    ``""`` (Hermes guards via ``if c``). Bare ``tool`` (no separator) is deliberately NOT
+    stripped: Hermes only strips it when the result is a registered tool, and Petasos has no
+    registry — an unconditional strip would over-canonicalize (``dbtool`` -> ``db``) and
+    break PET-118's ``mcp__mcp__tool`` -> ``tool`` fixtures. ``name`` is already casefolded
+    and namespace-stripped here."""
+    for _ in range(2):
+        for suffix in ("_tool", "-tool"):
+            if name.endswith(suffix):
+                stripped = name[: -len(suffix)].rstrip("_-")
+                if stripped:  # empty-guard: never strip to "" (keeps prior value)
+                    name = stripped
+                break
+        else:
+            break  # no separator-suffix matched this pass -> done
+    return name
+
 
 def canonicalize_tool_name(name: str) -> str:
-    """Alias-free canonical form for tool-name matching. Shared by ToolCallGuard's
-    normalizer (under its alias layer) and the reference plugin's classification, so
-    the two never diverge. Pure: no profile/alias dependency.
+    """Alias-free canonical form for tool-name matching, shared by ToolCallGuard's
+    normalizer (under its alias layer) and the reference plugin's classification.
+
+    Mirrors the deterministic shapes Hermes resolves at dispatch (PET-121): a
+    boundary-guarded CamelCase->snake split (BEFORE casefold — the case info is
+    load-bearing) and a trailing _tool/-tool suffix strip. It does NOT reproduce
+    Hermes's naive single-regex camel (which mangles all-caps names as a single
+    form), its registry-guarded bare-`tool` strip, its single-underscore mcp_
+    namespace stripping, or its fuzzy fallback — see D-CAMEL/D-SUFFIX/D-NS/D-FUZZY.
 
     Strips a SINGLE leading namespace prefix (matching the guard's existing behavior,
-    D-EQUIV / D6) — not a fixed-point loop. Stacked/alternate prefix shapes are a D6
+    D-EQUIV / D6) — not a fixed-point loop. Stacked/alternate prefix shapes remain a D6
     coverage item gated on the verified Hermes grammar (D-VERIFY)."""
     name = name.strip()
     name = unicodedata.normalize("NFKC", name)
     name = name.translate(_HOMOGLYPH_TABLE)
+    name = _CAMEL_BOUNDARY_RE.sub("_", name)  # PET-121 D-CAMEL/D1: BEFORE casefold
     name = name.casefold()
     name = _NAMESPACE_PREFIX_RE.sub("", name)
+    name = _strip_tool_suffix(name)  # PET-121 D-SUFFIX: after ns-strip
     return name.strip()
 
 

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -293,17 +293,24 @@ class ToolCallGuard:
         # so the two normalizers never diverge (D-CANON / D-EQUIV).
         name = canonicalize_tool_name(tool_name)
         if self._profile and self._profile.tool_alias_map:
-            combined = {**DEFAULT_TOOL_ALIASES, **self._profile.tool_alias_map}
+            raw_aliases = {**DEFAULT_TOOL_ALIASES, **self._profile.tool_alias_map}
         else:
-            combined = dict(DEFAULT_TOOL_ALIASES)
+            raw_aliases = dict(DEFAULT_TOOL_ALIASES)
+        # PET-121: canonicalize alias-map KEYS into the same space as `name`, so an alias keyed
+        # with a camel / _tool-suffixed form still fires once the shared primitive strips the
+        # suffix or splits the camel (incoming `custom_tool` -> `custom`; without this the raw
+        # `custom_tool` key would silently never match). Default keys are canonical-stable, so
+        # this is a no-op on them; profile keys collapsing to the same canonical form: last wins.
+        combined = {canonicalize_tool_name(k): v for k, v in raw_aliases.items()}
         pre_alias = name
         resolved = combined.get(name, name)
         # GUARD-03: a PROFILE-INTRODUCED alias must not redirect onto an exempt key.
         # Default aliases (bash->exec) onto an operator-exempted target stay legal (D8).
+        # Compare `name` against the profile's CANONICALIZED keys (PET-121: same space as name).
         if (
             resolved != pre_alias
             and self._profile
-            and name in self._profile.tool_alias_map
+            and name in {canonicalize_tool_name(k) for k in self._profile.tool_alias_map}
             and resolved.strip().casefold() in self._profile.tool_exempt_list
         ):
             _logger.warning(

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -156,6 +156,22 @@ class TestToolNameNormalization:
         assert g._normalize_tool_name("custom_tool") == "mapped"
         assert g._normalize_tool_name("bash") == "exec"
 
+    async def test_profile_alias_key_canonicalized(self, valid_key: str) -> None:
+        # Regression for PET-121: alias-map KEYS are canonicalized into the same space as the
+        # incoming name, so an alias keyed with a camel / _tool-suffixed form still fires after
+        # the shared primitive strips the suffix or splits the camel. Without key
+        # canonicalization the D-SUFFIX strip ("custom_tool" -> "custom") would silently miss
+        # the raw "custom_tool" key, breaking the alias. Both the raw-suffixed key and its camel
+        # sibling resolve onto the same target.
+        p = _profile(
+            tool_alias_map=MappingProxyType({"custom_tool": "mapped", "SendThing": "exec"})
+        )
+        g = _guard(profile=p, key=valid_key)
+        assert g._normalize_tool_name("custom_tool") == "mapped"  # _tool-suffixed key fires
+        assert g._normalize_tool_name("CustomTool") == "mapped"  # camel variant of same tool
+        assert g._normalize_tool_name("send_thing") == "exec"  # canonical of the camel key
+        assert g._normalize_tool_name("SendThing") == "exec"
+
     async def test_casefold_not_just_lower(self, valid_key: str) -> None:
         g = _guard(key=valid_key)
         assert g._normalize_tool_name("BASH") == "exec"
@@ -199,13 +215,24 @@ class TestToolNameNormalization:
             ("", ""),
             ("   ", ""),
             ("http_request ", "browser"),  # trailing NBSP: D-EQUIV no-op-strip pin
+            # PET-121: CamelCase / _tool variants route through the SAME shared primitive,
+            # so the guard inherits the new shapes and then layers aliases on top — no second
+            # normalizer. send_email is unaliased; the rest fold onto an alias target.
+            ("SendEmail", "send_email"),  # camel -> send_email (unaliased)
+            ("sendEmail", "send_email"),
+            ("send_email_tool", "send_email"),  # D-SUFFIX strip, unaliased
+            ("FileRead", "read"),  # camel -> file_read -> alias read
+            ("ReadFileTool", "read"),  # camel -> read_file_tool -> suffix read_file -> read
+            ("BashTool", "exec"),  # camel -> bash_tool -> suffix bash -> alias exec
+            ("WebFetch", "browser"),  # camel -> web_fetch -> alias browser
         ],
     )
     async def test_normalize_tool_name_equivalence_pin(
         self, valid_key: str, raw: str, expected: str
     ) -> None:
-        # Regression for PET-118: the canonicalize_tool_name + alias_resolve refactor of
-        # _normalize_tool_name is byte-for-byte equivalent for existing callers (D-EQUIV).
+        # Regression for PET-118 / PET-121: the canonicalize_tool_name + alias layer of
+        # _normalize_tool_name is byte-for-byte equivalent for existing callers (D-EQUIV) and
+        # inherits the PET-121 camel/_tool shapes through the one shared primitive (no drift).
         g = _guard(key=valid_key)
         assert g._normalize_tool_name(raw) == expected
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import unicodedata
 
+import pytest
+
 from petasos.normalize import (
     _HOMOGLYPH_TABLE,
     INVISIBLE_CHARS,
@@ -505,3 +507,93 @@ class TestCanonicalizeToolName:
     def test_canonicalize_empty_and_prefix_only(self) -> None:
         for raw in ("", "   ", "mcp__acme__"):
             assert canonicalize_tool_name(raw) == ""
+
+    # ------------------------------------------------------------------ PET-121
+    # CamelCase->snake (boundary-guarded, before casefold) + _tool/-tool suffix strip.
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("SendEmail", "send_email"),
+            ("sendEmail", "send_email"),
+            ("SEND_EMAIL", "send_email"),  # all-caps: no lower->upper boundary, casefold only
+            ("Send_Email", "send_email"),  # snake-with-capital: boundary already a "_"
+            ("SendEmailTool", "send_email"),  # camel emits send_email_tool, suffix strips _tool
+            ("HttpRequest", "http_request"),  # Pascal of a real snake wire name
+        ],
+    )
+    def test_canonicalize_camelcase_to_wire_name(self, raw: str, expected: str) -> None:
+        # PET-121 D-CAMEL: the deterministically-resolvable CamelCase / SCREAMING_SNAKE /
+        # Pascal variants of a configured snake wire name canonicalize ONTO that wire name.
+        # The all-caps and snake-with-capital rows are exactly what Hermes's literal naive
+        # `(?<!^)(?=[A-Z])` would mangle (s_e_n_d__e_m_a_i_l); the boundary-guarded rule does not.
+        assert canonicalize_tool_name(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("HTTPRequest", "httprequest"),  # acronym run: no lower/digit before the caps
+            ("get2FA", "get2_fa"),  # split after the digit, none inside the upper run
+            ("oauth2Token", "oauth2_token"),
+        ],
+    )
+    def test_canonicalize_acronym_and_digit_rule(self, raw: str, expected: str) -> None:
+        # PET-121 D-CAMEL: pins the boundary-guarded outputs that DIFFER from Hermes's literal
+        # naive regex. Acronym/all-caps forms (HTTPRequest) are not deterministically resolvable
+        # by Hermes either (its naive split yields a non-tool h_t_t_p_request); only its fuzzy
+        # fallback might map them, and fuzzy is out of scope to mirror (D-FUZZY) — so the
+        # divergence is non-exploitable. Digit boundaries are pinned only to lock the rule.
+        assert canonicalize_tool_name(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("send_email_tool", "send_email"),
+            ("send_email-tool", "send_email"),
+            ("x_tool_tool", "x"),  # two passes strip both
+            ("_tool", "_tool"),  # alone -> empty-guard keeps it (Hermes: "_tool" unchanged)
+            ("-tool", "-tool"),
+            ("dbtool", "dbtool"),  # bare `tool` (no separator) deliberately NOT stripped
+            ("x_tool_tool_tool", "x_tool"),  # range(2) bound: 3rd suffix intentionally left
+            ("___tool", "___tool"),  # rstrip("_-") would empty -> empty-guard keeps prior
+            ("_tool_tool", "_tool"),  # pass1 -> "_tool"; pass2 empty-guarded
+        ],
+    )
+    def test_canonicalize_tool_suffix_stripped(self, raw: str, expected: str) -> None:
+        # PET-121 D-SUFFIX: trailing _tool/-tool stripped, looped twice (mirrors Hermes's
+        # range(2)), empty-guarded (never strips to ""), bare `tool` not stripped. The
+        # range(2) and rstrip("_-")<->empty-guard interaction rows lock the loop against drift.
+        assert canonicalize_tool_name(raw) == expected
+
+    def test_canonicalize_ordering_camel_before_casefold(self) -> None:
+        # PET-121 D1 (the central correctness invariant): the camel split MUST run before
+        # casefold, and homoglyph-translate MUST run before the camel split.
+        #
+        # camel-before-casefold: casefold destroys the case the split keys on. If reversed,
+        # "SendEmail".casefold() -> "sendemail" (no boundary left) != "send_email".
+        assert canonicalize_tool_name("SEND_EMAIL") == "send_email"
+        assert canonicalize_tool_name("SendEmail") == canonicalize_tool_name("send_email")
+        #
+        # homoglyph-before-camel: a Cyrillic uppercase homoglyph standing in for the INTERNAL
+        # capital only creates a camel boundary AFTER it folds to ASCII. Here U+0415 'Е'
+        # stands in for the 'E' of sendEmail: homoglyph->'E'->camel split -> "send_email".
+        # If homoglyph-translate moved after casefold, the ASCII-only camel regex would never
+        # split at the Cyrillic char -> "sendemail", silently re-opening the bypass for the
+        # homoglyph-led camel variant this ticket targets. Only this assertion catches it.
+        #
+        # NOTE (spec correction): PET-121.spec used U+0421 'С' and claimed it folds to ASCII
+        # 'S'. It does NOT — _HOMOGLYPH_TABLE maps U+0421 -> 'C' (Cyrillic ES is a C-homoglyph),
+        # and a word-INITIAL homoglyph is not at a camel boundary so it cannot distinguish the
+        # ordering. The faithful guard uses U+0415 'Е' at the internal boundary; the second
+        # assertion pins the true U+0421 mapping so the table is not silently re-pointed.
+        assert canonicalize_tool_name("sendЕmail") == "send_email"  # U+0415 Cyrillic IE -> E
+        assert canonicalize_tool_name("Сend_email") == "cend_email"  # U+0421 Cyrillic ES -> C
+
+    def test_canonicalize_pet118_cases_unregressed(self) -> None:
+        # PET-121: the PET-118 primitive contract still holds with the camel/suffix additions.
+        assert canonicalize_tool_name("mcp__acme__Send_Email") == "send_email"
+        assert canonicalize_tool_name("mcp__mcp__tool") == "tool"  # bare `tool` not stripped
+        assert canonicalize_tool_name("mcp__acme__") == ""
+        for raw in ("", "   "):
+            assert canonicalize_tool_name(raw) == ""
+        assert canonicalize_tool_name("sеnd_email") == "send_email"  # U+0435 lower cyr e

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -258,6 +258,68 @@ def test_classification_shares_guard_canonical_form(
 
 
 # ---------------------------------------------------------------------------
+# PET-121: CamelCase / _tool variants + single-underscore mcp_ wire names
+# ---------------------------------------------------------------------------
+
+
+def test_camelcase_egress_variant_still_pii_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-121: the CamelCase / SCREAMING_SNAKE / _tool variants Hermes resolves
+    # at dispatch now canonicalize onto the configured egress wire name, so a CRITICAL PII
+    # finding still trips branch-3 egress blocking. These are the live bypass shapes PET-118
+    # left open. egress set holds only the (already-canonical) wire form of "send_email".
+    for variant in ("SendEmail", "SEND_EMAIL", "send_email_tool"):
+        out = _drive(
+            monkeypatch,
+            variant,
+            _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+            egress=_SEND_EMAIL_CANON,
+        )
+        assert out is not None and out["action"] == "block", f"{variant!r} should block"
+        assert out["message"].startswith("Security finding (PII, CRITICAL)")
+
+
+def test_camelcase_readonly_variant_not_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
+    # PET-121: a CamelCase variant of a READ_ONLY_TOOLS member (WebSearch -> web_search)
+    # canonicalizes back into _READ_ONLY_CANON -> not dangerous -> no false-positive quarantine,
+    # even with CRITICAL PII present (short-circuits to None at the read-only gate).
+    ref = _import_reference_plugin()
+    assert ref._is_dangerous("WebSearch") is False
+    out = _drive(
+        monkeypatch,
+        "WebSearch",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+    )
+    assert out is None
+
+
+def test_single_underscore_namespace_requires_full_wire_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # PET-121 D-NS: the single-underscore mcp_<server>_<tool> prefix is NOT heuristically
+    # stripped (ambiguous boundary). An MCP egress tool matches only when configured by its
+    # FULL wire name; its CamelCase/_tool variants then fold onto it, but the bare tool name
+    # does NOT (no greedy strip merges the namespaced and bare forms).
+    ref = _import_reference_plugin()
+    full_wire = frozenset({canonicalize_tool_name("mcp_acme_send_email")})
+    monkeypatch.setattr(ref, "_egress_sink_tools", full_wire)
+    # full wire name matches; bare name does not (no prefix strip)
+    assert ref._is_egress_sink("mcp_acme_send_email") is True
+    assert ref._is_egress_sink("send_email") is False
+    # CamelCase / _tool variants OF THE FULL WIRE NAME still resolve onto it
+    assert ref._is_egress_sink("mcp_acme_SendEmail") is True
+    assert ref._is_egress_sink("mcp_acme_send_email_tool") is True
+    # and a full-wire CamelCase variant carrying CRITICAL PII trips the egress block
+    out = _drive(
+        monkeypatch,
+        "mcp_acme_SendEmail",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+        egress=full_wire,
+    )
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("Security finding (PII, CRITICAL)")
+
+
+# ---------------------------------------------------------------------------
 # Non-PII finding types block all dangerous tools (D3 / D-EGRESS partition)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extends the shared alias-free `canonicalize_tool_name` (PET-118) to fold the **deterministic** tool-name shapes Hermes resolves at dispatch that Petasos did not: a boundary-guarded **CamelCase→snake** split (before casefold) and a trailing **`_tool`/`-tool`** suffix strip.
- The guard *and* the reference plugin's classification inherit the new shapes for free through the **one** shared primitive — closing the `SendEmail` / `SEND_EMAIL` / `send_email_tool` egress-bypass class on the shapes PET-118 left open.
- Single-underscore `mcp_<server>_<tool>` namespacing is **documented as a full-wire-name requirement** (deliberately not heuristically stripped — ambiguous boundary, D-NS); Hermes's fuzzy fallback is left to the host to bound/disable (D-FUZZY).

## Layered defense
1. **Primitive** (`petasos/normalize.py`): `_CAMEL_BOUNDARY_RE` is **boundary-guarded** (`(?<=[a-z0-9])(?=[A-Z])`), *not* Hermes's naive `(?<!^)(?=[A-Z])` — the naive form would mangle `SEND_EMAIL` → `s_e_n_d__e_m_a_i_l` and re-open the very bypass this ticket closes (D-CAMEL). `_strip_tool_suffix` loops twice (mirrors Hermes's `range(2)`), is empty-guarded, and leaves bare `tool` alone (D-SUFFIX). Camel split runs **before** casefold, suffix strip **after** ns-strip (D1 ordering, pinned).
2. **Guard** (`petasos/session/guard.py`): because both the configured sets and the incoming name flow through the same primitive, no enforcement edit is needed — **except** one deliberate change (see below).
3. **Config + docs**: full-wire-name requirement + host-side fuzzy posture.

## ⚠️ Two deviations from the spec (please review)

**1. One guard code change (spec said "zero guard changes").** PET-121's `_tool` strip canonicalizes an incoming `custom_tool` → `custom` *before* the guard's alias lookup, which is keyed on raw names — so a profile alias keyed `custom_tool` silently stopped firing (the spec's "`TestToolNameNormalization` stays green unchanged" claim only inspected the *camel* split vs uppercase fixtures and missed this `D-SUFFIX × alias-key` interaction). Defaults are unaffected (no default alias key ends in `_tool`). Resolved by **canonicalizing the alias-map keys** in `_normalize_tool_name` (and moving the GUARD-03 membership check into the same canonical space) so operator aliases stay backward-compatible. This was an explicit maintainer decision over the alternative (re-key the test + document a new operator contract).

**2. Corrected a factual error in the spec's ordering test.** The spec's `test_canonicalize_ordering_camel_before_casefold` used `U+0421 'С'` claiming the homoglyph table folds it to ASCII `S`. It actually maps to `C` (Cyrillic ES is a *C*-homoglyph), and a word-initial homoglyph isn't at a camel boundary — so it could neither produce `send_email` nor distinguish the ordering. The implemented test uses `U+0415 'Е'` standing in for the internal `E` of `sendEmail` (folds to `E`, sits at the boundary): correct order → `send_email`, broken order → `sendemail`. A second assertion pins the true `U+0421 → 'C'` mapping so the table can't be silently re-pointed.

## Files changed

| File | Change |
|------|--------|
| `petasos/normalize.py` | Adds `_CAMEL_BOUNDARY_RE` + `_strip_tool_suffix`; extends `canonicalize_tool_name` (camel before casefold, suffix after ns-strip) |
| `petasos/session/guard.py` | Canonicalizes alias-map keys + GUARD-03 check into the canonical space (backward-compat for `_tool`/camel-keyed profile aliases) |
| `petasos/config.py` | Documents the single-underscore MCP full-wire-name requirement (D-NS) on `egress_sink_tools` |
| `docs/deployment/hermes-desktop.md` | New "Tool-name canonicalization vs Hermes dispatch" subsection (full wire names; bound/disable host-side fuzzy) |
| `tests/test_normalize.py` | camel / acronym+digit / suffix / ordering / PET-118-unregressed unit tests |
| `tests/test_guard.py` | Equivalence-pin extended to camel/`_tool`; new alias-key canonicalization regression |
| `tests/test_reference_plugin_egress.py` | CamelCase egress still PII-blocked; readonly variant not dangerous; single-underscore full-wire-name (D-NS) |
| `docs/specs/TODO/PET-121.test-output.txt` | Test gate evidence |

## Test plan
- [x] `python -m pytest tests/test_normalize.py tests/test_guard.py tests/test_reference_plugin_egress.py tests/adversarial/guard/test_tool_smuggling.py -q` — 220/220 pass (full output: docs/specs/TODO/PET-121.test-output.txt)
- [x] `python -m pytest -q -k "not test_default_ignorable_rejected"` — 1656 passed, 41 skipped, 1 deselected (pre-existing Unicode-13 on local 3.10), 1 xfailed
- [x] `ruff check .` — clean · `ruff format --check .` — clean · `mypy --strict .` — clean (116 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved tool-name canonicalization to match more naming variants, including CamelCase→snake conversion and automatic stripping of trailing `_tool`/`-tool`.

* **Documentation**
  * Added clear guidance on Hermes tool dispatch matching, including deterministic MCP wire-name requirements and how fuzzy fallback should be constrained.

* **Bug Fixes**
  * Updated tool-call guard alias resolution so profile alias keys are canonicalized consistently before matching.
  * Tightened MCP single-underscore wire-name handling to avoid heuristic prefix stripping.

* **Tests**
  * Added PET-121 regression coverage for canonicalization, aliasing, and egress PI masking/exempt behavior across tool-name shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->