### PR TITLE
feat(pet-123): surface plain-language ELI5 intros atop each Config Editor section

### DIFF
--- a/docs/specs/TODO/PET-123.test-output.txt
+++ b/docs/specs/TODO/PET-123.test-output.txt
@@ -1,0 +1,57 @@
+PET-123 test gate — bec29b1 on feat/pet-123-config-section-intros
+Resolved test command (spec § Test command):
+  node --test tests/js/config-sections.test.mjs
+  python -m pytest tests/test_config_meta.py
+  ruff check . && ruff format --check . && mypy --strict petasos/console/_config_meta.py
+
+==================== node --test tests/js/config-sections.test.mjs ====================
+✔ loader: petasos.js exports the PET-114 surfaces (0.6142ms)
+✔ groupConfigSections: registry order + labels + booleans (0.4938ms)
+✔ groupConfigSections: default_collapsed is coerced to a real boolean (0.0879ms)
+✔ groupConfigSections: skips registry sections with no fields (0.0998ms)
+✔ groupConfigSections: unknown-section field is a trailing expanded group (0.1124ms)
+✔ groupConfigSections: stale-backend fallback (no sections) (0.1248ms)
+✔ groupConfigSections: empty/non-array fields return [] (0.066ms)
+✔ Pet.Panel collapsible: structure (collapsed) (0.4637ms)
+✔ Pet.Panel collapsible: structure (expanded) (0.5163ms)
+✔ Pet.Panel collapsible: click toggles live state + aria + onToggle (0.2218ms)
+✔ Pet.Panel collapsible: Enter key toggles (0.1351ms)
+✔ Pet.Panel collapsible: Space key toggles (0.0972ms)
+✔ Pet.Panel collapsible: other keys do not toggle (0.0727ms)
+✔ Pet.Panel collapsible: petSetCollapsed expands without firing onToggle (0.118ms)
+✔ Pet.Panel non-collapsible: unchanged (regression guard) (0.0915ms)
+✔ revealFieldSections: expands the owning section of an errored field (0.0997ms)
+✔ revealFieldSections: unknown / missing-panel field is a safe no-op (0.1103ms)
+✔ loader: petasos.js exports the PET-123 surface (sectionIntro) (0.0251ms)
+✔ groupConfigSections: carries each registry description onto its group (PET-123) (0.0703ms)
+✔ groupConfigSections: fallback groups carry description === "" (PET-123) (0.0755ms)
+✔ sectionIntro: renders a node whose textContent is the trimmed copy (PET-123) (0.0715ms)
+✔ sectionIntro: blank / non-string copy degrades to null, never throws (PET-123) (0.0568ms)
+ℹ tests 22
+ℹ suites 0
+ℹ pass 22
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 54.848
+
+==================== python -m pytest tests/test_config_meta.py ====================
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-123-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 18 items
+
+tests\test_config_meta.py ..................                             [100%]
+
+============================= 18 passed in 0.05s ==============================
+
+==================== ruff check . ====================
+All checks passed!
+==================== ruff format --check . ====================
+116 files already formatted
+==================== mypy --strict petasos/console/_config_meta.py ====================
+Success: no issues found in 1 source file

