### PR TITLE
feat(pet-124): console strength-preset "tuning dial" for the Config Editor

### DIFF
--- a/docs/specs/TODO/PET-124.test-output.txt
+++ b/docs/specs/TODO/PET-124.test-output.txt
@@ -1,0 +1,25 @@
+=== python -m pytest tests/test_presets.py tests/test_console_handlers.py tests/test_config_meta.py tests/test_config.py -q ===
+........................................................................ [ 55%]
+.........................................................                [100%]
+129 passed in 0.54s
+
+=== node --test tests/js/preset-dial.test.mjs ===
+✔ renderStrengthDial: recommendation line names Iron + code_generation (0.1892ms)
+✔ renderStrengthDial: degrades without throwing on malformed shapes (0.2565ms)
+✔ renderStrengthDial: a metal click invokes the apply path with that preset's overrides (0.1774ms)
+✔ renderStrengthDial: the Custom segment is not clickable (no onSelect) (0.1463ms)
+ℹ tests 13
+ℹ suites 0
+ℹ pass 13
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 52.3346
+
+=== ruff check . ===
+All checks passed!
+=== ruff format --check . ===
+118 files already formatted
+=== mypy --strict . ===
+Success: no issues found in 118 source files

--- a/petasos/console/_presets.py
+++ b/petasos/console/_presets.py
@@ -1,0 +1,271 @@
+"""Strength-preset registry for the Console Config Editor "tuning dial" (PET-124).
+
+A strength preset is a coherent bundle of *existing* config-level strictness
+fields that an operator can apply with one click, without knowing the individual
+knobs. The five built-ins form a "metals temper" scale ordered soft to strict:
+Tin, Bronze, Iron, Steel, Titanium. A sixth visible state, Custom, is *derived*
+(see ``resolve_active_preset``) and is not a registry entry.
+
+This module mirrors the ``_config_meta.py`` section-registry shape: a frozen
+tuple of frozen dataclasses plus a ``generate_*_metadata()`` exporter that
+returns a fresh list of fresh plain dicts each call. It adds no new config field,
+no new apply path, and no enforcement floor: a preset only ever *sets* fields
+that already exist on ``PetasosConfig``, so it is structurally incapable of
+reaching either the Tier-3 terminate floor or the unsuppressible-rule floor
+(both live below the config layer). See the PET-124 spec, Decisions D1-D9.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from petasos.config import PetasosConfig
+
+# D8: the preset-owned field set. Exactly these 13 config-level *strictness*
+# fields participate in every preset bundle and in the Custom comparator.
+# Deliberately excluded: the scanner circuit-breaker timing fields (reliability,
+# not strictness) and the profile-axis levers (`confidence_floor`,
+# `suppress_rules`), which are not config fields at all. `profile_name` is
+# excluded too (D3) so the strength axis and scenario axis cannot shadow each
+# other in the comparator.
+_PRESET_OWNED_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "fail_mode",
+        "tier1_threshold",
+        "tier2_threshold",
+        "tier3_threshold",
+        "presidio_score_threshold",
+        "anonymize",
+        "tool_guard_enabled",
+        "normalize_nfkc",
+        "strip_zero_width",
+        "map_homoglyphs",
+        "detect_rtl_override",
+        "fold_leet",
+        "decode_encoded_payloads",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StrengthPreset:
+    """One built-in strength level (a "metals temper" rung).
+
+    Frozen + slotted (the project's frozen-exports invariant); ``overrides`` is
+    a ``MappingProxyType`` so the bundle cannot be mutated in place. ``overrides``
+    holds exactly the keys in ``_PRESET_OWNED_FIELDS`` (no more, no less), so the
+    comparator is symmetric and unambiguous.
+    """
+
+    key: str  # "tin" | "bronze" | "iron" | "steel" | "titanium"
+    label: str  # "Tin" .. "Titanium"
+    order: int  # 0..4, ascending soft -> strict
+    description: str  # short posture summary (tooltip source)
+    overrides: Mapping[str, bool | float | str]
+
+
+def _preset(
+    key: str,
+    label: str,
+    order: int,
+    description: str,
+    overrides: dict[str, bool | float | str],
+) -> StrengthPreset:
+    """Build a StrengthPreset with an immutable overrides mapping."""
+    return StrengthPreset(
+        key=key,
+        label=label,
+        order=order,
+        description=description,
+        overrides=MappingProxyType(dict(overrides)),
+    )
+
+
+# D7: the five bundles. Lower tier thresholds escalate sooner (stricter); lower
+# presidio_score_threshold matches more PII (stricter); fail_mode open < degraded
+# < closed. Iron equals today's PetasosConfig defaults field-for-field (D6), so a
+# fresh install resolves to Iron with zero behavior change. Every float literal
+# below is the same decimal literal as the corresponding config default where
+# they coincide (Iron's tiers 15/30/50, presidio 0.35), so the IEEE-754 doubles
+# are identical and the Custom comparator's `==` is exact. The three core
+# canonicalization toggles (normalize_nfkc / strip_zero_width / map_homoglyphs)
+# stay on at every level; only Tin relaxes the higher-false-positive transforms.
+#
+# Floors are test-pinned regardless of these numbers: tier3 >= 30.0 (Titanium
+# sits exactly at the floor) and no field here can carry a rule-suppression lever.
+_PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
+    _preset(
+        "tin",
+        "Tin",
+        0,
+        "Loosest temper. Fail-open if an ML scanner breaks, tool-call guard off, "
+        "and the higher-false-positive transforms (RTL, leet, encoded-payload "
+        "decode) relaxed. Escalates latest. The always-on syntactic pre-filter "
+        "still runs and Tier-3 still terminates at the floor.",
+        {
+            "fail_mode": "open",
+            "tier1_threshold": 40.0,
+            "tier2_threshold": 60.0,
+            "tier3_threshold": 80.0,
+            "presidio_score_threshold": 0.60,
+            "anonymize": False,
+            "tool_guard_enabled": False,
+            "normalize_nfkc": True,
+            "strip_zero_width": True,
+            "map_homoglyphs": True,
+            "detect_rtl_override": False,
+            "fold_leet": False,
+            "decode_encoded_payloads": False,
+        },
+    ),
+    _preset(
+        "bronze",
+        "Bronze",
+        1,
+        "Relaxed temper. Fail-degraded, tool-call guard on, full normalization. "
+        "Escalates later than the default for noisier, lower-stakes workloads.",
+        {
+            "fail_mode": "degraded",
+            "tier1_threshold": 25.0,
+            "tier2_threshold": 45.0,
+            "tier3_threshold": 65.0,
+            "presidio_score_threshold": 0.50,
+            "anonymize": False,
+            "tool_guard_enabled": True,
+            "normalize_nfkc": True,
+            "strip_zero_width": True,
+            "map_homoglyphs": True,
+            "detect_rtl_override": True,
+            "fold_leet": True,
+            "decode_encoded_payloads": True,
+        },
+    ),
+    _preset(
+        "iron",
+        "Iron",
+        2,
+        "Balanced default temper, equal to the shipped config defaults: "
+        "fail-degraded, full normalization, tool-call guard on. Recommended with "
+        "the code_generation profile for coding agents.",
+        {
+            "fail_mode": "degraded",
+            "tier1_threshold": 15.0,
+            "tier2_threshold": 30.0,
+            "tier3_threshold": 50.0,
+            "presidio_score_threshold": 0.35,
+            "anonymize": False,
+            "tool_guard_enabled": True,
+            "normalize_nfkc": True,
+            "strip_zero_width": True,
+            "map_homoglyphs": True,
+            "detect_rtl_override": True,
+            "fold_leet": True,
+            "decode_encoded_payloads": True,
+        },
+    ),
+    _preset(
+        "steel",
+        "Steel",
+        3,
+        "Strict temper. Fail-closed, PII anonymization on, earlier escalation, "
+        "and tighter PII sensitivity. A safe posture for handling third-party data.",
+        {
+            "fail_mode": "closed",
+            "tier1_threshold": 10.0,
+            "tier2_threshold": 22.0,
+            "tier3_threshold": 40.0,
+            "presidio_score_threshold": 0.30,
+            "anonymize": True,
+            "tool_guard_enabled": True,
+            "normalize_nfkc": True,
+            "strip_zero_width": True,
+            "map_homoglyphs": True,
+            "detect_rtl_override": True,
+            "fold_leet": True,
+            "decode_encoded_payloads": True,
+        },
+    ),
+    _preset(
+        "titanium",
+        "Titanium",
+        4,
+        "Strictest temper. Fail-closed, anonymization on, earliest escalation, "
+        "and Tier-3 at the hard floor (30). Maximum teeth for high-stakes deployments.",
+        {
+            "fail_mode": "closed",
+            "tier1_threshold": 8.0,
+            "tier2_threshold": 18.0,
+            "tier3_threshold": 30.0,
+            "presidio_score_threshold": 0.25,
+            "anonymize": True,
+            "tool_guard_enabled": True,
+            "normalize_nfkc": True,
+            "strip_zero_width": True,
+            "map_homoglyphs": True,
+            "detect_rtl_override": True,
+            "fold_leet": True,
+            "decode_encoded_payloads": True,
+        },
+    ),
+)
+
+
+def generate_preset_metadata() -> list[dict[str, Any]]:
+    """Ordered strength-preset display metadata for the Config Editor dial.
+
+    Returns a fresh list of fresh dicts each call (defensive copy — the registry
+    source stays immutable). ``overrides`` is copied to a plain ``dict`` so no
+    caller can mutate the frozen ``MappingProxyType``. Mirrors
+    ``generate_section_metadata()``.
+    """
+    return [
+        {
+            "key": p.key,
+            "label": p.label,
+            "order": p.order,
+            "description": p.description,
+            "overrides": dict(p.overrides),
+        }
+        for p in _PRESET_REGISTRY
+    ]
+
+
+def resolve_active_preset(config: PetasosConfig | dict[str, Any]) -> str | None:
+    """Return the key of the preset whose bundle the config currently matches.
+
+    Projects ``config`` to ``_PRESET_OWNED_FIELDS`` and returns the unique
+    ``preset.key`` whose ``overrides`` equals that projection, or ``None`` when
+    none match (the derived **Custom** state, D5). There is no stored "is_custom"
+    flag, so the dial can never drift out of sync with the actual config.
+
+    Accepts a ``PetasosConfig`` (its ``to_dict()`` is called) or an already-built
+    config dict (e.g. a redacted payload). No owned field is a secret, so a
+    redacted dict resolves identically to the live object. A dict missing an
+    owned key resolves to ``None`` rather than raising.
+    """
+    if isinstance(config, dict):
+        config_dict: dict[str, Any] = config
+    else:
+        config_dict = config.to_dict()
+
+    try:
+        projection = {field: config_dict[field] for field in _PRESET_OWNED_FIELDS}
+    except (KeyError, TypeError):
+        return None
+
+    for preset in _PRESET_REGISTRY:
+        if dict(preset.overrides) == projection:
+            return preset.key
+    return None
+
+
+__all__ = [
+    "StrengthPreset",
+    "generate_preset_metadata",
+    "resolve_active_preset",
+]

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from petasos.console._config_meta import generate_config_metadata, generate_section_metadata
 from petasos.console._paths import resolve_hermes_config_path
+from petasos.console._presets import generate_preset_metadata, resolve_active_preset
 from petasos.console._ring_buffer import RingBuffer
 from petasos.console._sse import SSEBroadcaster
 from petasos.console._validation import SessionIdError, sanitize_session_id
@@ -135,7 +136,16 @@ class ConsoleHandlers:
         config_dict = self.pipeline.config.to_dict(redact_secrets=True)
         fields = generate_config_metadata()
         sections = generate_section_metadata()
-        return {"config": config_dict, "fields": fields, "sections": sections}
+        # PET-124: the strength-preset registry and the derived active level. The
+        # comparator is passed the PetasosConfig object (not the redacted payload
+        # dict) — no preset-owned field is a secret, so redaction cannot perturb it.
+        return {
+            "config": config_dict,
+            "fields": fields,
+            "sections": sections,
+            "presets": generate_preset_metadata(),
+            "active_preset": resolve_active_preset(self.pipeline.config),
+        }
 
     async def update_config(
         self, body: dict[str, Any]
@@ -157,6 +167,10 @@ class ConsoleHandlers:
             "config": validated.to_dict(redact_secrets=True),
             "fields": generate_config_metadata(),
             "sections": generate_section_metadata(),
+            # PET-124: recompute the dial level from the freshly validated config so
+            # the editor re-render reflects the just-applied preset (or Custom).
+            "presets": generate_preset_metadata(),
+            "active_preset": resolve_active_preset(validated),
         }
         if not persisted:
             result["warning"] = "Config applied in memory but failed to persist to disk"

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -191,6 +191,25 @@
 .pet .seg button { height: 26px; padding: 0 14px; border: none; background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--tx-mut); border-radius: 5px; transition: background .12s, color .12s; }
 .pet .seg button.on { background: var(--acc); color: var(--color-primary-foreground, #fff); }
 
+/* ── PET-124: strength-preset "tuning dial" (Config Editor) ── */
+.pet .pet-dial-host { flex: 0 0 auto; }
+.pet .pet-dial-wrap { display: flex; flex-direction: column; gap: 6px; padding: 4px 0 12px; margin-bottom: 8px; border-bottom: 1px solid var(--border-soft); }
+.pet .pet-dial-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.pet .pet-dial-title { flex: 0 0 auto; }
+/* The dial reuses .seg; its segments are wider and label-cased, and the Custom
+   tail reads as derived (dashed, muted) rather than a peer selectable level. */
+.pet .seg.pet-dial { flex-wrap: wrap; }
+.pet .pet-dial-seg { display: inline-flex; align-items: center; gap: 5px; height: 26px; padding: 0 12px; border: none; background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--tx-mut); border-radius: 5px; transition: background .12s, color .12s; }
+.pet .pet-dial-seg:hover { color: var(--tx-bright); background: var(--bg-hover); }
+.pet .pet-dial-seg.on { background: var(--acc); color: var(--color-primary-foreground, #fff); }
+.pet .pet-dial-seg.on:hover { background: var(--acc); }
+.pet .pet-dial-seg .help { color: inherit; }
+.pet .pet-dial-custom { cursor: default; font-style: italic; color: var(--tx-faint); box-shadow: inset 0 0 0 1px var(--border); }
+.pet .pet-dial-custom:hover { background: transparent; color: var(--tx-faint); }
+.pet .pet-dial-custom.on { background: var(--bg-active); color: var(--tx-bright); font-style: normal; box-shadow: inset 0 0 0 1px var(--border-strong); }
+.pet .pet-dial-rec { font-size: 11px; color: var(--tx-faint); font-family: var(--font-mono); }
+.pet .pet-dial-rec b { color: var(--amber); font-weight: 600; }
+
 /* flex: none, not a fixed basis — inside the column .pet-ctrl-wrap (petasos.js, PET-81)
    a 38px flex-basis becomes the *height* (column main axis beats the height property),
    rendering the pill as a 38x38 rounded square (PET-89). min/max-height + 999px radius

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1224,7 +1224,13 @@
         dataset: { preset: String(p.key) },
         onClick: function () { if (typeof onSelect === "function") onSelect(p); },
       }, p.label != null ? p.label : String(p.key));
-      if (p.description) btn.appendChild(Pet.HelpTip(p.description));
+      if (p.description) {
+        // The HelpTip lives inside the clickable segment; swallow its click so
+        // reading the tooltip never bubbles to onSelect and applies the preset.
+        var tip = Pet.HelpTip(p.description);
+        tip.addEventListener("click", function (e) { if (e && e.stopPropagation) e.stopPropagation(); });
+        btn.appendChild(tip);
+      }
       seg.appendChild(btn);
     });
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -288,6 +288,11 @@
     config: null,
     configFields: null,
     configDirty: {},
+    // PET-124: strength-preset registry + derived active level from the last
+    // /config fetch (alongside config / configFields). active level is recomputed
+    // authoritatively on every fetch and update response.
+    configPresets: null,
+    configActivePreset: null,
     scanHistory: [],
     alerts: [],
     auditLog: [],
@@ -1154,6 +1159,99 @@
     }, text);
   };
 
+  // ── PET-124: strength-preset "tuning dial" ──
+  // Pure JS mirror of petasos.console._presets.resolve_active_preset. Projects
+  // `configValues` to each preset's override keys and returns the matching
+  // preset key, or null (the derived "Custom" state) when none match. Used for
+  // live (pre-apply) flips while editing. Value-normalizing equality: booleans
+  // and the fail_mode string compare strictly; numeric owned fields compare as
+  // Number(a) === Number(b), so a JSON-sourced `30` and a literal `30.0` are
+  // equal and a freshly-applied preset never spuriously reads as Custom.
+  Pet.resolveActivePreset = function (configValues, presets) {
+    if (!configValues || typeof configValues !== "object") return null;
+    if (!Array.isArray(presets) || presets.length === 0) return null;
+    var valEq = function (a, b) {
+      if (typeof a === "boolean" || typeof b === "boolean") return a === b;
+      if (typeof a === "number" || typeof b === "number") return Number(a) === Number(b);
+      return a === b;
+    };
+    for (var i = 0; i < presets.length; i++) {
+      var p = presets[i];
+      if (!p || typeof p !== "object" || !p.overrides || typeof p.overrides !== "object") continue;
+      var keys = Object.keys(p.overrides);
+      if (keys.length === 0) continue;
+      var match = true;
+      for (var j = 0; j < keys.length; j++) {
+        var k = keys[j];
+        if (!Object.prototype.hasOwnProperty.call(configValues, k) || !valEq(configValues[k], p.overrides[k])) {
+          match = false;
+          break;
+        }
+      }
+      if (match) return p.key != null ? p.key : null;
+    }
+    return null;
+  };
+
+  // Renders the segmented strength dial: one button per preset (in `order`) plus
+  // a trailing non-selectable Custom segment, the active one highlighted from
+  // `activeKey` (Custom when null/absent/unknown). Each metal carries a HelpTip
+  // from its description. Clicking a metal calls onSelect(preset). Never throws
+  // (PET-99) / no innerHTML (PET-82): degrades on every malformed shape — a stale
+  // backend missing `presets` (renders nothing), an empty list (nothing), a
+  // preset entry lacking `overrides` (skipped).
+  Pet.renderStrengthDial = function (presets, activeKey, onSelect) {
+    var wrap = Pet.h("div", { className: "pet-dial-wrap" });
+    if (!Array.isArray(presets) || presets.length === 0) return wrap;
+    var ordered = presets
+      .filter(function (p) {
+        return p && typeof p === "object" && p.overrides && typeof p.overrides === "object";
+      })
+      .sort(function (a, b) { return ((a && a.order) || 0) - ((b && b.order) || 0); });
+    if (ordered.length === 0) return wrap;
+
+    var row = Pet.h("div", { className: "pet-dial-row" });
+    row.appendChild(Pet.h("span", { className: "pet-dial-title eyebrow" }, "Strength"));
+    var seg = Pet.h("div", { className: "seg pet-dial" });
+
+    var activeIsKnown = false;
+    ordered.forEach(function (p) {
+      var isOn = p.key === activeKey;
+      if (isOn) activeIsKnown = true;
+      var btn = Pet.h("button", {
+        className: "pet-dial-seg" + (isOn ? " on" : ""),
+        type: "button",
+        dataset: { preset: String(p.key) },
+        onClick: function () { if (typeof onSelect === "function") onSelect(p); },
+      }, p.label != null ? p.label : String(p.key));
+      if (p.description) btn.appendChild(Pet.HelpTip(p.description));
+      seg.appendChild(btn);
+    });
+
+    // Derived Custom segment — presentational, not clickable. Highlighted when no
+    // built-in level matches the live config.
+    var custom = Pet.h("span", {
+      className: "pet-dial-seg pet-dial-custom" + (activeIsKnown ? "" : " on"),
+      dataset: { preset: "custom" },
+      title: "Custom: the live config does not match any built-in level.",
+    }, "Custom");
+    seg.appendChild(custom);
+
+    row.appendChild(seg);
+    wrap.appendChild(row);
+
+    // D6: presentational recommendation pairing Iron (strength) with the
+    // code_generation profile (scenario, selected separately). Changes no default.
+    wrap.appendChild(Pet.h("div", { className: "pet-dial-rec" },
+      "Recommended for coding agents: ",
+      Pet.h("b", {}, "Iron"),
+      " strength with the ",
+      Pet.h("b", {}, "code_generation"),
+      " profile."
+    ));
+    return wrap;
+  };
+
   Pet.renderConfig = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "12px", height: "100%" } });
@@ -1179,7 +1277,63 @@
       }
       Pet.state.config = d.config;
       Pet.state.configFields = d.fields;
+      Pet.state.configPresets = d.presets;
+      Pet.state.configActivePreset = d.active_preset;
       formArea.innerHTML = "";
+
+      // PET-124: strength dial at the top of the editor. The owned-field set is
+      // derived from the presets payload so the live (pre-apply) recompute and the
+      // apply wiring stay in lockstep with the backend registry. If `presets` is
+      // absent (stale backend), OWNED is empty and the dial renders nothing.
+      var OWNED = {};
+      (Array.isArray(d.presets) ? d.presets : []).forEach(function (p) {
+        if (p && p.overrides && typeof p.overrides === "object") {
+          Object.keys(p.overrides).forEach(function (k) { OWNED[k] = true; });
+        }
+      });
+      var dialHost = Pet.h("div", { className: "pet-dial-host" });
+      formArea.appendChild(dialHost);
+      var dialApplyInFlight = false;
+      var currentConfigValues = function () {
+        // Persisted config overlaid with in-memory edits, restricted to owned fields.
+        var vals = {};
+        Object.keys(OWNED).forEach(function (k) {
+          if (d.config && Object.prototype.hasOwnProperty.call(d.config, k)) vals[k] = d.config[k];
+        });
+        Object.keys(Pet.state.configDirty).forEach(function (k) { vals[k] = Pet.state.configDirty[k]; });
+        return vals;
+      };
+      var onSelectPreset = function (preset) {
+        if (!preset || !preset.overrides || dialApplyInFlight) return;
+        dialApplyInFlight = true;  // in-flight guard, mirrors the Apply button
+        Pet.api.putConfig(preset.overrides).then(function (resp) {
+          if (resp && resp._status && resp.detail) {
+            var raw = Array.isArray(resp.detail) ? resp.detail : [resp.detail];
+            var msg = raw.map(function (e) {
+              if (!e || typeof e !== "object") return String(e);
+              return (e.field || "?") + ": " + (e.message || e.msg || e.detail || String(e));
+            }).join("; ");
+            alert("Preset apply failed: " + msg);
+            return;
+          }
+          if (resp && resp.error) { alert("Preset apply failed: " + resp.error); return; }
+          // Re-render from persisted truth: the merge base is the server-side
+          // config, so a preset apply intentionally discards unsaved non-owned
+          // edits and resets the dirty map, consistent with the Apply path.
+          Pet.state.config = resp.config || Pet.state.config;
+          Pet.state.configDirty = {};
+          Pet.renderConfig(container);
+        }).then(function () { dialApplyInFlight = false; }, function () { dialApplyInFlight = false; });
+      };
+      var renderDial = function () {
+        dialHost.innerHTML = "";
+        var activeKey = Pet.resolveActivePreset(currentConfigValues(), d.presets);
+        dialHost.appendChild(Pet.renderStrengthDial(d.presets, activeKey, onSelectPreset));
+      };
+      // Recompute the highlight only when an owned field changes; a non-owned edit
+      // never flips the dial.
+      var maybeUpdateDial = function (name) { if (OWNED[name]) renderDial(); };
+      renderDial();
 
       var groups = Pet.groupConfigSections(d.fields, d.sections);
       // Declared up front (not inside the loop) so the empty path leaves them
@@ -1214,6 +1368,7 @@
               sw.className = "switch" + (val ? " on" : "");
               sw.setAttribute("aria-checked", val ? "true" : "false");
               Pet.state.configDirty[f.name] = val;
+              maybeUpdateDial(f.name);
             };
             var sw = Pet.h("button", {
               className: "switch" + (val ? " on" : ""),
@@ -1234,6 +1389,7 @@
                   seg.querySelectorAll("button").forEach(function (b) { b.className = ""; b.setAttribute("aria-checked", "false"); });
                   btn.className = "on"; btn.setAttribute("aria-checked", "true");
                   Pet.state.configDirty[f.name] = opt;
+                  maybeUpdateDial(f.name);
                 }
               }, opt);
               seg.appendChild(btn);
@@ -1250,7 +1406,7 @@
             if (c.max != null) inp.setAttribute("max", String(c.max));
             var frac = (c.min != null && !Number.isInteger(c.min)) || (c.max != null && c.max <= 1);
             inp.setAttribute("step", frac ? "any" : "1");
-            inp.addEventListener("change", function () { Pet.state.configDirty[f.name] = parseFloat(inp.value); });
+            inp.addEventListener("change", function () { Pet.state.configDirty[f.name] = parseFloat(inp.value); maybeUpdateDial(f.name); });
             control = inp;
           } else if (f.redacted) {
             control = Pet.h("span", { className: "mono", style: { fontSize: "12px", color: "var(--tx-faint)" } }, val || "(not set)");
@@ -1259,7 +1415,7 @@
               className: "input mono", style: { width: "200px", height: "32px" },
               value: val != null ? String(val) : "",
             });
-            inp2.addEventListener("change", function () { Pet.state.configDirty[f.name] = inp2.value; });
+            inp2.addEventListener("change", function () { Pet.state.configDirty[f.name] = inp2.value; maybeUpdateDial(f.name); });
             control = inp2;
           }
 

--- a/tests/js/preset-dial.test.mjs
+++ b/tests/js/preset-dial.test.mjs
@@ -235,16 +235,48 @@ test("renderStrengthDial: degrades without throwing on malformed shapes", () => 
 
 test("renderStrengthDial: a metal click invokes the apply path with that preset's overrides", () => {
   let putBody = null;
-  // Stub the apply path; record the PUT body the dial sends.
-  Pet.api.putConfig = function (body) {
-    putBody = body;
-    return { then: function () { return { then: function () {} }; } };
-  };
-  const onSelect = function (p) { Pet.api.putConfig(p.overrides); };
-  const dial = Pet.renderStrengthDial(presets(), "iron", onSelect);
+  const originalPutConfig = Pet.api.putConfig;
+  // Stub the apply path; record the PUT body the dial sends. Restored in finally
+  // so the global mutation cannot leak into later tests.
+  try {
+    Pet.api.putConfig = function (body) {
+      putBody = body;
+      return { then: function () { return { then: function () {} }; } };
+    };
+    const onSelect = function (p) { Pet.api.putConfig(p.overrides); };
+    const dial = Pet.renderStrengthDial(presets(), "iron", onSelect);
 
-  fire(segByKey(dial, "bronze"), "click");
-  assertLoose.deepEqual(putBody, BRONZE);
+    fire(segByKey(dial, "bronze"), "click");
+    assertLoose.deepEqual(putBody, BRONZE);
+  } finally {
+    Pet.api.putConfig = originalPutConfig;
+  }
+});
+
+test("renderStrengthDial: the in-segment HelpTip swallows clicks (no preset apply)", () => {
+  // Regression for PET-124 review (Major): the HelpTip lives inside the clickable
+  // segment, so reading the tooltip must not bubble to onSelect. The fix registers
+  // a click handler on the tip that stops propagation; assert it is present.
+  const dial = Pet.renderStrengthDial(presets(), "iron", function () {});
+  const ironSeg = segByKey(dial, "iron");
+  const help = (function find(node) {
+    for (const c of node.childNodes || []) {
+      if (c.nodeType === 1) {
+        if (hasClass(c, "help")) return c;
+        const f = find(c);
+        if (f) return f;
+      }
+    }
+    return null;
+  })(ironSeg);
+  assert.ok(help, "metal segment carries a HelpTip");
+  assert.ok(help.handlers.click && help.handlers.click.length > 0, "HelpTip has a click handler");
+  // Firing the tip's click invokes its stopPropagation guard without throwing.
+  let propagationStopped = false;
+  assert.doesNotThrow(() =>
+    fire(help, "click", { stopPropagation() { propagationStopped = true; } })
+  );
+  assert.ok(propagationStopped, "tip click calls stopPropagation");
 });
 
 test("renderStrengthDial: the Custom segment is not clickable (no onSelect)", () => {

--- a/tests/js/preset-dial.test.mjs
+++ b/tests/js/preset-dial.test.mjs
@@ -1,0 +1,258 @@
+// Unit tests for PET-124 — the strength-preset "tuning dial".
+//
+// Covers the two new JS surfaces in petasos/console/static/petasos.js:
+//   1. Pet.resolveActivePreset(configValues, presets) — pure JS mirror of the
+//      Python comparator (exact match, owned-field edit → Custom, non-owned edit
+//      ignored, numeric value-normalizing equality).
+//   2. Pet.renderStrengthDial(presets, activeKey, onSelect) — segmented control:
+//      one segment per preset + a Custom tail, active marking, never-throw
+//      degradation on malformed shapes, and metal-click → apply path.
+//
+// Zero npm dependencies: Node's built-in test runner + assert + node:vm,
+// evaluating the real shipped petasos.js. Run with:
+//   node --test tests/js/preset-dial.test.mjs
+//
+// The DOM shim mirrors tests/js/config-sections.test.mjs (addEventListener /
+// setAttribute / dataset support), since the dial renders interactive buttons
+// and HelpTip tooltips.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import assertLoose from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Interactive DOM shim ────────────────────────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    dataset: {},
+    attributes: {},
+    handlers: {},
+    className: "",
+    title: "",
+    tabIndex: undefined,
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    setAttribute(k, v) {
+      this.attributes[k] = String(v);
+    },
+    getAttribute(k) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
+    },
+    addEventListener(type, fn) {
+      (this.handlers[type] = this.handlers[type] || []).push(fn);
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      const t = makeNode(3);
+      t.nodeValue = String(v);
+      this.childNodes = [t];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createElementNS(ns, tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    el.namespaceURI = ns;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ───────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function fire(node, type, evt) {
+  const hs = (node.handlers && node.handlers[type]) || [];
+  hs.forEach((fn) => fn(evt || { preventDefault() {} }));
+}
+
+const hasClass = (el, c) => (el.className || "").split(/\s+/).includes(c);
+
+// Collect every element carrying a data-preset (the dial segments), depth-first.
+function segments(node, acc) {
+  acc = acc || [];
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (child.dataset && child.dataset.preset != null) acc.push(child);
+      segments(child, acc);
+    }
+  }
+  return acc;
+}
+
+function segByKey(node, key) {
+  return segments(node).find((s) => s.dataset.preset === key) || null;
+}
+
+// Preset fixtures. Deliberately NOT in `order` sequence — the dial must sort.
+const IRON = {
+  fail_mode: "degraded", tier1_threshold: 15, tier2_threshold: 30, tier3_threshold: 50,
+  presidio_score_threshold: 0.35, anonymize: false, tool_guard_enabled: true,
+  normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
+  detect_rtl_override: true, fold_leet: true, decode_encoded_payloads: true,
+};
+const BRONZE = {
+  fail_mode: "degraded", tier1_threshold: 25, tier2_threshold: 45, tier3_threshold: 65,
+  presidio_score_threshold: 0.5, anonymize: false, tool_guard_enabled: true,
+  normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
+  detect_rtl_override: true, fold_leet: true, decode_encoded_payloads: true,
+};
+const TIN = {
+  fail_mode: "open", tier1_threshold: 40, tier2_threshold: 60, tier3_threshold: 80,
+  presidio_score_threshold: 0.6, anonymize: false, tool_guard_enabled: false,
+  normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
+  detect_rtl_override: false, fold_leet: false, decode_encoded_payloads: false,
+};
+function presets() {
+  return [
+    { key: "tin", label: "Tin", order: 0, description: "Loosest temper.", overrides: { ...TIN } },
+    { key: "iron", label: "Iron", order: 2, description: "Default temper.", overrides: { ...IRON } },
+    { key: "bronze", label: "Bronze", order: 1, description: "Relaxed temper.", overrides: { ...BRONZE } },
+  ];
+}
+
+// ── Loader guard ─────────────────────────────────────────────────────────────
+test("loader: petasos.js exports the PET-124 surfaces", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.resolveActivePreset, "function");
+  assert.equal(typeof Pet.renderStrengthDial, "function");
+});
+
+// ── resolveActivePreset ──────────────────────────────────────────────────────
+test("resolveActivePreset: exact match returns the preset key", () => {
+  assert.equal(Pet.resolveActivePreset({ ...IRON }, presets()), "iron");
+  assert.equal(Pet.resolveActivePreset({ ...BRONZE }, presets()), "bronze");
+});
+
+test("resolveActivePreset: an edited owned field flips to Custom (null)", () => {
+  assert.equal(Pet.resolveActivePreset({ ...IRON, fail_mode: "open" }, presets()), null);
+  assert.equal(Pet.resolveActivePreset({ ...IRON, tier1_threshold: 14 }, presets()), null);
+});
+
+test("resolveActivePreset: a non-owned field change does not flip the dial", () => {
+  // The resolver only inspects each preset's override keys; extra keys are ignored.
+  assert.equal(Pet.resolveActivePreset({ ...IRON, alert_per_minute_cap: 7 }, presets()), "iron");
+});
+
+test("resolveActivePreset: value-normalizing numeric equality (30 vs 30.0/'30')", () => {
+  // Numeric owned fields compare as Number(a) === Number(b), so a JSON-sourced
+  // integer or string still resolves to the float-literal preset.
+  const asStrings = { ...IRON, tier1_threshold: "15", tier2_threshold: "30", tier3_threshold: "50" };
+  assert.equal(Pet.resolveActivePreset(asStrings, presets()), "iron");
+});
+
+test("resolveActivePreset: degrades to null on malformed inputs", () => {
+  assert.equal(Pet.resolveActivePreset({ ...IRON }, null), null);
+  assert.equal(Pet.resolveActivePreset({ ...IRON }, []), null);
+  assert.equal(Pet.resolveActivePreset(null, presets()), null);
+  assert.equal(Pet.resolveActivePreset({}, presets()), null);
+});
+
+// ── renderStrengthDial ───────────────────────────────────────────────────────
+test("renderStrengthDial: one segment per preset plus a Custom tail", () => {
+  const dial = Pet.renderStrengthDial(presets(), "iron", function () {});
+  const segs = segments(dial);
+  // 3 metals + Custom.
+  assert.equal(segs.length, 4);
+  // Metals sorted by `order`: tin, bronze, iron — then custom last.
+  assertLoose.deepEqual(
+    segs.map((s) => s.dataset.preset),
+    ["tin", "bronze", "iron", "custom"]
+  );
+});
+
+test("renderStrengthDial: marks the active metal, Custom off", () => {
+  const dial = Pet.renderStrengthDial(presets(), "iron", function () {});
+  assert.ok(hasClass(segByKey(dial, "iron"), "on"), "iron is active");
+  assert.ok(!hasClass(segByKey(dial, "bronze"), "on"), "bronze not active");
+  assert.ok(!hasClass(segByKey(dial, "custom"), "on"), "custom not active");
+});
+
+test("renderStrengthDial: null/unknown active highlights Custom", () => {
+  for (const key of [null, undefined, "nonexistent"]) {
+    const dial = Pet.renderStrengthDial(presets(), key, function () {});
+    assert.ok(hasClass(segByKey(dial, "custom"), "on"), "custom active when no metal matches");
+    assert.ok(!hasClass(segByKey(dial, "iron"), "on"), "no metal active");
+  }
+});
+
+test("renderStrengthDial: recommendation line names Iron + code_generation", () => {
+  const dial = Pet.renderStrengthDial(presets(), "iron", function () {});
+  const text = dial.textContent;
+  assert.ok(text.includes("Iron"), "names Iron");
+  assert.ok(text.includes("code_generation"), "names the code_generation profile");
+});
+
+test("renderStrengthDial: degrades without throwing on malformed shapes", () => {
+  // Absent presets → renders nothing (no segments), no throw.
+  assert.doesNotThrow(() => Pet.renderStrengthDial(undefined, "iron", function () {}));
+  assert.equal(segments(Pet.renderStrengthDial(undefined, "iron", function () {})).length, 0);
+  // Empty presets → nothing.
+  assert.equal(segments(Pet.renderStrengthDial([], "iron", function () {})).length, 0);
+  // active_preset null/absent with presets present → dial renders, no throw.
+  assert.doesNotThrow(() => Pet.renderStrengthDial(presets(), null, function () {}));
+  // A preset entry lacking `overrides` is skipped; valid ones still render.
+  const withBad = presets().concat([{ key: "broken", label: "Broken", order: 9 }]);
+  const dial = Pet.renderStrengthDial(withBad, "iron", function () {});
+  assert.equal(segByKey(dial, "broken"), null, "malformed preset is skipped");
+  // tin/bronze/iron + custom survive.
+  assert.equal(segments(dial).length, 4);
+});
+
+test("renderStrengthDial: a metal click invokes the apply path with that preset's overrides", () => {
+  let putBody = null;
+  // Stub the apply path; record the PUT body the dial sends.
+  Pet.api.putConfig = function (body) {
+    putBody = body;
+    return { then: function () { return { then: function () {} }; } };
+  };
+  const onSelect = function (p) { Pet.api.putConfig(p.overrides); };
+  const dial = Pet.renderStrengthDial(presets(), "iron", onSelect);
+
+  fire(segByKey(dial, "bronze"), "click");
+  assertLoose.deepEqual(putBody, BRONZE);
+});
+
+test("renderStrengthDial: the Custom segment is not clickable (no onSelect)", () => {
+  let called = false;
+  const dial = Pet.renderStrengthDial(presets(), null, function () { called = true; });
+  // Custom carries no click handler.
+  const custom = segByKey(dial, "custom");
+  assert.ok(!custom.handlers.click, "custom has no click handler");
+  fire(custom, "click"); // no-op
+  assert.equal(called, false);
+});

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -74,6 +74,56 @@ async def test_update_config_returns_sections(handlers: ConsoleHandlers) -> None
         assert {"key", "label", "order"} <= set(s.keys())
 
 
+# ── PET-124: strength-preset dial payload keys ───────────────────────────────
+
+
+async def test_get_config_returns_presets(handlers: ConsoleHandlers) -> None:
+    # get_config carries the ordered preset registry and the derived active level.
+    result = await handlers.get_config()
+    assert "presets" in result
+    presets = result["presets"]
+    assert isinstance(presets, list) and len(presets) == 5
+    for p in presets:
+        assert {"key", "label", "order", "description", "overrides"} <= set(p.keys())
+        assert isinstance(p["overrides"], dict) and p["overrides"]
+    # A default pipeline resolves to Iron (the shipped default, D6).
+    assert result["active_preset"] == "iron"
+
+
+async def test_get_config_active_preset_ignores_redaction() -> None:
+    # A non-default hash_key (a secret) must not leak into resolution — the
+    # comparator sees the PetasosConfig object, not the redacted payload dict.
+    h = ConsoleHandlers(
+        Pipeline(
+            scanners=[MinimalScanner()],
+            config=PetasosConfig(hash_key="my-secret-key"),
+        )
+    )
+    result = await h.get_config()
+    assert result["config"]["hash_key"] == "[REDACTED]"
+    assert result["active_preset"] == "iron"
+
+
+async def test_update_config_returns_presets(handlers: ConsoleHandlers) -> None:
+    # update_config echoes presets and an active_preset consistent with the body.
+    from petasos.console._presets import _PRESET_REGISTRY
+
+    steel = next(p for p in _PRESET_REGISTRY if p.key == "steel")
+    result, errors = await handlers.update_config(dict(steel.overrides))
+    assert errors is None
+    assert result is not None
+    assert isinstance(result["presets"], list) and len(result["presets"]) == 5
+    assert result["active_preset"] == "steel"
+
+
+async def test_update_config_off_preset_field_is_custom(handlers: ConsoleHandlers) -> None:
+    # Applying a single off-preset owned field yields the derived Custom state.
+    result, errors = await handlers.update_config({"tier1_threshold": 12.0})
+    assert errors is None
+    assert result is not None
+    assert result["active_preset"] is None
+
+
 async def test_metadata_endpoint_carries_help_plain(handlers: ConsoleHandlers) -> None:
     # Regression for PET-88: config metadata carries plain-language help text
     # alongside the technical description for every field.

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,217 @@
+"""Tests for petasos.console._presets — the PET-124 strength-preset registry.
+
+Pure, ML-free, 3.10-clean: the registry, contract, validation, floor, and
+custom-detection guards. Mirrors tests/test_config_meta.py's section-registry
+tests (PET-114).
+"""
+
+import dataclasses
+
+import pytest
+
+from petasos.config import PetasosConfig
+from petasos.console._config_meta import _FIELD_META
+from petasos.console._presets import (
+    _PRESET_OWNED_FIELDS,
+    _PRESET_REGISTRY,
+    StrengthPreset,
+    generate_preset_metadata,
+    resolve_active_preset,
+)
+from petasos.scanners.minimal import _UNSUPPRESSIBLE_RULE_IDS, MinimalScanner
+
+# The exact owned-field set (D8): 13 config-level strength fields, no reliability
+# or profile levers. Pinned here so a drift in either the registry or the
+# allowlist is caught.
+_EXPECTED_OWNED_FIELDS = frozenset(
+    {
+        "fail_mode",
+        "tier1_threshold",
+        "tier2_threshold",
+        "tier3_threshold",
+        "presidio_score_threshold",
+        "anonymize",
+        "tool_guard_enabled",
+        "normalize_nfkc",
+        "strip_zero_width",
+        "map_homoglyphs",
+        "detect_rtl_override",
+        "fold_leet",
+        "decode_encoded_payloads",
+    }
+)
+
+
+def _config_from_preset(preset: StrengthPreset) -> PetasosConfig:
+    """Build a PetasosConfig by applying a preset over the shipped defaults."""
+    return PetasosConfig.from_dict({**PetasosConfig().to_dict(), **dict(preset.overrides)})
+
+
+def test_preset_registry_frozen_and_ordered() -> None:
+    # Tuple typed Final; frozen dataclass rejects attribute assignment.
+    assert isinstance(_PRESET_REGISTRY, tuple)
+    assert len(_PRESET_REGISTRY) == 5
+    preset = _PRESET_REGISTRY[0]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        preset.label = "mutated"  # type: ignore[misc]
+
+    # order is contiguous 0..4, unique and ascending in registry order.
+    orders = [p.order for p in _PRESET_REGISTRY]
+    assert orders == [0, 1, 2, 3, 4]
+    assert len(set(orders)) == len(orders)
+
+    keys = [p.key for p in _PRESET_REGISTRY]
+    assert keys == ["tin", "bronze", "iron", "steel", "titanium"]
+
+    # generate_preset_metadata returns fresh objects each call: mutating the
+    # result cannot corrupt the registry, and overrides is a plain dict.
+    a = generate_preset_metadata()
+    b = generate_preset_metadata()
+    assert a == b
+    assert a is not b
+    assert a[0] is not b[0]
+    assert isinstance(a[0]["overrides"], dict)
+    a[0]["label"] = "MUTATED"
+    a[0]["overrides"]["fail_mode"] = "tampered"
+    fresh = generate_preset_metadata()
+    assert fresh[0]["label"] != "MUTATED"
+    assert fresh[0]["overrides"]["fail_mode"] != "tampered"
+
+    # ordered, with the expected entry shape.
+    assert [p["order"] for p in fresh] == list(range(len(fresh)))
+    for entry in fresh:
+        assert set(entry.keys()) == {"key", "label", "order", "description", "overrides"}
+        assert isinstance(entry["key"], str) and entry["key"]
+        assert isinstance(entry["label"], str) and entry["label"].strip()
+        assert isinstance(entry["description"], str) and entry["description"].strip()
+        assert isinstance(entry["order"], int)
+
+
+def test_strength_preset_is_frozen_slots_dataclass() -> None:
+    assert dataclasses.is_dataclass(StrengthPreset)
+    params = StrengthPreset.__dataclass_params__  # type: ignore[attr-defined]
+    assert params.frozen is True
+    # slots=True means no per-instance __dict__.
+    sample = _PRESET_REGISTRY[0]
+    assert not hasattr(sample, "__dict__")
+    # overrides is an immutable mapping (cannot be mutated in place).
+    with pytest.raises(TypeError):
+        sample.overrides["fail_mode"] = "tampered"  # type: ignore[index]
+
+
+def test_every_preset_field_has_field_meta_entry() -> None:
+    # Mirrors PET-114's orphan-section contract: every overrides key is a known
+    # config field with a _FIELD_META entry (no orphan/typo fields).
+    for preset in _PRESET_REGISTRY:
+        for key in preset.overrides:
+            assert key in _FIELD_META, f"{preset.key}: unknown overrides field {key!r}"
+
+
+def test_all_presets_cover_same_fields() -> None:
+    # Symmetric comparator: each preset's key set equals _PRESET_OWNED_FIELDS,
+    # which equals the pinned expected set.
+    assert _PRESET_OWNED_FIELDS == _EXPECTED_OWNED_FIELDS
+    assert len(_PRESET_OWNED_FIELDS) == 13
+    for preset in _PRESET_REGISTRY:
+        assert set(preset.overrides.keys()) == _PRESET_OWNED_FIELDS, preset.key
+
+
+def test_preset_bundles_distinct() -> None:
+    # Resolution is unambiguous: all five overrides mappings are pairwise distinct.
+    seen: list[dict[str, bool | float | str]] = []
+    for preset in _PRESET_REGISTRY:
+        d = dict(preset.overrides)
+        assert d not in seen, f"{preset.key} duplicates an earlier bundle"
+        seen.append(d)
+
+
+def test_preset_bundle_validates() -> None:
+    # Each preset's full bundle constructs (ascending tiers, finite values, valid
+    # fail_mode).
+    for preset in _PRESET_REGISTRY:
+        cfg = _config_from_preset(preset)
+        assert cfg.fail_mode in ("open", "degraded", "closed")
+        assert cfg.tier1_threshold < cfg.tier2_threshold < cfg.tier3_threshold
+
+    # Guard-is-real: a hand-edited bundle that breaks the ascending invariant is
+    # rejected by from_dict (so a future numeric mistake fails loudly).
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict({**PetasosConfig().to_dict(), "tier1_threshold": 31.0})
+
+
+def test_preset_bundle_round_trips() -> None:
+    # Apply then to_dict/from_dict is stable (config.yaml round-trip contract).
+    for preset in _PRESET_REGISTRY:
+        cfg = _config_from_preset(preset)
+        round_tripped = PetasosConfig.from_dict(cfg.to_dict())
+        assert round_tripped.to_dict() == cfg.to_dict(), preset.key
+
+
+def test_no_preset_lowers_tier3_floor() -> None:
+    # Every preset's constructed tier3_threshold sits at or above the 30.0 floor.
+    for preset in _PRESET_REGISTRY:
+        cfg = _config_from_preset(preset)
+        assert cfg.tier3_threshold >= 30.0, preset.key
+
+    # Sanity: the floor is real — a sub-floor tier3 is rejected at construction.
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict(
+            {**PetasosConfig().to_dict(), "tier2_threshold": 20.0, "tier3_threshold": 29.0}
+        )
+
+
+def test_no_preset_touches_unsuppressible_rules() -> None:
+    # Presets are config-only: no owned field is a suppression lever, so a preset
+    # is structurally incapable of reaching the unsuppressible-rule floor.
+    assert _UNSUPPRESSIBLE_RULE_IDS, "sanity: the unsuppressible set is non-empty"
+    assert "suppress_rules" not in _PRESET_OWNED_FIELDS
+    assert "confidence_floor" not in _PRESET_OWNED_FIELDS
+
+    # End-to-end: after applying each preset, building MinimalScanner the way
+    # pipeline.py does (decode toggle from config, no profile suppression) leaves
+    # every unsuppressible id active.
+    for preset in _PRESET_REGISTRY:
+        cfg = _config_from_preset(preset)
+        scanner = MinimalScanner(decode_encoded_payloads=cfg.decode_encoded_payloads)
+        assert scanner._suppress_rules == frozenset(), preset.key
+        assert _UNSUPPRESSIBLE_RULE_IDS.isdisjoint(scanner._suppress_rules), preset.key
+
+
+def test_custom_detection() -> None:
+    # A default config resolves to Iron (the shipped default, D6).
+    assert resolve_active_preset(PetasosConfig()) == "iron"
+
+    # Editing one owned field flips to Custom (None).
+    assert resolve_active_preset(PetasosConfig(fail_mode="open")) is None
+
+    # An exact preset projection resolves back to that preset's key.
+    steel = next(p for p in _PRESET_REGISTRY if p.key == "steel")
+    assert resolve_active_preset(_config_from_preset(steel)) == "steel"
+
+    # Changing a NON-owned field does not flip the dial (still Iron).
+    assert resolve_active_preset(PetasosConfig(alert_per_minute_cap=7)) == "iron"
+
+    # Redaction never perturbs resolution: no owned field is a secret.
+    assert resolve_active_preset(PetasosConfig().to_dict(redact_secrets=True)) == "iron"
+    assert (
+        resolve_active_preset(PetasosConfig(hash_key="s3cret").to_dict(redact_secrets=True))
+        == "iron"
+    )
+
+
+def test_resolve_active_preset_accepts_dict_and_object() -> None:
+    # The comparator takes either a PetasosConfig or an already-built dict.
+    cfg = PetasosConfig()
+    assert resolve_active_preset(cfg) == resolve_active_preset(cfg.to_dict()) == "iron"
+    # A dict missing owned keys resolves to None rather than raising.
+    assert resolve_active_preset({"fail_mode": "degraded"}) is None
+    assert resolve_active_preset({}) is None
+
+
+def test_iron_equals_shipped_defaults() -> None:
+    # Pins the zero-behavior-change invariant (D6): PetasosConfig() projected to
+    # the owned fields equals Iron's overrides exactly.
+    iron = next(p for p in _PRESET_REGISTRY if p.key == "iron")
+    defaults = PetasosConfig().to_dict()
+    projection = {k: defaults[k] for k in _PRESET_OWNED_FIELDS}
+    assert projection == dict(iron.overrides)


### PR DESCRIPTION
## Summary
- Adds a single **strength dial** at the top of the Console Config Editor: five named "metals temper" levels (Tin, Bronze, Iron, Steel, Titanium) plus a derived **Custom** state. Selecting a level bulk-applies a coherent bundle of existing config strictness fields; editing any preset-owned field afterward makes the dial read Custom.
- Data + UI on top of paths that already exist: no new config field, no new apply path, no change to any enforcement floor. The strength axis stays orthogonal to the profile (scenario) axis (`profile_name` is excluded from the owned set).
- Iron's bundle equals the shipped `PetasosConfig` defaults field-for-field, so a fresh install resolves to **Iron** with zero behavior change (pinned by `test_iron_equals_shipped_defaults`).

## Layered defense
The two security floors live below the config layer and a config-only preset cannot reach them:
- **Tier-3 terminate floor**: every preset sets `tier3_threshold >= 30.0` (Titanium sits exactly at the floor); `from_dict` rejects sub-floor tiers and `derive_tier` uses the inline `max(tier3, 30.0)`. Pinned by `test_no_preset_lowers_tier3_floor`.
- **Unsuppressible injection/structural rules**: no preset-owned field is a rule-suppression lever (suppression is a profile attribute, not a config field). After applying each preset, building `MinimalScanner` the way `pipeline.py` does leaves every id in `_UNSUPPRESSIBLE_RULE_IDS` active. Pinned by `test_no_preset_touches_unsuppressible_rules`.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_presets.py` | New — frozen `StrengthPreset` + `_PRESET_REGISTRY`, `_PRESET_OWNED_FIELDS` (13), `generate_preset_metadata()`, pure `resolve_active_preset()`. Mirrors `_config_meta.py`. |
| `petasos/console/server.py` | Wires `"presets"` + `"active_preset"` into `get_config`/`update_config` at the same points as `"sections"`. Inherited by the Hermes plugin via the shared `ConsoleHandlers`. |
| `petasos/console/static/petasos.js` | Adds `Pet.resolveActivePreset` (JS mirror) and `Pet.renderStrengthDial`; renders the dial at the top of the editor, live pre-apply Custom flips, metal-click apply through the existing `PUT /config`. |
| `petasos/console/static/petasos.css` | Dial affordance (segmented control, active/Custom state, recommendation line). |
| `tests/test_presets.py` | New — registry/contract/validation/floor/custom-detection guards. |
| `tests/test_console_handlers.py` | Asserts the two new payload keys from `get_config` and `update_config` (incl. redaction-invariance). |
| `tests/js/preset-dial.test.mjs` | New — comparator + dial render/degradation/apply tests over the real `petasos.js`. |

## Test plan
- [x] `python -m pytest tests/test_presets.py tests/test_console_handlers.py tests/test_config_meta.py tests/test_config.py -q` — 129/129 pass (full output: docs/specs/TODO/PET-124.test-output.txt)
- [x] `node --test tests/js/preset-dial.test.mjs` — 13/13 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --strict .` — clean (118 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a strength preset tuning dial to the Config Editor with five preset levels (tin, bronze, iron, steel, titanium) plus a **Custom** state when no preset matches.
  * The editor now displays the active preset and keeps it synchronized as you edit owned fields.
  * Selecting a preset applies its settings in one step and updates the dial state accordingly.

* **API Updates**
  * Console config responses now include preset metadata and the currently active preset.

* **Bug Fixes**
  * Active preset detection remains correct even when the main config hash is redacted.

* **Tests**
  * Added backend and frontend test coverage for preset matching, rendering, and preset application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->