### PR TITLE
docs(pet-128): user-facing scanner + config pages, surfaced from About

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,13 +57,13 @@ class Scanner(Protocol):
                    session_id: str | None = None) -> ScanResult: ...
 ```
 
-Four backends: `MinimalScanner` (17 regex rules, zero deps, always ships), `LlmGuardScanner` (extras), `LlamaFirewallScanner` (extras), `PresidioScanner` (extras).
+Four backends: `MinimalScanner` (22 rules across 5 families, zero deps, always ships), `LlmGuardScanner` (extras), `LlamaFirewallScanner` (extras), `PresidioScanner` (extras).
 
 ### Pipeline Stages
 
 ```
 Input → Normalize (NFKC, zero-width, homoglyph, RTL)
-  → Syntactic pre-filter (17 rules, always runs)
+  → Syntactic pre-filter (22 rules, always runs)
   → Fan-out to N scanners (asyncio.gather)
   → Merge findings (dedup overlapping positions)
   → Frequency update → Escalation check
@@ -82,7 +82,7 @@ petasos/
 ├── pipeline.py          # Pipeline class — central orchestrator
 ├── config.py            # PetasosConfig dataclass
 ├── scanners/
-│   ├── minimal.py       # MinimalScanner (zero-dep, 17 regex rules)
+│   ├── minimal.py       # MinimalScanner (zero-dep, 22 rules across 5 families)
 │   ├── llm_guard.py     # LlmGuardScanner (extras: llm-guard)
 │   ├── llama_firewall.py # LlamaFirewallScanner (extras: llamafirewall)
 │   └── presidio.py      # PresidioScanner + anonymization (extras: presidio)

