### PR TITLE
feat(pet-122): self-describing profile_name picker in the config editor

### DIFF
--- a/docs/specs/TODO/PET-122.test-output.txt
+++ b/docs/specs/TODO/PET-122.test-output.txt
@@ -1,5 +1,5 @@
 PET-122 test gate — captured 2026-06-15T05:39:25Z
-Worktree: /c/Users/zioni/Documents/Vigil-Harbor/PET-122-worktree
+Worktree: <redacted-local-worktree>
 Commit base: 855c309
 
 ### 1. node --test tests/js/profile-picker.test.mjs
@@ -26,7 +26,7 @@ Commit base: 855c309
 ### 2. C:/python310/python.exe -m pytest tests/test_console_handlers.py -k "get_profiles or profile_metadata_surfaced"
 ============================= test session starts =============================
 platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
-rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-122-worktree
+rootdir: <redacted-local-worktree>
 configfile: pyproject.toml
 plugins: anyio-4.13.0, asyncio-1.3.0
 asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function

--- a/docs/specs/TODO/PET-122.test-output.txt
+++ b/docs/specs/TODO/PET-122.test-output.txt
@@ -1,0 +1,41 @@
+PET-122 test gate — captured 2026-06-15T05:39:25Z
+Worktree: /c/Users/zioni/Documents/Vigil-Harbor/PET-122-worktree
+Commit base: 855c309
+
+### 1. node --test tests/js/profile-picker.test.mjs
+✔ loader: petasos.js exports the PET-122 surfaces (0.5246ms)
+✔ profileDescriptions: five built-ins map to their exact trimmed descriptions (0.4059ms)
+✔ profileDescriptions: degrade matrix returns {} and never throws (0.1877ms)
+✔ profileNames: ordered, first-wins deduped, blank-description kept, no-name skipped (0.0929ms)
+✔ profileNames: degrade matrix returns an array, never throws, skips bad entries (0.1877ms)
+✔ duplicate-name payload: profileNames and profileDescriptions both first-wins (0.0709ms)
+✔ render seam: a custom/unknown value renders as a selectable option with the fallback tip (0.8242ms)
+✔ render seam: each enriched option tip is a focusable HelpTip (.help, tabIndex 0, focus handler) (0.1301ms)
+✔ render seam: empty profiles -> (none) + current value, selectable, no tips (0.8054ms)
+✔ render seam: a selection made before enrich survives the rebuild (0.3398ms)
+✔ render seam: a profile named (none) never duplicates the structural unset button (0.2802ms)
+ℹ tests 11
+ℹ suites 0
+ℹ pass 11
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 58.7627
+
+### 2. C:/python310/python.exe -m pytest tests/test_console_handlers.py -k "get_profiles or profile_metadata_surfaced"
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-122-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 49 items / 47 deselected / 2 selected
+
+tests\test_console_handlers.py ..                                        [100%]
+
+====================== 2 passed, 47 deselected in 0.18s =======================
+
+### 3. ruff check . && ruff format --check .
+All checks passed!
+116 files already formatted

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1275,7 +1275,10 @@
     if (!Array.isArray(profiles)) return out;
     for (var i = 0; i < profiles.length; i++) {
       var p = profiles[i];
-      if (p && typeof p.name === "string" && p.name &&
+      // Gate on p.name.trim() so a whitespace-only name (e.g. "   ") is rejected
+      // rather than rendered as a blank button; the original p.name is kept as the
+      // key/value so a padded-but-real name still matches the resolver exactly.
+      if (p && typeof p.name === "string" && p.name.trim() &&
           !Object.prototype.hasOwnProperty.call(out, p.name) &&
           typeof p.description === "string" && p.description.trim()) {
         out[p.name] = p.description.trim();
@@ -1292,7 +1295,9 @@
     if (!Array.isArray(profiles)) return out;
     for (var i = 0; i < profiles.length; i++) {
       var p = profiles[i];
-      if (p && typeof p.name === "string" && p.name &&
+      // Whitespace-only names are rejected (see profileDescriptions); the original
+      // name is the option value so it round-trips to the resolver unchanged.
+      if (p && typeof p.name === "string" && p.name.trim() &&
           !Object.prototype.hasOwnProperty.call(seen, p.name)) {
         seen[p.name] = true;
         out.push(p.name);
@@ -1393,9 +1398,10 @@
 
     rebuild([], {});   // minimal initial seg: "(none)" + current value
     if (profilesP && typeof profilesP.then === "function") {
-      profilesP.then(function (profiles) {
-        rebuild(Pet.profileNames(profiles), Pet.profileDescriptions(profiles));
-      });
+      profilesP.then(
+        function (profiles) { rebuild(Pet.profileNames(profiles), Pet.profileDescriptions(profiles)); },
+        function () { rebuild([], {}); }   // defensive: a non-normalized rejecting promise still degrades to the minimal seg
+      );
     }
     seg._petRebuild = rebuild;   // test seam: drive the enrich rebuild synchronously
     return seg;

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1258,6 +1258,149 @@
     return wrap;
   };
 
+  // ── Profile-picker pure builders (PET-122) ──
+  // Two single-purpose, never-throw builders in the Pet.groupConfigSections /
+  // Pet.scannerHealthRows idiom (no DOM, no network). profileNames is the option
+  // source (every valid name); profileDescriptions is the tip source (names that
+  // carry a usable description). Both first-wins dedup so they agree on a
+  // duplicate-name payload.
+
+  // Map a profile name -> its trimmed description. Tolerant of a missing/partial/
+  // failed /api/profiles payload. Never throws (PET-99 never-throw posture).
+  // Profiles with a blank/missing/non-string description are intentionally absent
+  // (caller falls back to neutral tip copy). First occurrence of a name wins, so a
+  // duplicate-name payload agrees with profileNames. Values are never undefined/empty.
+  Pet.profileDescriptions = function (profiles) {
+    var out = {};
+    if (!Array.isArray(profiles)) return out;
+    for (var i = 0; i < profiles.length; i++) {
+      var p = profiles[i];
+      if (p && typeof p.name === "string" && p.name &&
+          !Object.prototype.hasOwnProperty.call(out, p.name) &&
+          typeof p.description === "string" && p.description.trim()) {
+        out[p.name] = p.description.trim();
+      }
+    }
+    return out;
+  };
+
+  // Ordered list of valid profile names (ALL of them, regardless of description),
+  // deduped first-wins, malformed entries skipped. Never throws. This is the option
+  // source; profileDescriptions is the tip source.
+  Pet.profileNames = function (profiles) {
+    var out = [], seen = {};
+    if (!Array.isArray(profiles)) return out;
+    for (var i = 0; i < profiles.length; i++) {
+      var p = profiles[i];
+      if (p && typeof p.name === "string" && p.name &&
+          !Object.prototype.hasOwnProperty.call(seen, p.name)) {
+        seen[p.name] = true;
+        out.push(p.name);
+      }
+    }
+    return out;
+  };
+
+  // ── Profile-picker render seam (PET-122, D1/D3) ──
+  // Bespoke, fetch-sourced control for the nullable `profile_name` field. Render-
+  // then-enrich: paints a minimal seg ("(none)" + current value) synchronously,
+  // then swaps in the full option set + per-option HelpTips when profilesP resolves.
+  // Never blocks the form on /api/profiles and never throws. Exposed on Pet (like
+  // groupConfigSections / revealFieldSections) so the render-seam unit tests can
+  // drive it; the returned node carries a `_petRebuild(names, descMap)` handle for
+  // the dirty-selection and collision-guard tests.
+  //
+  // NONE_LABEL doubles as the structural unset button's label AND the reserved
+  // literal guarded against name collision (D6): a payload/stored value equal to
+  // "(none)" is treated as unset, never rendered as a second truthy-string button.
+  var PROFILE_NONE_LABEL = "(none)";
+  var PROFILE_FALLBACK_TIP = "Custom profile: no description provided.";   // D5, sole authored string
+  Pet.buildProfileControl = function (f, val, profilesP) {
+    var seg = Pet.h("div", { className: "seg", role: "radiogroup", ariaLabel: Pet.humanizeKey(f.name) });
+    var btns = [];   // explicit node array; selection clearing avoids querySelectorAll (F-1)
+
+    // Recompute selection from configDirty on EVERY call (F-4): dirty wins (may be
+    // null); else the config value captured once in this function's `val` param
+    // (F-3); null => unset. A click before getProfiles resolves wrote configDirty,
+    // so the enrich rebuild re-reads it and keeps the highlight.
+    function currentSelection() {
+      return Object.prototype.hasOwnProperty.call(Pet.state.configDirty, "profile_name")
+        ? Pet.state.configDirty.profile_name
+        : (typeof val === "string" && val ? val : null);
+    }
+    // null OR the literal "(none)" both resolve to the structural unset button.
+    function isNoneSel(sel) { return sel == null || sel === PROFILE_NONE_LABEL; }
+
+    function highlight() {
+      var sel = currentSelection();
+      var noneOn = isNoneSel(sel);
+      for (var i = 0; i < btns.length; i++) {
+        var b = btns[i];
+        var on = b._petNone ? noneOn : (!noneOn && b._petVal === sel);
+        b.className = on ? "on" : "";
+        b.setAttribute("aria-checked", on ? "true" : "false");
+      }
+    }
+
+    function addButton(label, value, tipText) {
+      var btn = Pet.h("button", {
+        className: "", type: "button", role: "radio", ariaChecked: "false",
+        onClick: function () { Pet.state.configDirty.profile_name = value; highlight(); },
+      }, label);
+      btn._petVal = value;          // null for the structural "(none)" button
+      btn._petNone = (value == null);
+      seg.appendChild(btn);
+      btns.push(btn);
+      if (tipText) seg.appendChild(Pet.HelpTip(tipText));   // sibling .help node, focus-revealable (D4)
+    }
+
+    // Clear via shim-observable node removal, never innerHTML="" (F-1): the test
+    // shim has no innerHTML setter, so an innerHTML write would leave childNodes
+    // intact and the enrich rebuild would stack on the stale minimal seg.
+    function clearSeg() {
+      while (seg.childNodes.length) seg.removeChild(seg.childNodes[seg.childNodes.length - 1]);
+      btns = [];
+    }
+
+    function rebuild(names, descMap) {
+      clearSeg();
+      var list = Array.isArray(names) ? names : [];
+      var map = (descMap && typeof descMap === "object") ? descMap : {};
+      // A non-empty profile list means we have enriched data and attach a HelpTip
+      // per name/union button. An empty list is the minimal/degrade seg (initial
+      // paint, or getProfiles rejected/empty): "(none)" + current value, selectable,
+      // NO tips, no console error (D3). tipFor() encodes that split.
+      var enriched = list.length > 0;
+      function tipFor(name) { return enriched ? (map[name] || PROFILE_FALLBACK_TIP) : null; }
+
+      addButton(PROFILE_NONE_LABEL, null, null);   // structural unset, writes null, never a tip
+      var sel = currentSelection();
+      var present = {};
+      for (var i = 0; i < list.length; i++) {
+        var nm = list[i];
+        if (nm === PROFILE_NONE_LABEL) continue;   // D6: never a second "(none)" button
+        present[nm] = true;
+        addButton(nm, nm, tipFor(nm));
+      }
+      // Union the current/dirty value if it is a real custom/unknown name not
+      // already listed (and not the reserved "(none)" literal — F-2).
+      if (typeof sel === "string" && sel && sel !== PROFILE_NONE_LABEL &&
+          !Object.prototype.hasOwnProperty.call(present, sel)) {
+        addButton(sel, sel, tipFor(sel));
+      }
+      highlight();
+    }
+
+    rebuild([], {});   // minimal initial seg: "(none)" + current value
+    if (profilesP && typeof profilesP.then === "function") {
+      profilesP.then(function (profiles) {
+        rebuild(Pet.profileNames(profiles), Pet.profileDescriptions(profiles));
+      });
+    }
+    seg._petRebuild = rebuild;   // test seam: drive the enrich rebuild synchronously
+    return seg;
+  };
+
   Pet.renderConfig = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "12px", height: "100%" } });
@@ -1273,6 +1416,16 @@
     );
     wrapper.appendChild(formArea);
     container.appendChild(wrapper);
+
+    // PET-122: kick off the profiles fetch concurrently with getConfig so it is
+    // already in flight when the form paints. Normalize to a never-throwing promise
+    // of a raw profile array: a rejected or malformed getProfiles resolves to [].
+    // (_get/_req return a fetch-based promise that resolves to {error} on failure
+    // rather than rejecting, so the onRejected arm is belt-and-suspenders.)
+    var profilesP = Pet.api.getProfiles().then(
+      function (resp) { return (resp && Array.isArray(resp.profiles)) ? resp.profiles : []; },
+      function () { return []; }
+    );
 
     Pet.api.getConfig().then(function (d) {
       if (d.error || !d.config || !d.fields) {
@@ -1368,7 +1521,12 @@
         var fieldEls = fields.map(function (f) {
           var val = d.config[f.name];
           var control;
-          if (f.type === "boolean") {
+          if (f.name === "profile_name") {
+            // PET-122: dedicated fetch-sourced control, placed first so no other
+            // field matches it and the generic enum/text branches stay unreachable
+            // for profile_name (D-OPT1).
+            control = Pet.buildProfileControl(f, val, profilesP);
+          } else if (f.type === "boolean") {
             var toggleFn = function () {
               val = !val;
               sw.className = "switch" + (val ? " on" : "");

--- a/tests/js/profile-picker.test.mjs
+++ b/tests/js/profile-picker.test.mjs
@@ -1,0 +1,339 @@
+// Unit tests for PET-122 — the self-describing profile_name picker.
+//
+// Covers the three JS surfaces added to petasos/console/static/petasos.js:
+//   1. Pet.profileDescriptions(profiles) — pure name->trimmed-description map
+//      (the tip source); first-wins dedup, blank/missing/non-string skipped,
+//      never-throw on any malformed /api/profiles payload.
+//   2. Pet.profileNames(profiles) — pure ordered valid-name list (the option
+//      source); first-wins dedup, blank-description names kept, never-throw.
+//   3. Pet.buildProfileControl(f, val, profilesP) — the render seam: a .seg of
+//      hoverable radio buttons with an explicit "(none)" unset option, per-option
+//      HelpTip enrich, dirty-selection recompute, and the "(none)" collision guard.
+//
+// Like config-sections.test.mjs this file ships its OWN extended DOM shim. It adds
+// `removeChild` (the only capability beyond that file's shim) because the picker's
+// enrich rebuild clears the seg via shim-observable node removal, never
+// innerHTML="" (which the shim does not service — see the spec's F-1 note).
+//
+// Zero npm dependencies: Node's built-in test runner + assert + node:vm, evaluating
+// the real shipped petasos.js. Run with:
+//   node --test tests/js/profile-picker.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+// Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
+// returned from the node:vm sandbox carry the sandbox realm's Object/Array
+// prototypes, so assert/strict's deepStrictEqual rejects them even when
+// structurally identical (config-sections.test.mjs:22-28). Structural comparisons
+// use this; primitive comparisons keep the strict `assert`.
+import assertLoose from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Extended interactive DOM shim ──────────────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    style: {},
+    dataset: {},
+    attributes: {},
+    handlers: {},
+    className: "",
+    title: "",
+    tabIndex: undefined,
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    removeChild(child) {
+      const i = this.childNodes.indexOf(child);
+      if (i !== -1) this.childNodes.splice(i, 1);
+      return child;
+    },
+    setAttribute(k, v) {
+      this.attributes[k] = String(v);
+    },
+    getAttribute(k) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
+    },
+    addEventListener(type, fn) {
+      (this.handlers[type] = this.handlers[type] || []).push(fn);
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      const t = makeNode(3);
+      t.nodeValue = String(v);
+      this.childNodes = [t];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createElementNS(ns, tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    el.namespaceURI = ns;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ───────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+const FALLBACK_TIP = "Custom profile: no description provided.";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const hasClass = (el, c) => (el.className || "").split(/\s+/).includes(c);
+
+// Option buttons of a built control, in DOM order.
+function buttons(seg) {
+  return (seg.childNodes || []).filter((n) => n.nodeType === 1 && n.tagName === "BUTTON");
+}
+// The .help (HelpTip) node, if any, that immediately follows `btn` in the seg.
+function tipAfter(seg, btn) {
+  const cn = seg.childNodes || [];
+  const next = cn[cn.indexOf(btn) + 1];
+  return next && next.nodeType === 1 && hasClass(next, "help") ? next : null;
+}
+// Read a HelpTip node's rendered tip text (through the richText fragment).
+function tipText(helpNode) {
+  const tip = (helpNode.childNodes || []).find((c) => c.nodeType === 1 && hasClass(c, "tip"));
+  return tip ? tip.textContent : null;
+}
+const btnByVal = (seg, v) => buttons(seg).find((b) => b._petVal === v);
+const isOn = (b) => hasClass(b, "on") && b.getAttribute("aria-checked") === "true";
+
+const PROFILE_FIELD = { name: "profile_name" };
+function build(val, profilesP) {
+  Pet.state.configDirty = {}; // module-global; reset per build so tests don't bleed
+  return Pet.buildProfileControl(PROFILE_FIELD, val, profilesP);
+}
+
+// Five built-ins with non-empty descriptions (fixtures; values are arbitrary copy,
+// no em dashes per house style — the test pins structure, not the shipped strings).
+function builtins() {
+  return [
+    { name: "general", description: "Balanced defaults for everyday agent traffic." },
+    { name: "customer_service", description: "Support chat: stricter PII handling." },
+    { name: "code_generation", description: "Lets code through; still blocks injection." },
+    { name: "research", description: "Permissive for analysis and long-context reading." },
+    { name: "admin", description: "Maximum strictness for privileged operations." },
+  ];
+}
+
+// Malformed payloads shared by the never-throw matrices (3) and (5).
+const BAD_PAYLOADS = [
+  null,
+  undefined,
+  [],
+  "nope",
+  7,
+  [{ name: "x" }], // no description
+  [{ description: "y" }], // no name
+  [{ name: "z", description: "  " }], // blank description
+  [{ name: "a", description: null }], // null description
+  [{ name: "b", description: 7 }], // number description
+  [{ name: "c", description: {} }], // object description
+  [null, undefined, {}], // garbage entries
+];
+
+// ── 1. Loader guard ──────────────────────────────────────────────────────────
+test("loader: petasos.js exports the PET-122 surfaces", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.profileDescriptions, "function");
+  assert.equal(typeof Pet.profileNames, "function");
+  assert.equal(typeof Pet.buildProfileControl, "function");
+});
+
+// ── 2. profileDescriptions happy path ────────────────────────────────────────
+test("profileDescriptions: five built-ins map to their exact trimmed descriptions", () => {
+  const map = Pet.profileDescriptions(builtins());
+  assertLoose.deepEqual(map, {
+    general: "Balanced defaults for everyday agent traffic.",
+    customer_service: "Support chat: stricter PII handling.",
+    code_generation: "Lets code through; still blocks injection.",
+    research: "Permissive for analysis and long-context reading.",
+    admin: "Maximum strictness for privileged operations.",
+  });
+  // Whitespace is trimmed off the stored value.
+  assertLoose.deepEqual(Pet.profileDescriptions([{ name: "g", description: "  hi  " }]), { g: "hi" });
+});
+
+// ── 3. profileDescriptions never-throw / degrade matrix ──────────────────────
+test("profileDescriptions: degrade matrix returns {} and never throws", () => {
+  for (const bad of BAD_PAYLOADS) {
+    let out;
+    assert.doesNotThrow(() => { out = Pet.profileDescriptions(bad); });
+    assertLoose.deepEqual(out, {}, `bad payload ${JSON.stringify(bad)} -> {}`);
+    // No undefined / empty values ever leak in (vacuously true for {}).
+    for (const k of Object.keys(out)) {
+      assert.equal(typeof out[k], "string");
+      assert.ok(out[k].length > 0);
+    }
+  }
+});
+
+// ── 4. profileNames happy path: order, dedup, blank-description kept ──────────
+test("profileNames: ordered, first-wins deduped, blank-description kept, no-name skipped", () => {
+  const payload = [
+    { name: "general", description: "g" },
+    { name: "research", description: "" }, // blank description is STILL a valid option
+    { name: "general", description: "dup" }, // dedup, first wins
+    { description: "noname" }, // missing name -> skipped
+    { name: "admin", description: "a" },
+  ];
+  assertLoose.deepEqual(Pet.profileNames(payload), ["general", "research", "admin"]);
+});
+
+// ── 5. profileNames never-throw / degrade matrix ─────────────────────────────
+test("profileNames: degrade matrix returns an array, never throws, skips bad entries", () => {
+  const expected = new Map([
+    [JSON.stringify(null), []],
+    [JSON.stringify([]), []],
+    [JSON.stringify("nope"), []],
+    [JSON.stringify(7), []],
+    [JSON.stringify([{ name: "x" }]), ["x"]], // name present, description irrelevant
+    [JSON.stringify([{ description: "y" }]), []], // no name
+    [JSON.stringify([{ name: "z", description: "  " }]), ["z"]], // blank desc, name kept
+    [JSON.stringify([{ name: "a", description: null }]), ["a"]],
+    [JSON.stringify([{ name: "b", description: 7 }]), ["b"]],
+    [JSON.stringify([{ name: "c", description: {} }]), ["c"]],
+    [JSON.stringify([null, undefined, {}]), []],
+  ]);
+  for (const bad of BAD_PAYLOADS) {
+    let out;
+    assert.doesNotThrow(() => { out = Pet.profileNames(bad); });
+    assert.ok(Array.isArray(out), "always an array");
+    const key = JSON.stringify(bad);
+    if (expected.has(key)) assertLoose.deepEqual(out, expected.get(key), `names(${key})`);
+  }
+  assertLoose.deepEqual(Pet.profileNames(undefined), []);
+});
+
+// ── 6. Duplicate-name payload: the two builders agree (first-wins) ────────────
+test("duplicate-name payload: profileNames and profileDescriptions both first-wins", () => {
+  const dup = [
+    { name: "x", description: "A" },
+    { name: "x", description: "B" },
+  ];
+  assertLoose.deepEqual(Pet.profileNames(dup), ["x"]);
+  assertLoose.deepEqual(Pet.profileDescriptions(dup), { x: "A" });
+});
+
+// ── 7. Unknown/custom profile fallback (render seam) ─────────────────────────
+test("render seam: a custom/unknown value renders as a selectable option with the fallback tip", () => {
+  let seg;
+  assert.doesNotThrow(() => { seg = build("my_custom", null); });
+  // Enrich with a payload that does NOT contain the custom value.
+  seg._petRebuild(["general"], { general: "g desc" });
+
+  const custom = btnByVal(seg, "my_custom");
+  assert.ok(custom, "custom value rendered as an option");
+  const help = tipAfter(seg, custom);
+  assert.ok(help, "custom option carries a HelpTip");
+  assert.equal(tipText(help), FALLBACK_TIP);
+
+  // A custom profile that IS in the payload but lacks a description: same fallback.
+  const seg2 = build(null, null);
+  seg2._petRebuild(["weird_one"], {});
+  const weird = btnByVal(seg2, "weird_one");
+  assert.ok(weird);
+  assert.equal(tipText(tipAfter(seg2, weird)), FALLBACK_TIP);
+});
+
+// ── 8. a11y focus-reveal structure (render seam) ─────────────────────────────
+test("render seam: each enriched option tip is a focusable HelpTip (.help, tabIndex 0, focus handler)", () => {
+  const seg = build(null, null);
+  seg._petRebuild(["research"], { research: "Permissive." });
+  const help = tipAfter(seg, btnByVal(seg, "research"));
+  assert.ok(help, "research option has a HelpTip sibling");
+  assert.ok(hasClass(help, "help"), "tip node is a .help span");
+  assert.equal(help.tabIndex, "0", "HelpTip is keyboard-focusable");
+  // Focus-reveal parity with hover: HelpTip registers a focus handler. Structure
+  // only; we do NOT fire it (reveal is pure CSS, and position() needs a real
+  // getBoundingClientRect the shim has no business providing).
+  assert.ok(Array.isArray(help.handlers.focus) && help.handlers.focus.length >= 1, "focus handler registered");
+  assert.equal(tipText(help), "Permissive.");
+});
+
+// ── 9. "(none)" + degrade render (render seam) ───────────────────────────────
+test("render seam: empty profiles -> (none) + current value, selectable, no tips", () => {
+  const seg = build("general", Promise.resolve([])); // /profiles down -> resolves []
+  seg._petRebuild([], {}); // the degrade repaint the empty promise drives
+
+  const none = btnByVal(seg, null);
+  const cur = btnByVal(seg, "general");
+  assert.ok(none, "(none) option present");
+  assert.ok(cur, "current configured value present");
+  // No tips on the minimal/degrade seg.
+  assert.equal(tipAfter(seg, none), null, "(none) has no tip");
+  assert.equal(tipAfter(seg, cur), null, "current value has no tip in degrade render");
+  assert.ok(!(seg.childNodes || []).some((n) => n.nodeType === 1 && hasClass(n, "help")), "no HelpTip nodes at all");
+
+  // Clicking "(none)" writes null and never throws.
+  assert.doesNotThrow(() => none.handlers.click[0]({ preventDefault() {} }));
+  assert.equal(Pet.state.configDirty.profile_name, null);
+  assert.ok(isOn(none), "(none) is highlighted after click");
+});
+
+// ── 10. Dirty selection survives the enrich rebuild (round-1 F-4) ─────────────
+test("render seam: a selection made before enrich survives the rebuild", () => {
+  const seg = build("general", null); // config value is "general"
+  // Operator clicks "research" before getProfiles resolves: writes configDirty.
+  Pet.state.configDirty.profile_name = "research";
+  // Enrich arrives.
+  seg._petRebuild(["general", "research", "admin"], { general: "g", research: "r", admin: "a" });
+
+  const research = btnByVal(seg, "research");
+  assert.ok(research);
+  assert.ok(isOn(research), "research (the dirty value) is highlighted, not the config value");
+  assert.ok(!isOn(btnByVal(seg, "general")), "config value is NOT highlighted");
+});
+
+// ── 11. "(none)" label collision guard (round-1 F-3, round-2 F-2) ─────────────
+test("render seam: a profile named (none) never duplicates the structural unset button", () => {
+  // (a) payload contains a profile literally named "(none)".
+  const seg = build(null, null);
+  seg._petRebuild(["(none)", "general"], { "(none)": "should be ignored", general: "g" });
+  const noneButtons = buttons(seg).filter((b) => b._petNone);
+  assert.equal(noneButtons.length, 1, "exactly one structural (none) button");
+  assert.equal(noneButtons[0]._petVal, null, "the (none) button writes null, not the string");
+  assert.ok(!buttons(seg).some((b) => b._petVal === "(none)"), "no button writes the literal '(none)' string");
+
+  // (b) a current/dirty value equal to the literal "(none)" is treated as unset:
+  // still exactly one structural button, and it is highlighted.
+  const seg2 = build(null, null);
+  Pet.state.configDirty.profile_name = "(none)";
+  seg2._petRebuild(["general"], { general: "g" });
+  const none2 = buttons(seg2).filter((b) => b._petNone);
+  assert.equal(none2.length, 1, "literal '(none)' dirty value adds no second button");
+  assert.ok(isOn(none2[0]), "structural (none) is highlighted for a '(none)' dirty value");
+  assert.ok(!buttons(seg2).some((b) => b._petVal === "(none)"), "no truthy '(none)' string button");
+});

--- a/tests/js/profile-picker.test.mjs
+++ b/tests/js/profile-picker.test.mjs
@@ -158,6 +158,7 @@ const BAD_PAYLOADS = [
   [{ name: "x" }], // no description
   [{ description: "y" }], // no name
   [{ name: "z", description: "  " }], // blank description
+  [{ name: "   ", description: "x" }], // whitespace-only NAME -> rejected (no blank button)
   [{ name: "a", description: null }], // null description
   [{ name: "b", description: 7 }], // number description
   [{ name: "c", description: {} }], // object description
@@ -222,6 +223,7 @@ test("profileNames: degrade matrix returns an array, never throws, skips bad ent
     [JSON.stringify([{ name: "x" }]), ["x"]], // name present, description irrelevant
     [JSON.stringify([{ description: "y" }]), []], // no name
     [JSON.stringify([{ name: "z", description: "  " }]), ["z"]], // blank desc, name kept
+    [JSON.stringify([{ name: "   ", description: "x" }]), []], // whitespace-only name dropped
     [JSON.stringify([{ name: "a", description: null }]), ["a"]],
     [JSON.stringify([{ name: "b", description: 7 }]), ["b"]],
     [JSON.stringify([{ name: "c", description: {} }]), ["c"]],


### PR DESCRIPTION
## Summary
- Replaces the Config Editor's free-text `profile_name` input with a bespoke, fetch-sourced `.seg` picker: the live profiles from `GET /api/profiles` (built-ins plus custom) render as selectable buttons with an explicit **"(none)"** unset option.
- Each option reveals its one-line `description` on **hover or keyboard focus** via the existing `Pet.HelpTip` (PET-113 descriptions, rendered verbatim; the sole authored string is a neutral fallback tip for description-less custom profiles).
- Render-side only: no backend, route, config-field, or enforcement change. `profile_name` stays `str | None`.

## Render-then-enrich, never block, never throw
`Pet.renderConfig` kicks off `getProfiles()` **concurrently** with `getConfig()`. The form (including the profile control) paints as soon as `getConfig` resolves, using a minimal `"(none)"` + current-value seg. When `getProfiles` resolves, an in-place rebuild swaps in the full option set and attaches a `HelpTip` per option. A rejected/malformed/empty `/api/profiles` resolves the profiles promise to `[]`, so the rebuild repaints the same minimal seg: selectable, tip-less, no console error. Selection is recomputed from `Pet.state.configDirty` on every rebuild, so a profile clicked **before** enrich survives it.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Adds `Pet.profileDescriptions` + `Pet.profileNames` pure builders, the `Pet.buildProfileControl` render seam, and a first `f.name === "profile_name"` branch in the control switch. The generic enum/`_derive_type` path is untouched. |
| `tests/js/profile-picker.test.mjs` | New: 11 `node --test` cases (builders' happy + never-throw/degrade matrices, duplicate-name tie-break, and the render seam). |
| `docs/specs/TODO/PET-122.test-output.txt` | New: captured green test-gate output. |

## Test plan
- [x] `node --test tests/js/profile-picker.test.mjs` — 11/11 pass (full output: docs/specs/TODO/PET-122.test-output.txt)
- [x] `C:\python310\python.exe -m pytest tests/test_console_handlers.py -k "get_profiles or profile_metadata_surfaced"` — 2 passed (the `test_profile_metadata_surfaced` data-contract guard the UI depends on)
- [x] `ruff check . && ruff format --check .` — clean (no Python change under `petasos/`; JS is lint-exempt)
- [x] Manual (both platforms, per PET-88/114/123): standalone (`127.0.0.1:8384`) + Hermes-plugin — hover/focus reveals a built-in's description; a custom/unknown profile renders with the fallback tip; with `/api/profiles` faulted the picker still renders every known option and selects correctly with no console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-describing profile picker for `profile_name` in the configuration interface, including descriptive help for each option.
  * Introduces a dedicated “(none)” option to clear the selection and return to an unset state.

* **Bug Fixes**
  * Made profile loading resilient so missing, malformed, or failed profile data no longer breaks the UI.
  * Prevents duplicate/conflicting “(none)” entries and preserves the current dirty selection across rebuilds.

* **Tests**
  * Added coverage for profile name/description parsing and picker rendering, including degradation and “(none)” collision cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->