--- a/docs/specs/TODO/PET-123.test-output.txt
+++ b/docs/specs/TODO/PET-123.test-output.txt
@@ -1,32 +1,36 @@
-PET-123 test gate — bec29b1 on feat/pet-123-config-section-intros
-Resolved test command (spec § Test command):
+PET-123 test gate — df5da3d on feat/pet-123-config-section-intros
+Resolved test command (spec § Test command), with mypy broadened to the full
+tree (mypy --strict .) to match repo policy (CLAUDE.md: mypy --strict for all
+**/*.py; PET-123 review thread 3411126743). The spec scoped mypy to the one
+changed file for speed and asserted the full tree was unaffected; this records
+the full-tree run as proof.
   node --test tests/js/config-sections.test.mjs
   python -m pytest tests/test_config_meta.py
-  ruff check . && ruff format --check . && mypy --strict petasos/console/_config_meta.py
+  ruff check . && ruff format --check . && mypy --strict .
 
 ==================== node --test tests/js/config-sections.test.mjs ====================
-✔ loader: petasos.js exports the PET-114 surfaces (0.6142ms)
-✔ groupConfigSections: registry order + labels + booleans (0.4938ms)
-✔ groupConfigSections: default_collapsed is coerced to a real boolean (0.0879ms)
-✔ groupConfigSections: skips registry sections with no fields (0.0998ms)
-✔ groupConfigSections: unknown-section field is a trailing expanded group (0.1124ms)
-✔ groupConfigSections: stale-backend fallback (no sections) (0.1248ms)
-✔ groupConfigSections: empty/non-array fields return [] (0.066ms)
-✔ Pet.Panel collapsible: structure (collapsed) (0.4637ms)
-✔ Pet.Panel collapsible: structure (expanded) (0.5163ms)
-✔ Pet.Panel collapsible: click toggles live state + aria + onToggle (0.2218ms)
-✔ Pet.Panel collapsible: Enter key toggles (0.1351ms)
-✔ Pet.Panel collapsible: Space key toggles (0.0972ms)
-✔ Pet.Panel collapsible: other keys do not toggle (0.0727ms)
-✔ Pet.Panel collapsible: petSetCollapsed expands without firing onToggle (0.118ms)
-✔ Pet.Panel non-collapsible: unchanged (regression guard) (0.0915ms)
-✔ revealFieldSections: expands the owning section of an errored field (0.0997ms)
-✔ revealFieldSections: unknown / missing-panel field is a safe no-op (0.1103ms)
-✔ loader: petasos.js exports the PET-123 surface (sectionIntro) (0.0251ms)
-✔ groupConfigSections: carries each registry description onto its group (PET-123) (0.0703ms)
-✔ groupConfigSections: fallback groups carry description === "" (PET-123) (0.0755ms)
-✔ sectionIntro: renders a node whose textContent is the trimmed copy (PET-123) (0.0715ms)
-✔ sectionIntro: blank / non-string copy degrades to null, never throws (PET-123) (0.0568ms)
+✔ loader: petasos.js exports the PET-114 surfaces (0.4873ms)
+✔ groupConfigSections: registry order + labels + booleans (0.5656ms)
+✔ groupConfigSections: default_collapsed is coerced to a real boolean (0.0696ms)
+✔ groupConfigSections: skips registry sections with no fields (0.0985ms)
+✔ groupConfigSections: unknown-section field is a trailing expanded group (0.1134ms)
+✔ groupConfigSections: stale-backend fallback (no sections) (0.1303ms)
+✔ groupConfigSections: empty/non-array fields return [] (0.0596ms)
+✔ Pet.Panel collapsible: structure (collapsed) (0.4755ms)
+✔ Pet.Panel collapsible: structure (expanded) (0.5082ms)
+✔ Pet.Panel collapsible: click toggles live state + aria + onToggle (0.2238ms)
+✔ Pet.Panel collapsible: Enter key toggles (0.1571ms)
+✔ Pet.Panel collapsible: Space key toggles (0.0961ms)
+✔ Pet.Panel collapsible: other keys do not toggle (0.0704ms)
+✔ Pet.Panel collapsible: petSetCollapsed expands without firing onToggle (0.1133ms)
+✔ Pet.Panel non-collapsible: unchanged (regression guard) (0.1037ms)
+✔ revealFieldSections: expands the owning section of an errored field (0.0975ms)
+✔ revealFieldSections: unknown / missing-panel field is a safe no-op (0.0971ms)
+✔ loader: petasos.js exports the PET-123 surface (sectionIntro) (0.0252ms)
+✔ groupConfigSections: carries each registry description onto its group (PET-123) (0.0677ms)
+✔ groupConfigSections: fallback groups carry description === "" (PET-123) (0.0747ms)
+✔ sectionIntro: renders a node whose textContent is the trimmed copy (PET-123) (0.0842ms)
+✔ sectionIntro: blank / non-string copy degrades to null, never throws (PET-123) (0.0656ms)
 ℹ tests 22
 ℹ suites 0
 ℹ pass 22
@@ -34,7 +38,7 @@ Resolved test command (spec § Test command):
 ℹ cancelled 0
 ℹ skipped 0
 ℹ todo 0
-ℹ duration_ms 54.848
+ℹ duration_ms 55.5611
 
 ==================== python -m pytest tests/test_config_meta.py ====================
 ============================= test session starts =============================
@@ -53,5 +57,5 @@ tests\test_config_meta.py ..................                             [100%]
 All checks passed!
 ==================== ruff format --check . ====================
 116 files already formatted
-==================== mypy --strict petasos/console/_config_meta.py ====================
-Success: no issues found in 1 source file
+==================== mypy --strict . ====================
+Success: no issues found in 116 source files

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -664,73 +664,89 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
     ConfigSection(
         "profiles",
         "Profiles",
-        "Pick a preset tuning bundle that adjusts rule sensitivity and tool"
-        " permissions for a use case.",
+        "Pick a ready-made settings bundle for your use case (coding agent,"
+        " customer service, and so on) instead of tuning every knob by hand."
+        " Start here if you are not sure what to change.",
         default_collapsed=False,
     ),
     ConfigSection(
         "anonymization",
         "PII / Anonymization",
-        "Hide personal information the scanners detect before it travels further.",
+        "Mask personal details (names, emails, card numbers) the scanners find"
+        " so they do not pass through in the clear. Leave on if your agent"
+        " handles real user data.",
         default_collapsed=False,
     ),
     ConfigSection(
         "fail_mode",
         "Fail Mode",
-        "Decide what happens to content when a scanner breaks or times out mid-scan.",
+        "Choose what happens to a message when a scanner crashes or times out:"
+        " block it, let it through, or block only on a hard failure. The safe"
+        " default blocks on failure.",
         default_collapsed=False,
     ),
     ConfigSection(
         "tool_guard",
         "Tool Call Guard",
-        "Inspect the agent's tool calls and rate-limit sub-agent spawns before they run.",
+        "Check the tools your agent tries to call and cap how fast it can spawn"
+        " sub-agents, before any of it runs. Tighten this for agents that touch"
+        " the file system or the shell.",
         default_collapsed=False,
     ),
     ConfigSection(
         "scanning",
         "Scanning",
-        "Core scan behavior: direction, scanner timeouts, circuit breakers, and"
-        " PII detection scope.",
+        "The core scan settings: which direction to scan (incoming, outgoing, or"
+        " both) and how widely to look for personal data. Also sets per-scanner"
+        " time limits and when to stop calling one that keeps failing.",
         default_collapsed=False,
     ),
     ConfigSection(
         "normalization",
         "Normalization",
-        "Clean up disguised text (homoglyphs, zero-width, leetspeak, encoded blobs)"
-        " before scanning.",
+        "Undo tricks that hide malicious text from the scanners (look-alike"
+        " letters, invisible characters, leetspeak, encoded blobs) before"
+        " anything is checked. Most operators leave this on as-is.",
         default_collapsed=True,
     ),
     ConfigSection(
         "escalation",
         "Escalation Tiers",
-        "Risk-score thresholds that tighten enforcement tier by tier as a"
-        " conversation misbehaves.",
+        "As a conversation keeps misbehaving, these risk-score cutoffs ratchet"
+        " enforcement up one tier at a time. Advanced: the built-in tiers are"
+        " sensible defaults.",
         default_collapsed=True,
     ),
     ConfigSection(
         "frequency",
         "Frequency Tracking",
-        "How per-conversation risk scores accumulate and decay over time.",
+        "Tracks how risky each conversation looks over time, so repeated"
+        " suspicious behavior adds up instead of being judged one message at a"
+        " time. Advanced: the defaults are sensible.",
         default_collapsed=True,
     ),
     ConfigSection(
         "audit",
         "Audit",
-        "Whether and how much detail every scan records for later review.",
+        "Decide whether each scan is recorded for later review, and how much"
+        " detail to keep. Turn the detail up when you need an investigation"
+        " trail.",
         default_collapsed=True,
     ),
     ConfigSection(
         "alerting",
         "Alerting",
-        "Fire warnings on suspicious patterns like rapid-fire scanning or PII"
-        " spikes, with rate limits.",
+        "Raise a warning when something looks off (rapid-fire scanning, a spike"
+        " in personal data, repeated blocks) without flooding you with"
+        " duplicates. Advanced: the defaults cover the common cases.",
         default_collapsed=True,
     ),
     ConfigSection(
         "session",
         "Session Management",
-        "Limits on how many conversations are tracked, how long they live, and"
-        " new-session rate caps.",
+        "Caps on how many conversations are tracked at once, how long each is"
+        " remembered, and how fast new ones may start. Advanced: raise these"
+        " only for high-traffic deployments.",
         default_collapsed=True,
     ),
 )

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1092,6 +1092,9 @@
         groups.push({
           key: gk,
           label: (s.label != null) ? s.label : gk,
+          // PET-123: carry the registry copy the last hop (builder -> render) so
+          // the section body can show a plain-language intro. Never-undefined (D4).
+          description: (s.description != null) ? s.description : "",
           default_collapsed: Boolean(s.default_collapsed),
           fields: bySection[gk],
         });
@@ -1102,7 +1105,9 @@
     // backend with no/empty sections), in field first-appearance order, expanded.
     appearance.forEach(function (gk) {
       if (used[gk]) return;
-      groups.push({ key: gk, label: gk, default_collapsed: false, fields: bySection[gk] });
+      // PET-123: a stale backend / unknown section has no registry copy; "" is the
+      // never-undefined sentinel the intro builder degrades on (D4).
+      groups.push({ key: gk, label: gk, description: "", default_collapsed: false, fields: bySection[gk] });
     });
     return groups;
   };
@@ -1134,6 +1139,19 @@
       var lw = w.toLowerCase();
       return Pet.CONFIG_ACRONYMS[lw] || (w.charAt(0).toUpperCase() + w.slice(1));
     }).join(" ");
+  };
+
+  // PET-123: intro node for a section body, or null when there is no copy to show
+  // (stale backend / unknown section). Never throws on a missing / blank /
+  // non-string description — degrades to null (PET-99 / D4 never-throw posture).
+  Pet.sectionIntro = function (description) {
+    if (typeof description !== "string") return null;
+    var text = description.trim();
+    if (!text) return null;
+    return Pet.h("div", {
+      style: { fontSize: "11.5px", color: "var(--tx-faint)", margin: "2px 0 10px",
+               lineHeight: "1.45" }
+    }, text);
   };
 
   Pet.renderConfig = function (container) {
@@ -1260,11 +1278,20 @@
         var collapsed = Object.prototype.hasOwnProperty.call(Pet.state.sectionCollapsed, group.key)
           ? Pet.state.sectionCollapsed[group.key]   // user chose
           : group.default_collapsed;                 // registry/builder default
+        // PET-123: prepend the plain-language intro (when present) above the field
+        // rows. fieldEls is passed as a direct array child in both branches, so the
+        // rows stay at today's DOM depth (Pet.h flattens an array child); the only
+        // tree change is the single intro node when copy exists. intro === null is
+        // byte-for-byte today's render (D4 / Design Change 3).
+        var intro = Pet.sectionIntro(group.description);
+        var body = intro
+          ? Pet.h("div", {}, intro, fieldEls)
+          : Pet.h("div", {}, fieldEls);
         var sectionPanel = Pet.Panel({
           icon: "sliders", title: group.label,
           collapsible: true, collapsed: collapsed,
           onToggle: function (c) { Pet.state.sectionCollapsed[group.key] = c; },
-          content: Pet.h("div", {}, fieldEls),
+          content: body,
         });
         sectionPanel.dataset.section = group.key;
         panelsBySection[group.key] = sectionPanel;

--- a/tests/js/config-sections.test.mjs
+++ b/tests/js/config-sections.test.mjs
@@ -341,3 +341,75 @@ test("revealFieldSections: unknown / missing-panel field is a safe no-op", () =>
     {}
   );
 });
+
+// ── PET-123: section intro copy carried builder -> render ────────────────────
+// The bug class is "registry copy that exists end-to-end but is dropped at the
+// last frontend hop". These pin the carry (builder), the graceful-degradation
+// sentinel, and the Pet.sectionIntro builder (trim + never-throw).
+
+// Dedicated loader sibling (keeps the PET-114 loader test name accurate).
+test("loader: petasos.js exports the PET-123 surface (sectionIntro)", () => {
+  assert.equal(typeof Pet.sectionIntro, "function");
+});
+
+// A registry carrying distinct, non-empty descriptions, in scrambled `order`.
+function registryWithDescriptions() {
+  return [
+    { key: "alerting", label: "Alerting", description: "alerting intro copy", default_collapsed: true, order: 9 },
+    { key: "profiles", label: "Profiles", description: "profiles intro copy", default_collapsed: false, order: 0 },
+    { key: "scanning", label: "Scanning", description: "scanning intro copy", default_collapsed: false, order: 4 },
+  ];
+}
+
+test("groupConfigSections: carries each registry description onto its group (PET-123)", () => {
+  const groups = Pet.groupConfigSections(scrambledFields(), registryWithDescriptions());
+  // Order still by `order` — the carry is additive, ordering untouched.
+  assertLoose.deepEqual(
+    groups.map((g) => g.key),
+    ["profiles", "scanning", "alerting"]
+  );
+  // Every emitted group's description equals its registry entry's description.
+  assertLoose.deepEqual(
+    groups.map((g) => g.description),
+    ["profiles intro copy", "scanning intro copy", "alerting intro copy"]
+  );
+});
+
+test("groupConfigSections: fallback groups carry description === \"\" (PET-123)", () => {
+  // Stale backend (null / []) — every trailing group gets the never-undefined "".
+  // strict assert.equal rejects undefined, so this pins strictly "".
+  for (const stale of [null, []]) {
+    const groups = Pet.groupConfigSections(scrambledFields(), stale);
+    assert.ok(groups.length > 0);
+    for (const g of groups) {
+      assert.equal(g.description, "", "stale-backend group description is strictly \"\"");
+    }
+  }
+  // Unknown-section field (no registry entry) — trailing group also gets "".
+  const fields = scrambledFields().concat([{ name: "x1", section: "future_thing" }]);
+  const groups = Pet.groupConfigSections(fields, registryWithDescriptions());
+  const last = groups[groups.length - 1];
+  assert.equal(last.key, "future_thing");
+  assert.equal(last.description, "", "unknown-section group description is strictly \"\"");
+});
+
+test("sectionIntro: renders a node whose textContent is the trimmed copy (PET-123)", () => {
+  // Deliberate leading/trailing whitespace — pins that the builder trims, not
+  // just that it renders clean input.
+  const node = Pet.sectionIntro("  Clean up disguised text before scanning.  ");
+  assert.ok(node, "intro node is truthy");
+  assert.equal(node.nodeType, 1, "intro is an element node");
+  assert.equal(node.textContent, "Clean up disguised text before scanning.");
+});
+
+test("sectionIntro: blank / non-string copy degrades to null, never throws (PET-123)", () => {
+  // Empty, whitespace-only, null, undefined, plus non-strings (number + the two
+  // collection types) so the test reads as obviously type-class-total.
+  for (const bad of ["", "   ", null, undefined, 42, [], {}]) {
+    let out = "UNSET";
+    assert.doesNotThrow(() => {
+      out = Pet.sectionIntro(bad);
+    });
+    assert.equal(out, null, `sectionIntro(${JSON.stringify(bad)}) returns null`);
+  }
+});

--- a/tests/test_config_meta.py
+++ b/tests/test_config_meta.py
@@ -227,6 +227,13 @@ def test_section_metadata_entry_shape() -> None:
         assert isinstance(s["description"], str) and s["description"].strip()
         assert isinstance(s["default_collapsed"], bool)
         assert isinstance(s["order"], int)
+        # PET-123 D6: ELI5 section copy uses no em dash (house style). Fence the
+        # em dash plus the two substitutes a copy editor reaches for (en dash,
+        # double hyphen) as a strict superset of D6.
+        for d in ("—", "–", "--"):  # em dash, en dash, double hyphen
+            assert d not in s["description"], (
+                f"{s['key']} description uses a banned dash {d!r} (house style: no em dashes)"
+            )
 
 
 def test_config_section_is_frozen_slots_dataclass() -> None:


### PR DESCRIPTION
## Summary
- Carries the existing per-section `description` the last two frontend hops (builder -> render) so each Config Editor section shows a one-line plain-language intro at the top of its body, under the collapsible header and above the first field row.
- Rewrites all 11 `_SECTION_REGISTRY` descriptions into true ELI5 register (what it does + when you'd touch it), no em dashes (house style, D6).
- Render-side surfacing plus a copy pass only: no backend, API, route, `server.py`, config field, or `default_collapsed` change. The data already crossed the wire (PET-114 single emission point); PET-123 stops the frontend dropping it.

## Layered defense (never-throw, D4)
`Pet.sectionIntro(description)` returns `null` for any non-string / empty / whitespace-only copy, and the section body falls back to fields-only. `groupConfigSections` carries `s.description` on the registry path and a never-`undefined` `""` sentinel on the trailing/fallback path, so a stale backend or unknown section degrades to no intro, never a crash or an empty box. `fieldEls` is passed as a direct array child in both render branches, so field-row DOM depth is byte-for-byte unchanged when no intro is present.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Carries `description` onto both `groupConfigSections` group shapes; adds the pure `Pet.sectionIntro` builder; prepends the intro above field rows in `renderConfig`. |
| `petasos/console/_config_meta.py` | Rewrites all 11 `_SECTION_REGISTRY` `description` strings into ELI5 register. Structure (key/label/`default_collapsed`/order/dataclass shape) untouched. |
| `tests/js/config-sections.test.mjs` | Adds PET-123 regression tests (carry-through, fallback carry, intro renders + trim, no-description never-throw) and a dedicated `sectionIntro` loader guard. |
| `tests/test_config_meta.py` | One assertion added to the existing `test_section_metadata_entry_shape` loop fencing the em dash, en dash, and double-hyphen in section copy (strict superset of D6). |

## Test plan
- [x] `node --test tests/js/config-sections.test.mjs` — 22/22 pass (5 new PET-123 + 17 PET-114 unchanged)
- [x] `python -m pytest tests/test_config_meta.py` — 18/18 pass
- [x] `ruff check . && ruff format --check . && mypy --strict petasos/console/_config_meta.py` — clean
- Full output: `docs/specs/TODO/PET-123.test-output.txt`
- [x] Manual (post-merge precedent): standalone console + Hermes plugin mode render check, screenshots per spec § Test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Configuration Editor to show per-section introductory descriptions above the relevant settings fields.
* **Documentation**
  * Refreshed the user-facing description text for multiple configuration sections (including profiles, anonymization, fail mode, tool guard, scanning, normalization, escalation, frequency, audit, alerting, and session) for clearer, consistent wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->