--- a/docs/specs/TODO/PET-128.test-output.txt
+++ b/docs/specs/TODO/PET-128.test-output.txt
@@ -1,0 +1,55 @@
+........................................................................ [  4%]
+........................................................................ [  8%]
+..................................................x..................... [ 12%]
+........................................................................ [ 16%]
+........................................................................ [ 20%]
+........................................................................ [ 25%]
+........................................................................ [ 29%]
+.............ssssssss................................................... [ 33%]
+........................................................................ [ 37%]
+........................................................................ [ 41%]
+........................................................................ [ 45%]
+........................................................................ [ 50%]
+........................................................................ [ 54%]
+.............................................ssss....................... [ 58%]
+........................................................................ [ 62%]
+..........sssssssssssssss.......................ssssssssss....ssss...... [ 66%]
+........................................................................ [ 70%]
+........................................................................ [ 75%]
+........................................................................ [ 79%]
+........................................................................ [ 83%]
+........................................................................ [ 87%]
+........................................................................ [ 91%]
+........................................................................ [ 96%]
+....................................................................     [100%]
+============================== warnings summary ===============================
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-128-worktree\petasos\console\server.py:315: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+1682 passed, 41 skipped, 1 deselected, 1 xfailed, 68 warnings in 35.40s
+=== ruff check . ===
+All checks passed!
+=== ruff format --check . ===
+119 files already formatted
+=== mypy --strict . ===
+Success: no issues found in 119 source files

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,0 +1,307 @@
+# Configuration guide
+
+This page walks every setting in the Petasos Config Editor, in the same groups
+and the same order the editor shows them. If you are reading the editor and the
+docs side by side, they line up one-to-one. Profiles are the "start here" bundle:
+pick one that matches your use case and you rarely need to touch anything else.
+
+> Verified against source at commit `770401e`. The section list, the field count,
+> and the set of documented fields are pinned to live source by
+> `tests/test_docs_usage_consistency.py`, so this page cannot silently fall out of
+> step with the editor.
+
+The editor shows 11 sections, in this render order:
+
+<!-- petasos-doc-assert: config_sections=profiles,anonymization,fail_mode,tool_guard,scanning,normalization,escalation,frequency,audit,alerting,session -->
+
+1. Profiles
+2. PII / Anonymization
+3. Fail Mode
+4. Tool Call Guard
+5. Scanning
+6. Normalization
+7. Escalation Tiers
+8. Frequency Tracking
+9. Audit
+10. Alerting
+11. Session Management
+
+Together these cover 59 editable fields.
+
+<!-- petasos-doc-assert: config_field_count=59 -->
+
+Each field below is named exactly as it appears in config files and the editor.
+Where a field has a safe range or a fixed set of choices, it is given.
+
+## 1. Profiles
+
+*Pick a ready-made settings bundle for your use case (coding agent, customer
+service, and so on) instead of tuning every knob by hand. Start here if you are
+not sure what to change.*
+
+- `profile_name`: selects a preset tuning bundle. The five built-ins are
+  `general`, `customer_service`, `code_generation`, `research`, and `admin`, each
+  adjusting rule sensitivity, severity handling, and tool permissions. Leave it
+  unset to run with no profile.
+
+## 2. PII / Anonymization
+
+*Mask personal details (names, emails, card numbers) the scanners find so they do
+not pass through in the clear. Leave on if your agent handles real user data.*
+
+- `anonymize`: after scanning, replace any personal information found with
+  placeholders so it does not travel further. Off by default; turn it on when
+  conversations may contain other people's data.
+- `pii_entities`: narrow which detected types are actually hidden at the
+  anonymize step (for example, list only `EMAIL_ADDRESS` to redact emails and
+  leave the rest untouched). Empty means anonymize every detected type. This
+  filters only what is hidden, not what the scanner looks for.
+- `redaction_mode`: how a found value is hidden. One of `redact` (a typed
+  placeholder), `replace` (numbered placeholders), `hash` (a non-reversible
+  scrambled code, useful for matching records without revealing them), or `mask`
+  (hide all but the last few characters).
+- `hash_key`: the secret key used when `redaction_mode` is `hash`. Required for
+  hash mode, ignored otherwise, and never displayed in full.
+
+## 3. Fail Mode
+
+*Choose what happens to a message when a scanner crashes or times out: block it,
+let it through, or block only on a hard failure. The safe default blocks on
+failure.*
+
+- `fail_mode`: one of `open` (let content pass when a scanner breaks), `degraded`
+  (the default: block on partial or total scanner failure, while the always-on
+  syntactic check still runs), or `closed` (strictest: also block immediately
+  when the syntactic check finds something critical, without waiting for the
+  other scanners).
+
+## 4. Tool Call Guard
+
+*Check the tools your agent tries to call and cap how fast it can spawn
+sub-agents, before any of it runs. Tighten this for agents that touch the file
+system or the shell.*
+
+- `tool_guard_enabled`: check each tool call before it runs, scanning its inputs
+  for smuggled instructions and blocking calls from escalated conversations. Off
+  lets all tool calls through unchecked.
+- `subagent_lineage_enabled`: make a spawned helper sub-agent start at least as
+  restricted as the conversation that launched it, so a flagged session cannot
+  reset its record by handing work to a fresh child. Needs the host to report
+  sub-agent start and stop; if it does not, this quietly does nothing.
+- `delegate_fanout_enabled`: cap how fast one conversation can spin up helper
+  sub-agents, so a hostile session cannot flood the system with delegated tasks.
+  The cap tightens automatically as the session's risk rises.
+- `lineage_max_depth`: how many levels up the family tree to look when deciding a
+  sub-agent's inherited restriction level (minimum 1). The default leaves
+  headroom while keeping the lookup fast.
+- `lineage_max_edges`: how many active sub-agent relationships to remember at once
+  (minimum 1). When full, the oldest link is dropped, a ceiling so the
+  bookkeeping cannot grow without bound.
+- `lineage_edge_ttl_seconds`: how long to keep a sub-agent's link to its parent
+  before treating it as stale (minimum 0.01). Set it comfortably longer than a
+  realistic helper's lifetime.
+- `delegate_max_fanout_per_window`: how many helper sub-agents a calm conversation
+  may launch within the window below (minimum 1). The allowance halves once the
+  session looks risky and drops to one when flagged.
+- `delegate_fanout_window_seconds`: the time span the spawn allowance is measured
+  over (minimum 0.01). A shorter window forgives bursts sooner; a longer one
+  keeps a tighter lid on sustained spawning.
+- `delegate_tool_names`: the tool names that count as launching a helper
+  sub-agent (by default just `delegate_task`). Add your host's own delegation
+  tool names if they differ.
+- `egress_sink_tools`: the tools that send content out of the machine (email,
+  social posts, external web requests, webhooks, clipboard). Detected personal
+  data is blocked only when an agent tries to send it through one of these;
+  writing to local files or the terminal is never blocked for personal data. Set
+  these to your host's actual outbound tool names.
+
+## 5. Scanning
+
+*The core scan settings: which direction to scan (incoming, outgoing, or both)
+and how widely to look for personal data. Also sets per-scanner time limits and
+when to stop calling one that keeps failing.*
+
+- `direction`: the default text flow. `inbound` is messages from the user to the
+  agent; `outbound` is the agent's replies going out. Some scanners apply
+  different checks per direction.
+- `scanner_timeout_seconds`: how long to wait for a slow scanner before giving up
+  on it for that scan (0.01 to 60 seconds). A timeout counts as a scanner
+  failure, so the fail mode setting decides what happens next.
+- `scanner_circuit_breaker_threshold`: how many consecutive timeouts before a
+  scanner is temporarily benched (minimum 1). Any scan that does not time out
+  resets the count.
+- `scanner_circuit_breaker_cooldown_seconds`: how long a benched scanner sits out
+  before another chance (minimum 0.01). While benched it is skipped instantly but
+  still counts as failed, so the fail mode decides whether content is blocked
+  meanwhile; the zero-dependency syntactic check keeps running regardless.
+- `presidio_entities`: replace the PII scanner's detected entity list wholesale.
+  Leave unset to use the curated default (the security-relevant types), which
+  deliberately omits noisier types that misfire on file paths and code.
+- `presidio_entities_extra`: add entity types back on top of the curated default
+  without replacing it (for example, add `URL` to detect web addresses again).
+  Entries are uppercased automatically.
+- `presidio_score_threshold`: how confident the PII scanner must be before it
+  reports a match (0 to 1). Higher means fewer false alarms but more misses;
+  setting it to 0 reports every candidate and brings back the noise the curated
+  default is meant to remove.
+
+## 6. Normalization
+
+*Undo tricks that hide malicious text from the scanners (look-alike letters,
+invisible characters, leetspeak, encoded blobs) before anything is checked. Most
+operators leave this on as-is.*
+
+- `normalize_nfkc`: rewrite stylized or alternate-form characters (such as
+  fullwidth letters) into plain text before scanning. Turning it off also
+  disables follow-up cleanup passes that depend on it.
+- `strip_zero_width`: remove invisible characters that can smuggle instructions
+  past the filters. Normal text looks identical with this on, so there is no
+  reason to turn it off in everyday use.
+- `map_homoglyphs`: convert look-alike letters (such as a Cyrillic character
+  posing as a Latin one) to their plain equivalents. Turning it off makes scans
+  slightly faster but easier to evade.
+- `detect_rtl_override`: flag characters that reverse the reading direction of
+  text, a trick that disguises content by displaying it backwards. This only
+  raises the flag; the actual removal is handled by `strip_zero_width`.
+- `fold_leet`: add a decoded copy of leetspeak text (such as "1gn0r3" for
+  "ignore") for the injection rules to check; the original is never altered. Note
+  that the built-in syntactic scanner always decodes leetspeak regardless of this
+  toggle, which affects only direct `normalize()` callers.
+- `decode_encoded_payloads`: decode and rescan base64, hex, and ROT13 blobs so a
+  wrapped injection is caught at full severity instead of slipping through as a
+  low-priority flag. Unlike `fold_leet`, turning this off does disable the decode
+  stage inside the syntactic scanner, reopening the encoded-payload gap. Decoding
+  is bounded by size, count, and depth caps, so it adds no false positives on
+  ordinary encoded data.
+
+## 7. Escalation Tiers
+
+*As a conversation keeps misbehaving, these risk-score cutoffs ratchet
+enforcement up one tier at a time. Advanced: the built-in tiers are sensible
+defaults.*
+
+- `escalation_enabled`: whether scan results report the conversation's escalation
+  tier. Turning it off does not relax enforcement: sessions still terminate at
+  the top tier, the tool-call guard still blocks escalated conversations, and
+  tier alerts still fire.
+- `tier1_threshold`: risk score at which a conversation gets light extra scrutiny;
+  tool calls still work but warnings are attached (minimum 0). Lower is stricter;
+  must stay below `tier2_threshold`.
+- `tier2_threshold`: risk score at which tool calls are blocked except those
+  explicitly exempted (minimum 0). Lower is stricter; must sit between
+  `tier1_threshold` and `tier3_threshold`.
+- `tier3_threshold`: risk score at which the conversation is shut down and stays
+  terminated. It can never take effect below the built-in floor of 30, which is
+  why its minimum is 30 and why Tier 3 cannot be disabled.
+
+## 8. Frequency Tracking
+
+*Tracks how risky each conversation looks over time, so repeated suspicious
+behavior adds up instead of being judged one message at a time. Advanced: the
+defaults are sensible.*
+
+- `frequency_enabled`: keep a running risk score per conversation. Turning it off
+  also stops the automatic escalation that depends on the score.
+- `frequency_half_life_seconds`: how quickly an idle conversation's risk score
+  fades; after this much quiet time the score halves (minimum 0.01). Higher means
+  suspicion is remembered longer.
+- `frequency_weights`: fine-tune how much each kind of finding adds to the score
+  (for example, injection attempts counting more than odd encodings). Leave unset
+  for the built-in weights; an explicitly empty table instead stops findings from
+  adding to the score at all.
+- `rolling_window_seconds`: the recent time span over which flagged scans are
+  counted per conversation (minimum 0.01). A bigger window catches slow, patient
+  misbehavior.
+- `rolling_threshold`: how many flagged scans within the window mark a
+  conversation for extra scrutiny (minimum 1), even when each finding was minor.
+
+## 9. Audit
+
+*Decide whether each scan is recorded for later review, and how much detail to
+keep. Turn the detail up when you need an investigation trail.*
+
+- `audit_enabled`: record an audit event for every scan. Turning it off disables
+  the activity feed and anything built on audit events.
+- `audit_verbosity`: how much detail each record carries. One of `minimal` (the
+  verdict and a finding count), `standard` (adds findings and session-risk
+  detail), or `verbose` (adds full scanner output and a settings snapshot).
+
+## 10. Alerting
+
+*Raise a warning when something looks off (rapid-fire scanning, a spike in
+personal data, repeated blocks) without flooding you with duplicates. Advanced:
+the defaults cover the common cases.*
+
+- `alert_enabled`: watch scan results for suspicious patterns and fire warnings.
+  Off silences all alerts.
+- `alert_cooldown_seconds`: minimum quiet time before the same alert can fire
+  again for the same conversation (minimum 0.01). Critical alerts ignore this.
+- `alert_per_minute_cap`: the most alerts a single rule may fire per minute across
+  all conversations (minimum 1). Critical alerts have their own separate cap.
+- `alert_per_hour_cap`: the long-term per-hour ceiling behind the per-minute cap
+  (minimum 1).
+- `alert_critical_per_minute_cap`: a separate per-minute allowance just for
+  critical alerts, which skip the normal limits so emergencies always get through
+  (minimum 1).
+- `alert_high_severity_threshold`: the minimum seriousness a finding needs to
+  trigger the high-severity alert. One of `critical`, `high`, `medium`, `low`, or
+  `info`; lower fires for almost everything.
+- `alert_rapid_fire_count`: how many scans from one conversation inside the window
+  count as a rapid-fire burst (minimum 1). Lower is more sensitive.
+- `alert_rapid_fire_window_seconds`: the time span over which one conversation's
+  scans are counted for rapid-fire detection (minimum 0.01).
+- `alert_cross_session_burst_count`: how many different conversations must show
+  findings within the window before the coordinated-burst alert fires
+  (minimum 1).
+- `alert_cross_session_burst_window_seconds`: the time span used to spot findings
+  across multiple conversations at once (minimum 0.01).
+- `alert_pii_volume_threshold`: the total pieces of personal data detected within
+  the window, across all conversations, that count as a leak spike (minimum 1).
+- `alert_pii_volume_window_seconds`: the time span over which detected personal
+  data is totalled for the leak-spike alert (minimum 0.01).
+- `alert_ring_buffer_capacity`: how many recent events the alert rules keep in
+  memory for their counting (minimum 1). The burst thresholds above must fit
+  within it.
+- `alert_per_session_contribution_cap`: the most alerts any single conversation
+  may contribute per rule per minute (minimum 1), so one noisy session cannot use
+  up the shared allowance. Must not exceed `alert_per_minute_cap`.
+- `alert_max_session_contribution_entries`: a memory-safety limit on how many
+  conversation-and-rule combinations the alert fairness tracking follows at once
+  (minimum 1). When full, alerts from brand-new combinations are dropped until
+  stale entries expire.
+
+## 11. Session Management
+
+*Caps on how many conversations are tracked at once, how long each is remembered,
+and how fast new ones may start. Advanced: raise these only for high-traffic
+deployments.*
+
+- `max_sessions`: the most conversations tracked at once (minimum 1). When full,
+  the oldest finished-with sessions are dropped first; during a flood of new
+  conversations, new ones may temporarily go untracked instead.
+- `session_ttl_seconds`: how long an idle conversation stays tracked before
+  cleanup (minimum 0.01; default one hour). Cleanup happens opportunistically
+  during later activity, not on an exact timer.
+- `max_new_sessions_per_minute`: caps how many brand-new conversations may start
+  per minute (minimum 1), but only once the session store is already full.
+  Protects against floods of throwaway sessions.
+- `max_terminated_tombstones`: how many terminated conversations to remember by ID
+  after cleanup (minimum 1), so a banned session cannot sneak back in under the
+  same name.
+
+## Advanced: not in the Config Editor
+
+One field of the runtime configuration is deliberately not exposed in the editor,
+so do not conclude this page is incomplete if you cannot find it:
+
+- `session_secret`: the secret used to bind and verify session identity. It is
+  excluded from the editor by design (it is the single field in the difference
+  between the full runtime config and the editor's field set) and is set out of
+  band, not through the UI.
+
+---
+
+<!-- Drift-guard index: the full set of editor-surfaced field names documented
+     above. Kept in sync with petasos.console._config_meta._FIELD_META by
+     tests/test_docs_usage_consistency.py. -->
+<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,detect_rtl_override,fold_leet,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones -->

--- a/docs/usage/scanners.md
+++ b/docs/usage/scanners.md
@@ -1,0 +1,191 @@
+# Scanner reference
+
+Petasos inspects content with a set of pluggable *scanners*. Each one looks at
+text and returns findings; the pipeline merges those findings, tracks them per
+session, and decides what to do. This page explains what each scanner detects,
+how it works, when it runs, and what you get by installing its optional extra.
+
+Detection ships free and keyless. The zero-dependency syntactic scanner is
+always present. The three machine-learning backends are *dependency-gated*: they
+are normal pip extras you opt into (`pip install petasos[...]`), not paid or
+licensed tiers. If you do not install an extra, that scanner is simply absent and
+the rest of the pipeline runs without it.
+
+> Verified against source at commit `770401e`. Every count and list on this page
+> is pinned to live source by `tests/test_docs_usage_consistency.py`, so the
+> numbers below cannot drift away from the code without a test going red.
+
+## Where each scanner runs
+
+The pipeline processes one piece of text through a fixed order of stages. The
+"when it runs" line in each scanner section below refers to this order:
+
+1. **Normalize**: NFKC folding, zero-width stripping, homoglyph mapping, and
+   right-to-left override handling, so look-alike and hidden-character tricks are
+   undone before anything is checked.
+2. **Syntactic pre-filter**: the always-on `MinimalScanner`, zero dependencies,
+   runs on every scan.
+3. **Fan-out to the configured machine-learning scanners** (`LlmGuardScanner`,
+   `LlamaFirewallScanner`, `PresidioScanner`), gathered concurrently.
+4. **Merge and dedup** the findings from all scanners.
+5. **Frequency update**, then **escalation check** against the session's running
+   risk score.
+6. **Anonymize** (Presidio), if personal data was found and anonymization is on.
+7. **Audit**, then **alerting**.
+
+A scanner that is not installed is skipped at the fan-out stage. The syntactic
+pre-filter at stage 2 always runs regardless of which extras are present.
+
+## MinimalScanner (always ships, zero dependencies)
+
+`MinimalScanner` is the syntactic pre-filter. It needs no machine-learning
+dependencies and runs on every scan as stage 2 above, holding to a sub-5ms
+budget so it can sit in front of everything else.
+
+**What it detects.** A taxonomy of 22 rules grouped into 5 families:
+
+<!-- petasos-doc-assert: rule_taxonomy_total=22 -->
+
+- **injection** (8 rules): prompt-injection phrasings such as "ignore all
+  previous instructions", instruction delimiters, and system-prompt overrides.
+- **role-switch** (2 rules): attempts to reassign the assistant's role or claim
+  new capabilities.
+- **structural** (3 rules): oversized payloads, excessive nesting depth, and raw
+  binary content.
+- **encoding** (4 rules): base64-in-text, invisible characters, homoglyph
+  substitution, and right-to-left override abuse.
+- **command** (5 rules): shell-command patterns such as pipe-to-shell,
+  fetch-and-execute, decode-and-execute, and destructive recursive deletes.
+
+<!-- petasos-doc-assert: rule_family.injection=8 rule_family.role_switch=2 rule_family.structural=3 rule_family.encoding=4 rule_family.command=5 -->
+
+**How it works.**
+
+- *Anchor gates.* Before running the full injection or command batteries, the
+  scanner checks a cheap necessary-condition anchor (a small substring superset
+  of every pattern in the family). If the anchor is absent the whole battery is
+  skipped, which is what keeps the syntactic pass inside its sub-5ms budget on
+  ordinary text.
+- *Decode-and-rescan.* base64, hex, and ROT13 blobs are decoded and the
+  plaintext is re-run through the injection patterns. An "ignore all previous
+  instructions" wrapped in base64 is therefore caught at full injection severity
+  instead of slipping through as a low-priority encoding flag. Decoding is
+  bounded by size, count, and depth caps so it cannot be turned into a denial of
+  service, and it only ever raises a flag on a real injection in the decoded
+  text.
+- *Suppressibility.* A profile can suppress the **command** and **encoding**
+  families when they are noisy for its use case (for example, the
+  `code_generation` profile, which legitimately handles shell snippets). The
+  **injection**, **role-switch**, and **structural** families are hardcoded as
+  unsuppressible: no profile can switch them off.
+
+**When it runs.** Stage 2, on every scan, always.
+
+**What an extra adds.** Nothing. `MinimalScanner` is part of the base install
+(`pip install petasos`) and has no optional dependency.
+
+## LlmGuardScanner (extra: `llm-guard`)
+
+`LlmGuardScanner` wraps the [LLM Guard](https://github.com/protectai/llm-guard)
+library to add model-backed prompt-injection and content detection on top of the
+syntactic rules.
+
+**What it detects.** LLM Guard's scanner suite (model-scored prompt-injection and
+related content checks), contributing its findings to the merge stage.
+
+**How it works.** The backend is absent unless you install the extra
+(`pip install petasos[llm-guard]`); until then the scanner reports itself
+unavailable rather than failing a scan. The underlying models load lazily on
+first use, with a bounded retry budget (one attempt plus two retries) behind a
+stdio and weakref shield so that structlog's weakref registration cannot crash
+hosts with slots-only stdio (Hermes Desktop is the motivating case).
+
+The scanner distinguishes two unavailable states for operators: **absent** (the
+`llm-guard` extra is not installed) versus **load-failed** (the extra is
+installed but the model could not be loaded). The first is a packaging choice;
+the second is something to investigate.
+
+**When it runs.** Stage 3, in the machine-learning fan-out, only when installed
+and enabled.
+
+**What the extra adds.** `pip install petasos[llm-guard]` installs LLM Guard and
+its model dependencies and makes this scanner available.
+
+## LlamaFirewallScanner (extra: `llamafirewall`)
+
+`LlamaFirewallScanner` wraps Meta's
+[LlamaFirewall](https://github.com/meta-llama/PurpleLlama) and exposes three
+named components.
+
+**What it detects.** Three components, each mapped to a finding category and a
+severity:
+
+<!-- petasos-doc-assert: llamafirewall_components=prompt_guard,alignment_check,code_shield -->
+
+- `prompt_guard`: prompt-injection detection, category `injection`, severity
+  HIGH.
+- `alignment_check`: agent-alignment auditing, category `alignment`, severity
+  HIGH.
+- `code_shield`: unsafe-code detection, category `unsafe_code`, severity MEDIUM.
+
+**How it works.** The live path may need a Hugging Face token and model
+prerequisites to download the underlying models. The first scan triggers a model
+load and reports a short "warming up" status while that happens. A stdin guard
+intercepts the interactive prompt some model loaders raise in a non-interactive
+host, turning it into an actionable message instead of a hang.
+
+**When it runs.** Stage 3, in the machine-learning fan-out, only when installed
+and enabled.
+
+**What the extra adds.** `pip install petasos[llamafirewall]` installs
+LlamaFirewall and makes the three components above available.
+
+## PresidioScanner (extra: `presidio`)
+
+`PresidioScanner` wraps [Microsoft Presidio](https://github.com/microsoft/presidio)
+for personally identifiable information (PII) detection, and it is also the
+backend for the anonymization stage.
+
+**What it detects.** A curated default band of 10 entity types, chosen to be the
+security-relevant CRITICAL and HIGH classes:
+
+<!-- petasos-doc-assert: presidio_default=CREDIT_CARD,IBAN_CODE,US_SSN,US_BANK_NUMBER,CRYPTO,EMAIL_ADDRESS,PHONE_NUMBER,US_DRIVER_LICENSE,US_PASSPORT,IP_ADDRESS -->
+
+- CRITICAL: `CREDIT_CARD`, `IBAN_CODE`, `US_SSN`, `US_BANK_NUMBER`, `CRYPTO`.
+- HIGH: `EMAIL_ADDRESS`, `PHONE_NUMBER`, `US_DRIVER_LICENSE`, `US_PASSPORT`,
+  `IP_ADDRESS`.
+
+Five further entity types are **opt-in by design**, not part of the default:
+
+<!-- petasos-doc-assert: presidio_opt_in=PERSON,LOCATION,DATE_TIME,NRP,URL -->
+
+`PERSON`, `LOCATION`, `DATE_TIME`, `NRP`, and `URL` are left out of the default
+because they misfire on technical text: file paths, code, version numbers, and
+hostnames trip them constantly. You can add any of them back when your data
+warrants it, but the default set deliberately avoids that noise. The opt-in set
+is never presented as the default.
+
+**How it works.** Detection is tuned by a small group of config fields, and a
+separate anonymization stage acts on what is found:
+
+- `presidio_entities`: replace the detected entity list wholesale.
+- `presidio_entities_extra`: add entity types back on top of the curated default
+  (for example, opt `URL` back in) without discarding the rest.
+- `presidio_score_threshold`: the confidence floor a match must clear before it
+  is reported.
+- `anonymize`: whether the anonymization stage runs at all.
+- `pii_entities`: narrow which detected types are actually hidden at the
+  anonymize step (detection scope is separate).
+- `redaction_mode`: how a hidden value is rewritten (redact, replace, hash, or
+  mask).
+- `hash_key`: the secret key used when `redaction_mode` is `hash`.
+
+See [the configuration guide](configuration.md) for the full walkthrough of these
+fields.
+
+**When it runs.** Detection happens at stage 3 (the fan-out) when installed and
+enabled; anonymization happens later, at stage 6, only when PII was found and
+`anonymize` is on.
+
+**What the extra adds.** `pip install petasos[presidio]` installs Presidio and
+its language model and makes both PII detection and anonymization available.

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1715,7 +1715,9 @@
       icon: "flow", title: "Links",
       content: Pet.h("div", {},
         Pet.h("a", { href: "https://github.com/Vigil-Harbor/Petasos", target: "_blank", rel: "noopener", className: "link", style: { display: "block", padding: "6px 0" } }, "Repository"),
-        Pet.h("a", { href: "https://github.com/Vigil-Harbor/Petasos/issues", target: "_blank", rel: "noopener", className: "link", style: { display: "block", padding: "6px 0" } }, "Issue Tracker")
+        Pet.h("a", { href: "https://github.com/Vigil-Harbor/Petasos/issues", target: "_blank", rel: "noopener", className: "link", style: { display: "block", padding: "6px 0" } }, "Issue Tracker"),
+        Pet.h("a", { href: "https://github.com/Vigil-Harbor/Petasos/blob/master/docs/usage/scanners.md", target: "_blank", rel: "noopener", className: "link", style: { display: "block", padding: "6px 0" } }, "Scanner Reference"),
+        Pet.h("a", { href: "https://github.com/Vigil-Harbor/Petasos/blob/master/docs/usage/configuration.md", target: "_blank", rel: "noopener", className: "link", style: { display: "block", padding: "6px 0" } }, "Configuration Guide")
       ),
     }));
 

--- a/tests/test_docs_usage_consistency.py
+++ b/tests/test_docs_usage_consistency.py
@@ -1,0 +1,257 @@
+"""Doc/source consistency tests for the user-facing usage pages (PET-128).
+
+The pages under ``docs/usage/`` state load-bearing numbers and lists in human
+prose (for example "22 rules across 5 families"). Prose drifts silently from the
+code it describes -- the "17 rules" stale-count class of bug. To stop that, each
+page embeds machine-readable markers next to the prose. The markers are HTML
+comments, invisible in rendered Markdown and on GitHub::
+
+    <!-- petasos-doc-assert: rule_taxonomy_total=22 -->
+    <!-- petasos-doc-assert: presidio_opt_in=PERSON,LOCATION,DATE_TIME,NRP,URL -->
+
+``_parse_doc_asserts`` parses the markers and fails loudly (duplicate key, empty
+value, missing required key all raise). Each test then compares the parsed values
+to the imported source using the comparison mode pinned for that key: integer
+equality, an ordered list, or set membership. The reviewer confirms prose ==
+marker once at authoring; these tests guarantee marker == source forever.
+
+All imports are base-safe module-level constants (no ML extras), so this file
+runs in the default ``ci.yml`` lane (PET-106: ``console`` is not a scanner, so no
+new extras lane is needed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from petasos.console._config_meta import _FIELD_META, _SECTION_REGISTRY
+from petasos.scanners.llama_firewall import _COMPONENT_TAXONOMY
+from petasos.scanners.minimal import (
+    _COMMAND_RULE_IDS,
+    _ENCODING_RULE_IDS,
+    _INJECTION_RULE_IDS,
+    _ROLE_SWITCH_RULE_IDS,
+    _STRUCTURAL_RULE_IDS,
+    RULE_TAXONOMY,
+)
+from petasos.scanners.presidio import (
+    DEFAULT_PRESIDIO_ENTITIES,
+    NOISY_OPT_IN_ENTITIES,
+)
+
+# Single source of truth for the marker sentinel. The Markdown pages MUST use
+# this identical literal; the parser keys off it.
+_MARKER_PREFIX = "petasos-doc-assert:"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCANNERS_DOC = _REPO_ROOT / "docs" / "usage" / "scanners.md"
+_CONFIG_DOC = _REPO_ROOT / "docs" / "usage" / "configuration.md"
+_CONSOLE_JS = _REPO_ROOT / "petasos" / "console" / "static" / "petasos.js"
+
+
+def _parse_doc_asserts(
+    path: Path,
+    *,
+    required: frozenset[str],
+    int_keys: frozenset[str] = frozenset(),
+) -> dict[str, str]:
+    """Parse ``petasos-doc-assert`` markers from ``path`` into a flat dict.
+
+    A marker line is ``<prefix> <pair> [<pair> ...]`` where each ``<pair>`` is
+    ``key=value``. Tokens split on whitespace, then on the first ``=``. Multiple
+    pairs per line are allowed (the ``rule_family.*`` marker); a value containing
+    commas is a CSV. Because tokens split on whitespace, CSV values can never
+    contain spaces.
+
+    Fails loudly, never silently:
+      * a token with no ``=`` raises;
+      * an empty value, or an empty CSV element, raises;
+      * a key in ``int_keys`` whose value is not a base-10 integer raises;
+      * a duplicate key anywhere in the file raises (drift cannot hide behind a
+        second copy);
+      * any key in ``required`` absent from the parsed markers raises, naming the
+        missing key -- so a deleted marker reds its test rather than yielding a
+        silent zero-assertion pass.
+    """
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if _MARKER_PREFIX not in raw_line:
+            continue
+        # Take the text after the sentinel, then drop the HTML-comment close.
+        segment = raw_line.split(_MARKER_PREFIX, 1)[1].split("-->", 1)[0].strip()
+        for token in segment.split():
+            if "=" not in token:
+                raise ValueError(
+                    f"malformed doc-assert token {token!r} in {path.name} (expected key=value)"
+                )
+            key, value = token.split("=", 1)
+            if not value:
+                raise ValueError(f"empty value for doc-assert key {key!r} in {path.name}")
+            if "," in value and any(part == "" for part in value.split(",")):
+                raise ValueError(f"empty CSV element in doc-assert key {key!r} in {path.name}")
+            if key in int_keys and not _is_int(value):
+                raise ValueError(
+                    f"doc-assert key {key!r} expected an integer, got {value!r} in {path.name}"
+                )
+            if key in parsed:
+                raise ValueError(f"duplicate doc-assert key {key!r} in {path.name}")
+            parsed[key] = value
+    missing = required - parsed.keys()
+    if missing:
+        raise ValueError(f"missing required doc-assert key(s) {sorted(missing)} in {path.name}")
+    return parsed
+
+
+def _is_int(value: str) -> bool:
+    try:
+        int(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _csv(parsed: dict[str, str], key: str) -> list[str]:
+    return parsed[key].split(",")
+
+
+# The six marker keys the rule-count test requires, bridged to their source
+# frozensets. The bridge is explicit (not inferred from the keys present in the
+# file) so a deleted marker is caught by the required-key contract, and so the
+# marker key ``role_switch`` maps unambiguously to ``_ROLE_SWITCH_RULE_IDS``.
+_RULE_FAMILY_SOURCE: dict[str, frozenset[str]] = {
+    "rule_family.injection": _INJECTION_RULE_IDS,
+    "rule_family.role_switch": _ROLE_SWITCH_RULE_IDS,
+    "rule_family.structural": _STRUCTURAL_RULE_IDS,
+    "rule_family.encoding": _ENCODING_RULE_IDS,
+    "rule_family.command": _COMMAND_RULE_IDS,
+}
+
+
+def test_docs_scanner_rule_count_matches_taxonomy() -> None:
+    # Regression for PET-128: scanners.md must pin the real MinimalScanner
+    # taxonomy. Adding/removing a rule without updating the doc reds this.
+    required = frozenset({"rule_taxonomy_total", *_RULE_FAMILY_SOURCE})
+    parsed = _parse_doc_asserts(_SCANNERS_DOC, required=required, int_keys=required)
+    assert int(parsed["rule_taxonomy_total"]) == len(RULE_TAXONOMY)
+    for marker_key, source_ids in _RULE_FAMILY_SOURCE.items():
+        assert int(parsed[marker_key]) == len(source_ids), marker_key
+    # The five families partition the taxonomy: their lengths sum to the total.
+    # So moving a rule between families reds a per-family marker even though the
+    # total is unchanged.
+    assert sum(len(ids) for ids in _RULE_FAMILY_SOURCE.values()) == len(RULE_TAXONOMY)
+
+
+def test_docs_llamafirewall_components_match_source() -> None:
+    # Regression for PET-128: the three named LlamaFirewall components.
+    parsed = _parse_doc_asserts(_SCANNERS_DOC, required=frozenset({"llamafirewall_components"}))
+    assert set(_csv(parsed, "llamafirewall_components")) == set(_COMPONENT_TAXONOMY.keys())
+
+
+def test_docs_presidio_default_set_matches_source() -> None:
+    # Regression for PET-128: the Presidio default vs opt-in entity bands.
+    # Compared as sets; the source tuples' order is not a documented contract,
+    # so a benign source reorder must not red this test.
+    parsed = _parse_doc_asserts(
+        _SCANNERS_DOC,
+        required=frozenset({"presidio_default", "presidio_opt_in"}),
+    )
+    assert set(_csv(parsed, "presidio_default")) == set(DEFAULT_PRESIDIO_ENTITIES)
+    assert set(_csv(parsed, "presidio_opt_in")) == set(NOISY_OPT_IN_ENTITIES)
+
+
+def test_docs_config_sections_match_meta() -> None:
+    # Regression for PET-128: configuration.md must match the editor's sections
+    # (in render order) and document every editor-surfaced field.
+    parsed = _parse_doc_asserts(
+        _CONFIG_DOC,
+        required=frozenset({"config_sections", "config_field_count", "config_fields"}),
+        int_keys=frozenset({"config_field_count"}),
+    )
+
+    registry_order = [section.key for section in _SECTION_REGISTRY]
+
+    # (a) section list, in render order (tuple position is the contract).
+    assert _csv(parsed, "config_sections") == registry_order
+
+    # (b) the human-facing field count equals the live field total.
+    assert int(parsed["config_field_count"]) == len(_FIELD_META)
+
+    # (c) every field's `section` value has a registry entry. Closes the gap
+    # where a field could carry a section value with no registry entry (the
+    # "unknown" sentinel) yet still count toward the total.
+    assert {meta["section"] for meta in _FIELD_META.values()} == set(registry_order)
+
+    # (d) documented field set matches the live field set, bidirectionally, over
+    # the author-maintained config_fields marker (not an open-ended scan of every
+    # backtick span, which would false-positive on profile/section/enum spans).
+    documented = _csv(parsed, "config_fields")
+    assert set(documented) == set(_FIELD_META)
+    assert int(parsed["config_field_count"]) == len(documented)
+
+    # Forward prose coverage: each documented field appears as a backtick-
+    # delimited token in the prose (marker lines excluded). Backtick delimiting
+    # is required because `presidio_entities` is a substring of
+    # `presidio_entities_extra`; a bare substring match would let the longer
+    # field satisfy the shorter field's check.
+    prose = "\n".join(
+        line
+        for line in _CONFIG_DOC.read_text(encoding="utf-8").splitlines()
+        if _MARKER_PREFIX not in line
+    )
+    for name in documented:
+        assert f"`{name}`" in prose, name
+
+
+def test_docs_links_present_in_console_js() -> None:
+    # Regression for PET-128: the About tab links both usage pages. String pin
+    # only (no DOM/JS execution); guards the surfacing edit against silent loss.
+    js = _CONSOLE_JS.read_text(encoding="utf-8")
+    assert "docs/usage/scanners.md" in js
+    assert "docs/usage/configuration.md" in js
+
+
+# --- Parser fail-loud contract (the silent-drift guard itself) --------------
+# These exercise the three drift shapes the suite must catch beyond value flips
+# (which the source-comparison tests above catch structurally): a deleted marker
+# (missing required key) and a duplicated marker key, plus empty/shape guards.
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    doc = tmp_path / "fixture.md"
+    doc.write_text(body, encoding="utf-8")
+    return doc
+
+
+def test_parser_raises_on_duplicate_key(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "<!-- petasos-doc-assert: k=1 -->\n<!-- petasos-doc-assert: k=2 -->\n",
+    )
+    with pytest.raises(ValueError, match="duplicate doc-assert key"):
+        _parse_doc_asserts(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_missing_required_key(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: present=1 -->\n")
+    with pytest.raises(ValueError, match="missing required doc-assert key"):
+        _parse_doc_asserts(doc, required=frozenset({"absent"}))
+
+
+def test_parser_raises_on_empty_value(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: k= -->\n")
+    with pytest.raises(ValueError, match="empty value"):
+        _parse_doc_asserts(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_empty_csv_element(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: k=a,,b -->\n")
+    with pytest.raises(ValueError, match="empty CSV element"):
+        _parse_doc_asserts(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_non_int_where_int_expected(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: n=abc -->\n")
+    with pytest.raises(ValueError, match="expected an integer"):
+        _parse_doc_asserts(doc, required=frozenset({"n"}), int_keys=frozenset({"n"}))


### PR DESCRIPTION
## Summary
- Adds two operator-facing usage pages under `docs/usage/` and links them from the Console About tab Links panel.
- `scanners.md` is a per-backend breakdown (Minimal, LLM Guard, LlamaFirewall, Presidio) plus pipeline placement; `configuration.md` walks all 11 Config Editor sections in render order, covering every one of the 59 editor-surfaced fields, with a `session_secret` "not in the editor" appendix.
- A new ML-free doc/source consistency suite pins every load-bearing number and list to live source, so the "17 rules" class of silent drift cannot recur. Companion fix corrects three stale "17 rules" references in `CLAUDE.md`.

## Drift-guard mechanism
Each page embeds machine-readable markers (`<!-- petasos-doc-assert: key=value -->`, invisible in rendered Markdown) next to the prose that states the same value. `_parse_doc_asserts` fails loudly on a duplicate key, empty value, or missing required key. Each test then compares the parsed marker to the imported source using a comparison mode pinned per key: integer equality (rule counts, field count), ordered list (`config_sections` render order), or set membership (entity bands, components, field set). Reviewer confirms prose == marker once; the tests guarantee marker == source forever.

## Files changed

| File | Change |
|------|--------|
| `docs/usage/scanners.md` | New: scanner breakdown + pipeline placement + 22-rule/5-family taxonomy markers |
| `docs/usage/configuration.md` | New: 11-section config explainer, all 59 fields, `session_secret` appendix + config markers |
| `tests/test_docs_usage_consistency.py` | New: 4 core consistency tests + fail-loud parser + 5 parser-contract tests + JS link pin |
| `petasos/console/static/petasos.js` | Adds two `<a>` link nodes (Scanner Reference, Configuration Guide) to the About Links panel |
| `CLAUDE.md` | Corrects three stale "17 rules" references to "22 rules across 5 families" (D-DRIFT-1) |
| `docs/specs/TODO/PET-128.test-output.txt` | Test-gate evidence capture |

## Test plan
- [x] `C:\python310\python.exe -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 1682 passed, 41 skipped, 1 deselected, 1 xfailed (full output: `docs/specs/TODO/PET-128.test-output.txt`)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 119 files already formatted
- [x] `mypy --strict .` — no issues in 119 source files
- [x] Drift shapes verified: value flip reds its test; deleted marker reds via the required-key contract; duplicate marker key raises in the parser
- [x] No em dashes in either page (or in the CLAUDE.md / JS edits)

Note: `test_default_ignorable_rejected` is deselected because it fails pre-existingly on this machine's Python 3.10.6 (Unicode 13 vs expected 14), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive scanner reference guide explaining each scanner's capabilities, detection methods, and configuration behavior.
  * Added complete configuration guide documenting all editable settings across configuration sections.

* **New Features**
  * Added direct links to scanner reference and configuration guide within the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->