### PR TITLE
feat(pet-126): hot-apply config edits to the live session

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -22,10 +22,13 @@ import os
 import threading
 import time
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from petasos._types import Severity  # PET-112: dep-light (enum + dataclasses, no ML imports)
 from petasos.normalize import canonicalize_tool_name  # PET-118: dep-light (re + unicodedata)
+
+if TYPE_CHECKING:
+    from petasos import PetasosConfig
 
 logger = logging.getLogger("petasos.plugin")
 
@@ -219,7 +222,7 @@ def _load_config() -> dict[str, Any]:
     return section
 
 
-def _build_config_from_section(section: dict[str, Any]):
+def _build_config_from_section(section: dict[str, Any]) -> PetasosConfig:
     """Build a validated PetasosConfig from a raw petasos: section.
 
     Applies the SAME env overlay as boot (PET-126 Decision 10): injects
@@ -647,7 +650,7 @@ def _log_reload_failure(detail: str) -> None:
     logger.warning("PETASOS_RELOAD_FAILED: %s; keeping last-good config", detail)
 
 
-async def _apply_reconfigure(cfg) -> None:
+async def _apply_reconfigure(cfg: PetasosConfig) -> None:
     """Apply a reloaded config to the live gateway as one uninterrupted unit.
 
     Dispatched onto _async_loop via _run_async (PET-126 Decision 6), so it is

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import logging
 import os
 import threading
@@ -48,6 +49,17 @@ _session_ids: dict[int, str] = {}
 _disarm_log_lock = threading.Lock()
 _last_disarm_log = 0.0
 _DISARM_LOG_EVERY_S = 30.0
+
+# PET-126: live config reload. The cross-process re-read (petasos.console._reload)
+# detects a config.yaml change on the hot path and _maybe_reconfigure applies it
+# to the running pipeline + guard + lineage registry. Two rate-limited streams
+# reuse the _DISARM_LOG_EVERY_S window but keep their OWN clocks so neither can
+# suppress the other (or the security-critical PETASOS_DISARMED tripwire): an
+# attribution WARNING on each applied change, and a failure WARNING on a
+# build/apply error (keep-last-good).
+_reload_log_lock = threading.Lock()
+_last_attribution_log = 0.0
+_last_reload_fail_log = 0.0
 
 # PET-107: sub-agent lineage (Option A). The registry is constructed in
 # _deferred_init (it shares the tracker's clock + lock discipline), but the
@@ -207,6 +219,40 @@ def _load_config() -> dict[str, Any]:
     return section
 
 
+def _build_config_from_section(section: dict[str, Any]):
+    """Build a validated PetasosConfig from a raw petasos: section.
+
+    Applies the SAME env overlay as boot (PET-126 Decision 10): injects
+    session_secret / hash_key from the environment and applies boot's
+    hash_key-missing anonymize=False defang, so a boot config and a live-reload
+    config are equivalent. Operates on a copy and never mutates the caller's dict.
+    Raises (TypeError/ValueError) on a validation failure of any other field; the
+    reload path absorbs that via its fail-safe keep-last-good branch.
+    """
+    from petasos import PetasosConfig
+
+    raw = dict(section)
+    # host_id is a Pipeline constructor arg (not a config field) and `enabled` is
+    # owned by the _armed fast path; neither is reconfigured (Decision 2).
+    raw.pop("host_id", None)
+    raw.pop("enabled", None)
+
+    session_secret_b64 = os.environ.get("PETASOS_SESSION_SECRET")
+    if session_secret_b64:
+        # Invalid base64: leave as-is (boot warns separately and does not inject).
+        with contextlib.suppress(Exception):
+            raw["session_secret"] = base64.b64decode(session_secret_b64)
+
+    hash_key = os.environ.get("PETASOS_HASH_KEY")
+    if hash_key:
+        raw["hash_key"] = hash_key
+    elif raw.get("redaction_mode") == "hash":
+        # Boot's defang: downgrade rather than raise when hash_key is absent.
+        raw["anonymize"] = False
+
+    return PetasosConfig.from_dict(raw)
+
+
 # ---------------------------------------------------------------------------
 # Deferred initialization — runs in background thread from register()
 # ---------------------------------------------------------------------------
@@ -238,11 +284,15 @@ def _deferred_init() -> None:
                 enabled,
             )
 
+            # Boot-time operator guidance. The actual env overlay + validation is
+            # the shared _build_config_from_section (also used by the live reload,
+            # PET-126 Decision 10), so a boot config and a live-reload config are
+            # equivalent. The warnings stay here so the reload path does not re-emit
+            # them on every applied change.
             session_secret_b64 = os.environ.get("PETASOS_SESSION_SECRET")
-            session_secret = None
             if session_secret_b64:
                 try:
-                    session_secret = base64.b64decode(session_secret_b64)
+                    base64.b64decode(session_secret_b64)
                 except Exception:
                     logger.warning(
                         "PETASOS_SESSION_SECRET is not valid base64"
@@ -251,22 +301,18 @@ def _deferred_init() -> None:
             else:
                 logger.warning("PETASOS_SESSION_SECRET not set — HMAC session binding disabled")
 
-            hash_key = os.environ.get("PETASOS_HASH_KEY")
-            if not hash_key and raw_config.get("redaction_mode") == "hash":
+            if (
+                not os.environ.get("PETASOS_HASH_KEY")
+                and raw_config.get("redaction_mode") == "hash"
+            ):
                 logger.warning(
                     "PETASOS_HASH_KEY not set but redaction_mode=hash "
                     "— PII anonymization will fail. Set PETASOS_HASH_KEY "
                     "or change redaction_mode."
                 )
-                raw_config["anonymize"] = False
-
-            if session_secret is not None:
-                raw_config["session_secret"] = session_secret
-            if hash_key:
-                raw_config["hash_key"] = hash_key
 
             try:
-                config = PetasosConfig.from_dict(raw_config)
+                config = _build_config_from_section(raw_config)
             except (TypeError, ValueError) as exc:
                 logger.error("PetasosConfig validation failed: %s — using defaults", exc)
                 config = PetasosConfig()
@@ -566,6 +612,103 @@ def _log_disarmed_bypass(tool_name: str) -> None:
     )
 
 
+def _reset_reload_logs() -> None:
+    """Test seam — reset the PET-126 reload rate-limit clocks."""
+    global _last_attribution_log, _last_reload_fail_log
+    with _reload_log_lock:
+        _last_attribution_log = 0.0
+        _last_reload_fail_log = 0.0
+
+
+def _log_reconfigure_applied() -> None:
+    """Rate-limited WARNING so every applied live config change is attributable."""
+    global _last_attribution_log
+    now = time.monotonic()
+    with _reload_log_lock:
+        if now - _last_attribution_log < _DISARM_LOG_EVERY_S:
+            return
+        _last_attribution_log = now
+    logger.warning("PETASOS_RECONFIGURED: live config.yaml change applied to the running session")
+
+
+def _log_reload_failure(detail: str) -> None:
+    """Rate-limited WARNING for a build/apply failure; the live config is unchanged.
+
+    Its own clock (never _last_disarm_log / _last_attribution_log) so a
+    persistently-malformed section, which re-detects every TTL, cannot spam the
+    log or suppress the disarm tripwire.
+    """
+    global _last_reload_fail_log
+    now = time.monotonic()
+    with _reload_log_lock:
+        if now - _last_reload_fail_log < _DISARM_LOG_EVERY_S:
+            return
+        _last_reload_fail_log = now
+    logger.warning("PETASOS_RELOAD_FAILED: %s; keeping last-good config", detail)
+
+
+async def _apply_reconfigure(cfg) -> None:
+    """Apply a reloaded config to the live gateway as one uninterrupted unit.
+
+    Dispatched onto _async_loop via _run_async (PET-126 Decision 6), so it is
+    serialized with scans between await points. The body is fully synchronous (it
+    never yields), so the steps are atomic with respect to any other loop task.
+
+    Two-phase (Decision 5): validate everything that can fail BEFORE committing
+    anything, then commit. Because guard.validate_config and the apply tracker
+    stages parse the SAME already-validated cfg through pure functions, phase-1
+    success guarantees no commit step raises, so there is no partial cross-object
+    apply. The gateway owns the guard, lineage registry, and egress set, which the
+    pipeline cannot reach, so all four are reconfigured here (Decision 4).
+    """
+    # Phase 1: validate (no mutation) — D8 overlap + frequency_weights trial.
+    _guard.validate_config(cfg)
+    # Phase 2: commit.
+    _pipeline.reconfigure(cfg)
+    _guard.apply_config(cfg)
+    if _lineage_registry is not None:
+        _lineage_registry.apply_config(cfg)
+    global _egress_sink_tools
+    _egress_sink_tools = frozenset(
+        c for c in (canonicalize_tool_name(t) for t in cfg.egress_sink_tools) if c
+    )
+
+
+def _maybe_reconfigure() -> None:
+    """PET-126: detect a config.yaml change and hot-apply it to the live session.
+
+    Called at the top of _pre_tool_call once initialized. The no-change path is
+    one os.stat (see _reload). On a detected change: build the config (failure ->
+    rate-limited fail log, keep last-good, do NOT commit so it retries next call)
+    and dispatch _apply_reconfigure onto _async_loop. On a successful apply:
+    commit_seen(key) + a rate-limited attribution WARNING. On apply failure:
+    swallow fail-safe (matching the _is_armed / guard-eval posture, rate-limited
+    fail log) and do NOT commit, so the change is re-attempted next call. A reload
+    error never blocks a tool call and never silently pins a stale config.
+    """
+    try:
+        from petasos.console._reload import commit_seen, read_changed_section
+    except Exception:
+        return
+
+    changed = read_changed_section()
+    if changed is None:
+        return
+    section, key = changed
+    try:
+        cfg = _build_config_from_section(section)
+    except Exception as exc:
+        _log_reload_failure(f"build failed: {exc}")
+        return  # keep last-good; not committed -> retried next call
+    try:
+        _run_async(_apply_reconfigure(cfg))
+    except Exception as exc:
+        _log_reload_failure(f"apply failed: {exc}")
+        return  # keep last-good; not committed -> retried next call
+    commit_seen(key)
+    _log_reconfigure_applied()
+
+
 def _pre_tool_call(
     tool_name: str, args: dict, task_id: str = "", **kwargs
 ) -> dict[str, str] | None:
@@ -583,6 +726,13 @@ def _pre_tool_call(
         # silently allow during the cold-start window (fail_mode=closed
         # means we should be blocking, not passing through).
         return _fallback_pre_tool_call(tool_name, args, task_id, **kwargs)
+
+    # PET-126: initialized here — pick up any live config.yaml change before this
+    # call is evaluated. Self-guarded and fail-safe; never blocks the tool call.
+    try:
+        _maybe_reconfigure()
+    except Exception as exc:
+        logger.debug("Petasos reconfigure check failed: %s — keeping last-good", exc)
 
     session_id = _derive_session_id(task_id, kwargs)
 

--- a/docs/specs/TODO/PET-126.test-output.txt
+++ b/docs/specs/TODO/PET-126.test-output.txt
@@ -1,0 +1,139 @@
+============================= test session starts =============================
+platform win32 -- Python 3.10.6, pytest-9.0.3, pluggy-1.6.0
+rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-126-worktree
+configfile: pyproject.toml
+plugins: anyio-4.13.0, asyncio-1.3.0
+asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 1748 items / 1 deselected / 1747 selected
+
+tests\adversarial\config\test_bool_coercion.py ......................... [  1%]
+......                                                                   [  1%]
+tests\adversarial\config\test_config_poisoning.py ............           [  2%]
+tests\adversarial\escalation\test_derive_tier.py ......                  [  2%]
+tests\adversarial\escalation\test_standalone_tier3.py .....              [  3%]
+tests\adversarial\escalation\test_tier3_floor_inline.py ..               [  3%]
+tests\adversarial\frequency\test_rate_limited_sentinel.py ....           [  3%]
+tests\adversarial\frequency\test_session_spoofing.py .....               [  3%]
+tests\adversarial\frequency\test_terminated_state_loss.py .........      [  4%]
+tests\adversarial\frequency\test_ttl_eviction.py ....                    [  4%]
+tests\adversarial\guard\test_tool_smuggling.py ...................       [  5%]
+tests\adversarial\license\test_jwt_attacks.py ...                        [  5%]
+tests\adversarial\license\test_license_hardening.py .................... [  6%]
+...                                                                      [  7%]
+tests\adversarial\normalization\test_unicode_bypass.py ................. [  8%]
+.....                                                                    [  8%]
+tests\adversarial\pipeline\test_callback_isolation.py ...............    [  9%]
+tests\adversarial\pipeline\test_cancel_mid_gather.py ......              [  9%]
+tests\adversarial\pipeline\test_cancel_scan_residual.py .                [  9%]
+tests\adversarial\pipeline\test_degraded_fail_open.py .................. [ 10%]
+......                                                                   [ 10%]
+tests\adversarial\pipeline\test_env_license_trust.py ...                 [ 11%]
+tests\adversarial\pipeline\test_rt075_chain.py x....                     [ 11%]
+tests\adversarial\pipeline\test_scanner_timeout_breaker.py ............. [ 12%]
+.....                                                                    [ 12%]
+tests\adversarial\profiles\test_suppress_bypass.py ......                [ 12%]
+tests\adversarial\scanner\test_confidence_clamp.py ......                [ 13%]
+tests\adversarial\syntactic\test_binary_nul.py .                         [ 13%]
+tests\adversarial\syntactic\test_command_rules.py ...................... [ 14%]
+........................................................................ [ 18%]
+.....                                                                    [ 18%]
+tests\adversarial\syntactic\test_encoding_evasion.py ............        [ 19%]
+tests\adversarial\syntactic\test_injection_evasion.py .................. [ 20%]
+.....................................                                    [ 22%]
+tests\adversarial\syntactic\test_json_depth_strings.py .                 [ 22%]
+tests\adversarial\types\test_type_validation.py ...................      [ 23%]
+tests\test_alerting.py ................................................. [ 26%]
+..................                                                       [ 27%]
+tests\test_audit.py ..................................                   [ 29%]
+tests\test_benchmarks.py ssssssss                                        [ 30%]
+tests\test_ci_extras_lanes.py ............                               [ 30%]
+tests\test_config.py ..............................................      [ 33%]
+tests\test_config_meta.py ..................                             [ 34%]
+tests\test_console_armed.py ..............................               [ 36%]
+tests\test_console_handlers.py ......................................... [ 38%]
+............                                                             [ 39%]
+tests\test_console_playground.py ....                                    [ 39%]
+tests\test_console_reload.py ...........                                 [ 40%]
+tests\test_console_server.py .                                           [ 40%]
+tests\test_console_validation.py ....................................... [ 42%]
+....................                                                     [ 43%]
+tests\test_escalation.py ...............                                 [ 44%]
+tests\test_finding_merge.py ............                                 [ 44%]
+tests\test_formatting.py ....................                            [ 46%]
+tests\test_frequency.py .......................................          [ 48%]
+tests\test_frequency_tombstone.py .................                      [ 49%]
+tests\test_guard.py .................................................... [ 52%]
+......................................                                   [ 54%]
+tests\test_guard_reconfigure.py .......                                  [ 54%]
+tests\test_hardening.py ..............                                   [ 55%]
+tests\test_hermes_integration_defaults.py .................              [ 56%]
+tests\test_hermes_smoke.py ssss..                                        [ 57%]
+tests\test_integration_e2e.py ..................                         [ 58%]
+tests\test_license.py ....................                               [ 59%]
+tests\test_lineage.py ...................                                [ 60%]
+tests\test_llama_firewall_scanner.py ................................... [ 62%]
+...........sssssssssssss                                                 [ 63%]
+tests\test_llama_firewall_wrapper.py ss                                  [ 63%]
+tests\test_llm_guard_scanner.py .......................ssssssssss        [ 65%]
+tests\test_llm_guard_wrapper.py ....ssss.......                          [ 66%]
+tests\test_minimal_scanner.py .......................................... [ 68%]
+....................................                                     [ 70%]
+tests\test_normalize.py ................................................ [ 73%]
+.................................                                        [ 75%]
+tests\test_pipeline.py ................................................. [ 78%]
+......                                                                   [ 78%]
+tests\test_pipeline_reconfigure.py ..............                        [ 79%]
+tests\test_pipeline_suppression.py ..........                            [ 80%]
+tests\test_plugin_api_paths.py .......................................   [ 82%]
+tests\test_plugin_api_sse.py ......                                      [ 82%]
+tests\test_plugin_init_logging.py ....                                   [ 82%]
+tests\test_presets.py ............                                       [ 83%]
+tests\test_presidio_entity_scoping.py .....................              [ 84%]
+tests\test_presidio_scanner.py ......................................... [ 87%]
+.............                                                            [ 87%]
+tests\test_profiles.py ..............................................    [ 90%]
+tests\test_profiles_retained_ref.py ...                                  [ 90%]
+tests\test_profiles_suppress.py ........                                 [ 91%]
+tests\test_reference_plugin_egress.py ..............................     [ 92%]
+tests\test_ring_buffer.py ........                                       [ 93%]
+tests\test_safe_json.py .........                                        [ 93%]
+tests\test_scanner_init.py ...........                                   [ 94%]
+tests\test_session_integration.py ...................................... [ 96%]
+...........                                                              [ 97%]
+tests\test_sse.py .......                                                [ 97%]
+tests\test_subagent_plugin_wiring.py ............                        [ 98%]
+tests\test_types.py ................                                     [ 99%]
+tests\test_verify.py ............                                        [100%]
+
+============================== warnings summary ===============================
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-126-worktree\petasos\console\server.py:320: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    @app.on_event("shutdown")
+
+tests/test_console_armed.py: 8 warnings
+tests/test_console_playground.py: 2 warnings
+tests/test_console_validation.py: 24 warnings
+  C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
+          on_event is deprecated, use lifespan event handlers instead.
+  
+          Read more about it in the
+          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+          
+    return self.router.on_event(event_type)  # ty: ignore[deprecated]
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=== 1705 passed, 41 skipped, 1 deselected, 1 xfailed, 68 warnings in 28.08s ===
+
+=== ruff check . ===
+All checks passed!
+=== ruff format --check . ===
+123 files already formatted
+=== mypy --strict . ===
+Success: no issues found in 123 source files

--- a/docs/specs/TODO/PET-126.test-output.txt
+++ b/docs/specs/TODO/PET-126.test-output.txt
@@ -4,7 +4,7 @@ rootdir: C:\Users\zioni\Documents\Vigil-Harbor\PET-126-worktree
 configfile: pyproject.toml
 plugins: anyio-4.13.0, asyncio-1.3.0
 asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
-collected 1748 items / 1 deselected / 1747 selected
+collected 1775 items / 1 deselected / 1774 selected
 
 tests\adversarial\config\test_bool_coercion.py ......................... [  1%]
 ......                                                                   [  1%]
@@ -19,21 +19,21 @@ tests\adversarial\frequency\test_ttl_eviction.py ....                    [  4%]
 tests\adversarial\guard\test_tool_smuggling.py ...................       [  5%]
 tests\adversarial\license\test_jwt_attacks.py ...                        [  5%]
 tests\adversarial\license\test_license_hardening.py .................... [  6%]
-...                                                                      [  7%]
-tests\adversarial\normalization\test_unicode_bypass.py ................. [  8%]
+...                                                                      [  6%]
+tests\adversarial\normalization\test_unicode_bypass.py ................. [  7%]
 .....                                                                    [  8%]
 tests\adversarial\pipeline\test_callback_isolation.py ...............    [  9%]
 tests\adversarial\pipeline\test_cancel_mid_gather.py ......              [  9%]
 tests\adversarial\pipeline\test_cancel_scan_residual.py .                [  9%]
 tests\adversarial\pipeline\test_degraded_fail_open.py .................. [ 10%]
 ......                                                                   [ 10%]
-tests\adversarial\pipeline\test_env_license_trust.py ...                 [ 11%]
+tests\adversarial\pipeline\test_env_license_trust.py ...                 [ 10%]
 tests\adversarial\pipeline\test_rt075_chain.py x....                     [ 11%]
-tests\adversarial\pipeline\test_scanner_timeout_breaker.py ............. [ 12%]
+tests\adversarial\pipeline\test_scanner_timeout_breaker.py ............. [ 11%]
 .....                                                                    [ 12%]
 tests\adversarial\profiles\test_suppress_bypass.py ......                [ 12%]
-tests\adversarial\scanner\test_confidence_clamp.py ......                [ 13%]
-tests\adversarial\syntactic\test_binary_nul.py .                         [ 13%]
+tests\adversarial\scanner\test_confidence_clamp.py ......                [ 12%]
+tests\adversarial\syntactic\test_binary_nul.py .                         [ 12%]
 tests\adversarial\syntactic\test_command_rules.py ...................... [ 14%]
 ........................................................................ [ 18%]
 .....                                                                    [ 18%]
@@ -45,56 +45,58 @@ tests\adversarial\types\test_type_validation.py ...................      [ 23%]
 tests\test_alerting.py ................................................. [ 26%]
 ..................                                                       [ 27%]
 tests\test_audit.py ..................................                   [ 29%]
-tests\test_benchmarks.py ssssssss                                        [ 30%]
+tests\test_benchmarks.py ssssssss                                        [ 29%]
 tests\test_ci_extras_lanes.py ............                               [ 30%]
-tests\test_config.py ..............................................      [ 33%]
-tests\test_config_meta.py ..................                             [ 34%]
-tests\test_console_armed.py ..............................               [ 36%]
+tests\test_config.py ..............................................      [ 32%]
+tests\test_config_meta.py ..................                             [ 33%]
+tests\test_console_armed.py ..............................               [ 35%]
+tests\test_console_auth.py .............                                 [ 36%]
 tests\test_console_handlers.py ......................................... [ 38%]
 ............                                                             [ 39%]
 tests\test_console_playground.py ....                                    [ 39%]
 tests\test_console_reload.py ...........                                 [ 40%]
-tests\test_console_server.py .                                           [ 40%]
+tests\test_console_server.py ..                                          [ 40%]
 tests\test_console_validation.py ....................................... [ 42%]
 ....................                                                     [ 43%]
-tests\test_escalation.py ...............                                 [ 44%]
-tests\test_finding_merge.py ............                                 [ 44%]
+tests\test_docs_usage_consistency.py ..........                          [ 44%]
+tests\test_escalation.py ................                                [ 45%]
+tests\test_finding_merge.py ............                                 [ 45%]
 tests\test_formatting.py ....................                            [ 46%]
-tests\test_frequency.py .......................................          [ 48%]
-tests\test_frequency_tombstone.py .................                      [ 49%]
+tests\test_frequency.py .......................................          [ 49%]
+tests\test_frequency_tombstone.py .................                      [ 50%]
 tests\test_guard.py .................................................... [ 52%]
-......................................                                   [ 54%]
-tests\test_guard_reconfigure.py .......                                  [ 54%]
-tests\test_hardening.py ..............                                   [ 55%]
-tests\test_hermes_integration_defaults.py .................              [ 56%]
+......................................                                   [ 55%]
+tests\test_guard_reconfigure.py .......                                  [ 55%]
+tests\test_hardening.py ..............                                   [ 56%]
+tests\test_hermes_integration_defaults.py .................              [ 57%]
 tests\test_hermes_smoke.py ssss..                                        [ 57%]
 tests\test_integration_e2e.py ..................                         [ 58%]
 tests\test_license.py ....................                               [ 59%]
 tests\test_lineage.py ...................                                [ 60%]
 tests\test_llama_firewall_scanner.py ................................... [ 62%]
-...........sssssssssssss                                                 [ 63%]
-tests\test_llama_firewall_wrapper.py ss                                  [ 63%]
-tests\test_llm_guard_scanner.py .......................ssssssssss        [ 65%]
+...........sssssssssssss                                                 [ 64%]
+tests\test_llama_firewall_wrapper.py ss                                  [ 64%]
+tests\test_llm_guard_scanner.py .......................ssssssssss        [ 66%]
 tests\test_llm_guard_wrapper.py ....ssss.......                          [ 66%]
-tests\test_minimal_scanner.py .......................................... [ 68%]
-....................................                                     [ 70%]
-tests\test_normalize.py ................................................ [ 73%]
+tests\test_minimal_scanner.py .......................................... [ 69%]
+.....................................                                    [ 71%]
+tests\test_normalize.py ................................................ [ 74%]
 .................................                                        [ 75%]
 tests\test_pipeline.py ................................................. [ 78%]
-......                                                                   [ 78%]
+......                                                                   [ 79%]
 tests\test_pipeline_reconfigure.py ..............                        [ 79%]
 tests\test_pipeline_suppression.py ..........                            [ 80%]
 tests\test_plugin_api_paths.py .......................................   [ 82%]
 tests\test_plugin_api_sse.py ......                                      [ 82%]
-tests\test_plugin_init_logging.py ....                                   [ 82%]
+tests\test_plugin_init_logging.py ....                                   [ 83%]
 tests\test_presets.py ............                                       [ 83%]
-tests\test_presidio_entity_scoping.py .....................              [ 84%]
+tests\test_presidio_entity_scoping.py .....................              [ 85%]
 tests\test_presidio_scanner.py ......................................... [ 87%]
-.............                                                            [ 87%]
+.............                                                            [ 88%]
 tests\test_profiles.py ..............................................    [ 90%]
 tests\test_profiles_retained_ref.py ...                                  [ 90%]
 tests\test_profiles_suppress.py ........                                 [ 91%]
-tests\test_reference_plugin_egress.py ..............................     [ 92%]
+tests\test_reference_plugin_egress.py ...............................    [ 93%]
 tests\test_ring_buffer.py ........                                       [ 93%]
 tests\test_safe_json.py .........                                        [ 93%]
 tests\test_scanner_init.py ...........                                   [ 94%]
@@ -107,9 +109,10 @@ tests\test_verify.py ............                                        [100%]
 
 ============================== warnings summary ===============================
 tests/test_console_armed.py: 8 warnings
+tests/test_console_auth.py: 13 warnings
 tests/test_console_playground.py: 2 warnings
 tests/test_console_validation.py: 24 warnings
-  C:\Users\zioni\Documents\Vigil-Harbor\PET-126-worktree\petasos\console\server.py:320: DeprecationWarning: 
+  C:\Users\zioni\Documents\Vigil-Harbor\PET-126-worktree\petasos\console\server.py:383: DeprecationWarning: 
           on_event is deprecated, use lifespan event handlers instead.
   
           Read more about it in the
@@ -118,6 +121,7 @@ tests/test_console_validation.py: 24 warnings
     @app.on_event("shutdown")
 
 tests/test_console_armed.py: 8 warnings
+tests/test_console_auth.py: 13 warnings
 tests/test_console_playground.py: 2 warnings
 tests/test_console_validation.py: 24 warnings
   C:\python310\lib\site-packages\fastapi\applications.py:4598: DeprecationWarning: 
@@ -129,11 +133,11 @@ tests/test_console_validation.py: 24 warnings
     return self.router.on_event(event_type)  # ty: ignore[deprecated]
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-=== 1705 passed, 41 skipped, 1 deselected, 1 xfailed, 68 warnings in 28.08s ===
+=== 1732 passed, 41 skipped, 1 deselected, 1 xfailed, 94 warnings in 32.39s ===
 
 === ruff check . ===
 All checks passed!
 === ruff format --check . ===
-123 files already formatted
+125 files already formatted
 === mypy --strict . ===
-Success: no issues found in 123 source files
+Success: no issues found in 125 source files

--- a/petasos/console/_reload.py
+++ b/petasos/console/_reload.py
@@ -1,0 +1,116 @@
+"""Cross-process config-change reader: sibling of ``_armed.py`` (PET-126).
+
+A TTL + ``(mtime_ns, size)``-gated reader over ``resolve_hermes_config_path()``
+that surfaces a *changed*, non-empty ``petasos:`` section so the gateway can
+hot-apply a Config Editor save to a running session. It differs from
+``read_armed`` in two load-bearing ways (spec Decision 3):
+
+* **Fail-safe, not fail-secure.** Any stat/read error, or an empty/missing/wiped
+  section, returns ``None`` ("no change, keep last-good"); it never builds an
+  all-defaults config from a wiped section (D-WIN, Decision 9). ``read_armed``
+  instead fails *secure* (errors arm). The two keep separate caches over the same
+  resolver so neither posture is forced onto the other; a test pins that they
+  resolve to the identical path.
+* **Emits change, not state.** ``read_armed`` may re-emit the same bool;
+  ``read_changed_section`` returns a section only when it actually changed.
+
+Peek + commit-on-success (Decision 3): ``read_changed_section`` does NOT advance
+the seen key by itself. It returns ``(section, key)`` and the caller calls
+``commit_seen(key)`` only after a successful apply. A failed apply leaves the key
+uncommitted, so the same change is re-attempted on the next call after the TTL: a
+failed apply can never silently pin a stale config. Never raises.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from petasos.console._paths import read_petasos_section, resolve_hermes_config_path
+
+_RELOAD_LOCK = threading.Lock()
+_RELOAD_TTL_S = 1.0
+# (seen_key, seen_section, monotonic_ts) | None — seen_key is the
+# (st_mtime_ns, st_size) of the last COMMITTED section; written only by
+# commit_seen / _reset_reload_cache. read_changed_section is a pure reader of it.
+_RELOAD_CACHE: tuple[tuple[int, int], dict[str, Any], float] | None = None
+
+
+def _reset_reload_cache() -> None:
+    """Test seam: drop the cache (mirrors ``_reset_armed_cache``)."""
+    global _RELOAD_CACHE
+    with _RELOAD_LOCK:
+        _RELOAD_CACHE = None
+
+
+def read_changed_section() -> tuple[dict[str, Any], tuple[int, int]] | None:
+    """Return ``(section, key)`` when the ``petasos:`` section changed, else ``None``.
+
+    ``key = (mtime_ns, size)``. Logic:
+
+    * stat fails (missing/locked) -> ``None`` (fail-safe, keep last-good).
+    * key matches the committed key and age < TTL -> ``None`` (no re-parse).
+    * otherwise re-read; an empty ``{}`` from ``read_petasos_section``
+      (missing/wiped/malformed) -> ``None`` and the cache is NOT advanced
+      (D-WIN + the stat-then-read TOCTOU collapse into one "empty -> None" path).
+    * key matches the committed key and the parsed dict equals the committed
+      section -> ``None`` (the timestamp is refreshed to throttle re-parsing). This
+      is the same-tick guard: a same-size, same-mtime-tick rewrite on coarse-mtime
+      Windows/FAT is still observed once the content differs.
+    * anything else is a real change -> ``(section, key)``.
+
+    Does not self-advance the seen key; the caller commits via ``commit_seen``.
+    Never raises.
+    """
+    global _RELOAD_CACHE
+    try:
+        res = resolve_hermes_config_path()
+        try:
+            st = res.path.stat()
+            key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            return None  # cannot stat -> keep last-good (fail-safe)
+
+        now = time.monotonic()
+        with _RELOAD_LOCK:
+            cache = _RELOAD_CACHE
+            if cache is not None and cache[0] == key and (now - cache[2]) < _RELOAD_TTL_S:
+                return None  # within TTL at the committed key -> no work
+
+        section = read_petasos_section(res)  # never raises (D3)
+        if not section:
+            # Empty/missing/wiped/malformed -> no change, keep last-good (D-WIN).
+            # The cache is NOT advanced, so a later non-empty write is still seen.
+            return None
+
+        with _RELOAD_LOCK:
+            cache = _RELOAD_CACHE
+            if cache is not None and cache[0] == key and section == cache[1]:
+                # Same key, identical content: not a change. Refresh the timestamp
+                # so a steady state re-parses at most once per TTL (mirrors
+                # read_armed's steady-state cost).
+                _RELOAD_CACHE = (cache[0], cache[1], now)
+                return None
+            return section, key
+    except Exception:
+        return None  # never raises out (fail-safe)
+
+
+def commit_seen(key: tuple[int, int]) -> None:
+    """Advance the seen key after a successful apply (commit-on-success).
+
+    Re-reads the resolved section so the cached ``(key, section, ts)`` lets a
+    subsequent same-key call short-circuit (and feeds the same-tick content
+    compare). Re-applying the same already-validated config is idempotent, so the
+    rare race where the file changes again between read and commit costs at most
+    one redundant re-apply on the next call rather than a correctness bug.
+    """
+    global _RELOAD_CACHE
+    try:
+        res = resolve_hermes_config_path()
+        section = read_petasos_section(res)
+    except Exception:
+        section = {}
+    with _RELOAD_LOCK:
+        _RELOAD_CACHE = (key, section, time.monotonic())

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -162,7 +162,12 @@ class ConsoleHandlers:
             msg = str(exc)
             field = _extract_field_from_error(msg, body)
             return None, [{"field": field, "message": msg}]
-        self.pipeline._config = validated
+        # PET-126: route through reconfigure so the change takes effect on the
+        # running pipeline (frequency, escalation, audit verbosity, alerting, and
+        # decode_encoded_payloads all live-update), not just on a new session. A
+        # bare ``self.pipeline._config = validated`` only updated the fields read
+        # directly off _config at scan time.
+        self.pipeline.reconfigure(validated)
         persisted = _persist_config(validated)
         result = {
             "config": validated.to_dict(redact_secrets=True),

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -167,7 +167,18 @@ class ConsoleHandlers:
         # decode_encoded_payloads all live-update), not just on a new session. A
         # bare ``self.pipeline._config = validated`` only updated the fields read
         # directly off _config at scan time.
-        self.pipeline.reconfigure(validated)
+        try:
+            self.pipeline.reconfigure(validated)
+        except (ValueError, TypeError) as exc:
+            # from_dict validates structure, but frequency_weights content (glob
+            # position, non-negative/finite values) is validated inside
+            # FrequencyTracker.apply_config during reconfigure. Surface that as a
+            # structured field error (422), not an unhandled 500. reconfigure is
+            # atomic (Decision 5), so the live config is unchanged on failure and
+            # we do not persist a config that could not be applied.
+            msg = str(exc)
+            field = _extract_field_from_error(msg, body)
+            return None, [{"field": field, "message": msg}]
         persisted = _persist_config(validated)
         result = {
             "config": validated.to_dict(redact_secrets=True),

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -308,6 +308,10 @@ class Pipeline:
 
         self._frequency_tracker = FrequencyTracker(self._config)
         self._profile_resolver = ProfileResolver()
+        # PET-126: retain the raw constructor `profile` arg so reconfigure can
+        # re-resolve _default_profile with the same precedence (a pinned profile
+        # stays pinned; a config-driven one follows profile_name — Decision 7).
+        self._profile_arg = profile
         self._default_profile: ResolvedProfile | None = self._resolve_profile(profile)
         self._audit_emitter = AuditEmitter(self._config, on_audit=on_audit)
         self._alert_manager = AlertManager(self._config, on_alert=on_alert)
@@ -328,6 +332,48 @@ class Pipeline:
     @property
     def config(self) -> PetasosConfig:
         return self._config
+
+    def reconfigure(self, new_config: PetasosConfig) -> None:
+        """Atomically swap ``self._config`` and propagate it into every
+        subcomponent that cached config, without resetting accumulated session
+        state (PET-126).
+
+        The single in-process propagation primitive (spec Decision 1). Order is
+        chosen for all-or-nothing atomicity (Decision 5):
+
+        1. Merge-preserve the restart-required ``session_secret`` (Decision 2): the
+           applied config always keeps the LIVE secret. A differing non-None
+           incoming secret logs one WARNING and is ignored (restart required); a
+           None/absent secret preserves silently (the console path always drops
+           it). ``replace`` re-runs ``__post_init__`` (full validation) before any
+           live state is touched, so a sub-floor or unordered tier is rejected here.
+        2. Apply the only fail-prone step FIRST: ``FrequencyTracker.apply_config``
+           stages the weight parse then commits. If it raises (malformed weights),
+           ``self._config`` is untouched and the pipeline stays wholly on the prior
+           config.
+        3. Apply the infallible steps: audit, alert, and the MinimalScanner decode
+           flag.
+        4. Commit the swap and re-resolve the profile.
+        """
+        applied = replace(new_config, session_secret=self._config.session_secret)
+        if (
+            new_config.session_secret is not None
+            and new_config.session_secret != self._config.session_secret
+        ):
+            _logger.warning(
+                "reconfigure: session_secret change ignored (restart required); "
+                "the live secret is preserved"
+            )
+        # Fail-prone step first (the atomic abort point, Decision 5).
+        self._frequency_tracker.apply_config(applied)
+        # Infallible steps.
+        self._audit_emitter.apply_config(applied)
+        self._alert_manager.apply_config(applied)
+        assert self._minimal_scanner is not None
+        self._minimal_scanner.set_decode_encoded_payloads(applied.decode_encoded_payloads)
+        # Commit the swap, then re-resolve the profile with constructor precedence.
+        self._config = applied
+        self._default_profile = self._resolve_profile(self._profile_arg)
 
     def activate(self, key: str) -> LicenseState:
         """Validate a license key for supporter/compliance recognition.

--- a/petasos/scanners/minimal.py
+++ b/petasos/scanners/minimal.py
@@ -462,6 +462,16 @@ class MinimalScanner:
             decode_encoded_payloads=self._decode_encoded_payloads,
         )
 
+    def set_decode_encoded_payloads(self, flag: bool) -> None:
+        """PET-126: flip the decode toggle in place (read live at scan time).
+
+        The one targeted in-place mutation in the reconfigure path: MinimalScanner
+        carries no session state, so a caller-supplied scanner keeps its other
+        tunables (``max_payload_bytes``, ``max_json_depth``, ``suppress_rules``)
+        and its object identity rather than being rebuilt (spec Decision 1).
+        """
+        self._decode_encoded_payloads = flag
+
     @property
     def name(self) -> str:
         return "minimal"

--- a/petasos/session/alerting.py
+++ b/petasos/session/alerting.py
@@ -54,6 +54,25 @@ class AlertManager:
         self._cross_session_tracker: dict[str, float] = {}
         self._callback_errors: list[str] = []
 
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """PET-126: rebind ``_config``; rebuild ``_pii_ring_buffer`` only when
+        ``alert_ring_buffer_capacity`` changed.
+
+        On a capacity *shrink*, ``deque(old, maxlen=new)`` keeps the most-recent
+        ``new`` items (oldest dropped): ring-buffer recency semantics. All
+        counters, cooldowns, per-rule/per-session deques, ``_ring_buffers``, and
+        ``_cross_session_tracker`` are preserved. The capacity is pre-validated as
+        a positive int in ``__post_init__``, so the rebuild cannot raise. Existing
+        per-rule ``_ring_buffers`` entries keep their construction-time ``maxlen``
+        (harmless: ``__post_init__`` bounds ``alert_rapid_fire_count <= capacity``);
+        newly-created entries pick up the new capacity.
+        """
+        old_capacity = self._config.alert_ring_buffer_capacity
+        self._config = new_config
+        new_capacity = new_config.alert_ring_buffer_capacity
+        if new_capacity != old_capacity:
+            self._pii_ring_buffer = deque(self._pii_ring_buffer, maxlen=new_capacity)
+
     @property
     def callback_errors(self) -> tuple[str, ...]:
         return tuple(self._callback_errors)

--- a/petasos/session/audit.py
+++ b/petasos/session/audit.py
@@ -31,6 +31,16 @@ class AuditEmitter:
         self._last_callback_error: str | None = None
         self._listeners: list[Callable[[AuditEvent], None]] = []
 
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """PET-126: rebind ``_config`` in place.
+
+        ``audit_verbosity`` is read live off ``_config`` in ``_build_payload``, so
+        a swap takes effect on the next emitted event. Preserves
+        ``_global_sequence`` (the audit sequence is not reset), ``_listeners``, and
+        ``_last_callback_error``.
+        """
+        self._config = new_config
+
     @property
     def last_callback_error(self) -> str | None:
         return self._last_callback_error

--- a/petasos/session/frequency.py
+++ b/petasos/session/frequency.py
@@ -129,6 +129,68 @@ class FrequencyTracker:
         self._max_terminated: int = config.max_terminated_tombstones
         self._ttl_deque: deque[tuple[float, str]] = deque()
 
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """Re-read tunables from ``new_config`` in place, preserving session state.
+
+        PET-126: the live-reconfigure hook. Re-parses ``frequency_weights`` and
+        re-reads the seven cached scalars without reconstructing the tracker, so
+        accumulated per-session scores, tombstones, and rolling-window deques
+        survive a Config Editor save or a cross-process reload.
+
+        Atomicity (spec Decision 5): the full ``frequency_weights`` validation
+        lives here, not in ``PetasosConfig.__post_init__``, so a malformed glob
+        key or a negative/non-finite weight passes ``from_dict`` but must abort
+        ``reconfigure`` before any live state is touched. The parse is therefore
+        *staged* into locals first (may raise) and only then *committed* under
+        ``_lock``; the rebind and the on-shrink tombstone trim share that one
+        critical section (``_enforce_tombstone_cap`` assumes the lock is held).
+
+        ``_session_secret`` is treated as immutable (spec Decision 2): it is never
+        rebound here, at either the pipeline or the guard tracker, so HMAC-bound
+        session tokens minted before the reload still verify afterward.
+        """
+        # Stage: re-run the full weight parse (mirrors __init__). May raise
+        # ValueError on a malformed glob key or a negative/non-finite weight;
+        # nothing has been mutated yet, so reconfigure aborts cleanly.
+        raw_weights = (
+            new_config.frequency_weights
+            if new_config.frequency_weights is not None
+            else DEFAULT_FREQUENCY_WEIGHTS
+        )
+        new_exact_weights: dict[str, float] = {}
+        new_glob_entries: list[tuple[str, float]] = []
+        for key, weight in raw_weights.items():
+            if key.endswith(".*"):
+                prefix = key[:-2]
+                if "*" in prefix:
+                    raise ValueError(f"glob key has '*' in non-terminal position: {key!r}")
+                new_glob_entries.append((prefix, weight))
+            elif "*" in key:
+                raise ValueError(f"weight key has '*' in non-terminal position: {key!r}")
+            else:
+                new_exact_weights[key] = weight
+
+            if weight < 0 or not math.isfinite(weight):
+                raise ValueError(f"weight must be non-negative and finite: {key!r}={weight!r}")
+
+        new_glob_entries.sort(key=lambda e: len(e[0]), reverse=True)
+
+        # Commit: rebind scalars + weights + _config under the lock, then trim
+        # tombstones (a no-op unless _max_terminated shrank below the live count).
+        # _session_secret is intentionally NOT rebound (Decision 2).
+        with self._lock:
+            self._half_life = new_config.frequency_half_life_seconds
+            self._rolling_window = new_config.rolling_window_seconds
+            self._rolling_threshold = new_config.rolling_threshold
+            self._max_sessions = new_config.max_sessions
+            self._session_ttl = new_config.session_ttl_seconds
+            self._max_new_per_minute = new_config.max_new_sessions_per_minute
+            self._max_terminated = new_config.max_terminated_tombstones
+            self._exact_weights = new_exact_weights
+            self._glob_weights = new_glob_entries
+            self._config = new_config
+            self._enforce_tombstone_cap()
+
     @property
     def requires_token(self) -> bool:
         return self._session_secret is not None

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
@@ -102,6 +102,18 @@ class SpawnBudget:
         self._events: dict[str, deque[float]] = {}
         self._last_sweep = 0.0
 
+    def set_window(self, seconds: float) -> None:
+        """PET-126: rebind the rolling-window length in place.
+
+        Rebinds ``_window`` only: never resets ``_last_sweep`` or ``_events``, so
+        buffered spawn timestamps survive a reconfigure. A *shrink* simply
+        re-interprets them against the smaller cutoff on the next ``try_consume``
+        (older events expire sooner). Taken under ``_lock`` because ``try_consume``
+        reads ``_window`` under the same lock.
+        """
+        with self._lock:
+            self._window = seconds
+
     def try_consume(self, session_id: str, cap: int, now: float) -> bool:
         with self._lock:
             cutoff = now - self._window
@@ -174,6 +186,68 @@ class ToolCallGuard:
                 "away) — the delegation fan-out gate is inert"
             )
         self._spawn_budget = SpawnBudget(config.delegate_fanout_window_seconds)
+
+    def validate_config(self, new_config: PetasosConfig) -> None:
+        """Dry-run validation of a candidate config: raises, never mutates (D5/D8).
+
+        Two guard-only invariants that ``PetasosConfig.__post_init__`` does not
+        cover, run here BEFORE any commit so ``apply_config`` is all-or-nothing:
+
+        1. D8 exempt-overlap: a delegate tool must never also be profile-exempt (an
+           exempt delegate would skip the tier ladder). Mirrors the ``__init__``
+           check against the candidate's normalized delegate set.
+        2. ``frequency_weights`` parse trial: the full glob-position and
+           non-negative/finite weight validation lives in ``FrequencyTracker``,
+           not in ``__post_init__``. Trial-parse the candidate so a malformed map
+           is caught here, before the guard's tracker is reconfigured.
+        """
+        if self._profile is not None:
+            candidate_delegates = frozenset(
+                n
+                for n in (self._normalize_tool_name(raw) for raw in new_config.delegate_tool_names)
+                if n
+            )
+            exempt_overlap = candidate_delegates & self._profile.tool_exempt_list
+            if exempt_overlap:
+                raise ValueError(
+                    f"delegate tool name(s) {sorted(exempt_overlap)} appear in the profile "
+                    f"exempt list; a delegate must not be exempt (it would skip the tier ladder)"
+                )
+        # Weight-parse trial: a throwaway FrequencyTracker re-runs the full weight
+        # validation with no side effects beyond the parse, so a malformed
+        # frequency_weights map raises here, before any commit.
+        from petasos.session.frequency import FrequencyTracker
+
+        FrequencyTracker(new_config)
+
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """PET-126: live-reconfigure the guard in place (spec D2/D5).
+
+        Calls ``validate_config`` FIRST, so a D8 violation or a malformed
+        ``frequency_weights`` map aborts before any mutation. Then:
+
+        - merge-preserves ``session_secret`` into the guard's OWN ``_config`` via
+          ``replace(new_config, session_secret=<live>)`` so ``_read_state``'s mint
+          decision stays in lockstep with the immutable tracker secret. A
+          ``None``<->non-None presence flip would otherwise force tier3 fail-secure
+          on every session (FREQ-03, Decision 2);
+        - recomputes ``_delegate_tool_names`` through the guard's own normalizer;
+        - resizes the ``_spawn_budget`` window in place (preserving counters);
+        - delegates to its OWN ``_frequency_tracker.apply_config`` (which holds the
+          tracker secret immutable).
+
+        Preserved: ``SpawnBudget._events`` / ``_last_sweep``, the guard tracker's
+        session/tombstone state, and ``_config.session_secret``.
+        """
+        self.validate_config(new_config)
+        self._config = replace(new_config, session_secret=self._config.session_secret)
+        self._delegate_tool_names = frozenset(
+            n
+            for n in (self._normalize_tool_name(raw) for raw in new_config.delegate_tool_names)
+            if n
+        )
+        self._spawn_budget.set_window(new_config.delegate_fanout_window_seconds)
+        self._frequency_tracker.apply_config(self._config)
 
     async def evaluate(
         self,

--- a/petasos/session/lineage.py
+++ b/petasos/session/lineage.py
@@ -40,6 +40,21 @@ class LineageRegistry:
         self._lock = threading.Lock()
         self._edges: dict[str, tuple[str, float]] = {}
 
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """PET-126: rebind the cached bounds in place, preserving ``_edges``.
+
+        ``_max_depth`` / ``_max_edges`` / ``_edge_ttl`` are cached at construction
+        and read live in ``register`` / ``ancestors`` / ``is_pinned``. The rebind
+        runs under ``_lock`` (the same lock those reads take), which is the
+        happens-before for the next live scalar read. The load-bearing lock-order
+        invariant is preserved: this method touches only registry state and never
+        calls into ``FrequencyTracker`` (spec D10).
+        """
+        with self._lock:
+            self._max_depth = new_config.lineage_max_depth
+            self._max_edges = new_config.lineage_max_edges
+            self._edge_ttl = new_config.lineage_edge_ttl_seconds
+
     def register(self, child: str, parent: str) -> None:
         """Record (or re-parent) the ``child -> parent`` edge.
 

--- a/tests/test_console_reload.py
+++ b/tests/test_console_reload.py
@@ -1,0 +1,247 @@
+"""PET-126: cross-process config reload (petasos.console._reload) + gateway wiring.
+
+The _reload unit tests drive ``read_changed_section`` / ``commit_seen`` against a
+tmp config via ``HERMES_HOME`` (tier-1 resolution; no real Hermes install). The
+gateway tests import the reference plugin and exercise ``_build_config_from_section``
+and ``_maybe_reconfigure`` (two-phase apply, fail-safe keep-last-good).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib.util
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import petasos.console._reload as reload_mod
+from petasos.config import PetasosConfig
+from petasos.console._reload import commit_seen, read_changed_section
+from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import MinimalScanner
+from petasos.session.frequency import FrequencyTracker
+from petasos.session.guard import ToolCallGuard
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterator
+
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet126", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_config(path: Path, petasos_section: dict[str, Any] | None) -> None:
+    import yaml
+
+    data: dict[str, Any] = {"model": {"provider": "test"}}
+    if petasos_section is not None:
+        data["petasos"] = petasos_section
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # Cache is keyed by (mtime_ns, size), not path — reset so a fresh tmp file
+    # can't be served a coincidentally-matching stale key.
+    reload_mod._reset_reload_cache()
+    for var in ("PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY", "PETASOS_LICENSE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+    reload_mod._reset_reload_cache()
+
+
+@pytest.fixture()
+def cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path / "config.yaml"
+
+
+# ── _reload: change detection + peek/commit ──────────────────────────────────
+
+
+def test_reload_picks_up_changed_section_within_ttl(cfg: Path) -> None:
+    _write_config(cfg, petasos_section={"profile_name": "general"})
+    res = read_changed_section()
+    assert res is not None
+    section, _key = res
+    assert section.get("profile_name") == "general"
+
+
+def test_reload_ignores_unchanged_file(cfg: Path) -> None:
+    _write_config(cfg, petasos_section={"profile_name": "general"})
+    res = read_changed_section()
+    assert res is not None
+    commit_seen(res[1])
+    # Same (mtime, size) within TTL after a commit -> no change.
+    assert read_changed_section() is None
+
+
+def test_reload_apply_failure_reattempts(cfg: Path) -> None:
+    # Regression for PET-126 (edge-cases F-2): without commit_seen the same change
+    # is re-offered, so a failed apply can never silently pin a stale config.
+    _write_config(cfg, petasos_section={"profile_name": "general"})
+    r1 = read_changed_section()
+    assert r1 is not None
+    r2 = read_changed_section()  # no commit -> re-attempt
+    assert r2 is not None
+    assert r2[1] == r1[1]
+    commit_seen(r1[1])
+    assert read_changed_section() is None  # committed -> quiet
+
+
+def test_reload_same_size_same_tick_change_observed(
+    cfg: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import os
+
+    # TTL=0 so the section-compare (not the mtime/size key) is the change signal.
+    monkeypatch.setattr(reload_mod, "_RELOAD_TTL_S", 0.0)
+    _write_config(cfg, petasos_section={"profile_name": "general"})
+    res1 = read_changed_section()
+    assert res1 is not None
+    commit_seen(res1[1])
+    st = cfg.stat()
+
+    # Rewrite to a same-byte-size value, then force the same mtime tick.
+    _write_config(cfg, petasos_section={"profile_name": "relaxed"})
+    os.utime(cfg, ns=(st.st_atime_ns, st.st_mtime_ns))
+    assert cfg.stat().st_size == st.st_size
+
+    res2 = read_changed_section()
+    assert res2 is not None
+    assert res2[0].get("profile_name") == "relaxed"
+
+
+def test_reload_empty_section_is_noop(cfg: Path) -> None:
+    # A wiped petasos: section (Windows UI model switcher, D-WIN) is "no change".
+    _write_config(cfg, petasos_section={})
+    assert read_changed_section() is None
+    assert reload_mod._RELOAD_CACHE is None  # key not advanced
+
+
+def test_reload_wiped_section_keeps_last_good(cfg: Path) -> None:
+    _write_config(cfg, petasos_section={"profile_name": "general"})
+    res = read_changed_section()
+    assert res is not None
+    commit_seen(res[1])
+    # The model switcher removes the petasos: section entirely.
+    _write_config(cfg, petasos_section=None)
+    assert read_changed_section() is None  # last-good kept, never reset to defaults
+
+
+def test_reload_malformed_yaml_keeps_last_good(cfg: Path) -> None:
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text("petasos: : : not valid yaml ::\n", encoding="utf-8")
+    assert read_changed_section() is None
+
+
+def test_reload_and_armed_resolve_same_path() -> None:
+    # Both caches must anchor on the SAME resolver so write and read never diverge.
+    import petasos.console._armed as armed_mod
+
+    reload_fn = reload_mod.resolve_hermes_config_path  # type: ignore[attr-defined]
+    armed_fn = armed_mod.resolve_hermes_config_path  # type: ignore[attr-defined]
+    assert reload_fn is armed_fn
+
+
+# ── gateway: _build_config_from_section env overlay (Decision 10) ─────────────
+
+
+def test_build_config_from_section_preserves_env_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ref = _import_reference_plugin()
+    secret = b"x" * 32
+    monkeypatch.setenv("PETASOS_SESSION_SECRET", base64.b64encode(secret).decode())
+    monkeypatch.setenv("PETASOS_HASH_KEY", "secret-key")
+
+    built = ref._build_config_from_section({"redaction_mode": "hash", "anonymize": True})
+    assert built.session_secret == secret
+    assert built.hash_key == "secret-key"
+    assert built.anonymize is True  # hash_key present -> no defang
+
+    # Without hash_key, a redaction_mode=hash section downgrades to anonymize=False
+    # (matching boot), rather than raising.
+    monkeypatch.delenv("PETASOS_HASH_KEY", raising=False)
+    downgraded = ref._build_config_from_section({"redaction_mode": "hash", "anonymize": True})
+    assert downgraded.anonymize is False
+    assert downgraded.redaction_mode == "hash"
+
+
+# ── gateway: _maybe_reconfigure two-phase apply + fail-safe ───────────────────
+
+
+def _wire_gateway(
+    ref: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Pipeline, ToolCallGuard]:
+    cfg = PetasosConfig(fail_mode="degraded")
+    pipe = Pipeline(scanners=[MinimalScanner()], config=cfg)
+    tracker = FrequencyTracker(cfg)
+    guard = ToolCallGuard(pipe, tracker, cfg, lineage=None)
+    monkeypatch.setattr(ref, "_pipeline", pipe)
+    monkeypatch.setattr(ref, "_guard", guard)
+    monkeypatch.setattr(ref, "_lineage_registry", None)
+    monkeypatch.setattr(ref, "_initialized", True)
+    # Run the apply coroutine inline instead of on the background loop thread.
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+    return pipe, guard
+
+
+def test_maybe_reconfigure_applies_pipeline_and_guard_atomically(
+    cfg: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ref = _import_reference_plugin()
+    pipe, guard = _wire_gateway(ref, monkeypatch)
+
+    # A clean change applies to BOTH the pipeline and the guard (Decision 4).
+    _write_config(cfg, petasos_section={"fail_mode": "closed"})
+    ref._maybe_reconfigure()
+    assert pipe.config.fail_mode == "closed"
+    assert guard._config.fail_mode == "closed"
+
+    # A config that passes from_dict but fails guard.validate_config (malformed
+    # frequency_weights) aborts in phase 1 -> neither object is mutated.
+    reload_mod._reset_reload_cache()
+    before_pipe = pipe.config
+    before_guard = guard._config
+    _write_config(cfg, petasos_section={"frequency_weights": {"x": -1.0}})
+    ref._maybe_reconfigure()
+    assert pipe.config is before_pipe
+    assert guard._config is before_guard
+
+
+def test_reload_failure_log_rate_limited(
+    cfg: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    ref = _import_reference_plugin()
+    ref._reset_reload_logs()
+    # A persistently-malformed section re-detects every call (never committed).
+    _write_config(cfg, petasos_section={"redaction_mode": "bogus"})
+
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        ref._maybe_reconfigure()
+        ref._maybe_reconfigure()
+        ref._maybe_reconfigure()
+
+    fails = [r for r in caplog.records if "PETASOS_RELOAD_FAILED" in r.getMessage()]
+    assert len(fails) == 1  # rate-limited to one per 30s window, not one per call

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -43,3 +43,22 @@ async def test_update_config_routes_through_reconfigure(
     assert len(seen) == 1  # routed through reconfigure, not a bare _config assignment
     assert seen[0].fail_mode == "closed"
     assert pipe.config.fail_mode == "closed"  # live config actually swapped
+
+
+async def test_update_config_invalid_frequency_weights_returns_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # frequency_weights content passes from_dict but is validated inside
+    # reconfigure (FrequencyTracker.apply_config); the route must surface a
+    # structured field error, not let the ValueError become a 500.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pipe = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig())
+    handlers = ConsoleHandlers(pipe)
+    before = pipe.config
+
+    result, errors = await handlers.update_config({"frequency_weights": {"x": -1.0}})
+
+    assert result is None
+    assert errors is not None
+    assert errors[0]["message"]  # non-empty error message
+    assert pipe.config is before  # reconfigure aborted atomically; live config unchanged

--- a/tests/test_console_server.py
+++ b/tests/test_console_server.py
@@ -1,0 +1,45 @@
+"""PET-126: ConsoleHandlers.update_config routes through Pipeline.reconfigure.
+
+The standalone (shared-pipeline) console path must use the same propagation
+primitive as the gateway, not the bare ``self.pipeline._config = validated`` that
+silently left subcomponents on the old config.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console.server import ConsoleHandlers  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_update_config_routes_through_reconfigure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Contain the persist write to a tmp config.yaml (no real Hermes home touched).
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pipe = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    handlers = ConsoleHandlers(pipe)
+
+    seen: list[PetasosConfig] = []
+    real_reconfigure = Pipeline.reconfigure
+
+    def spy(self: Pipeline, new_config: PetasosConfig) -> None:
+        seen.append(new_config)
+        real_reconfigure(self, new_config)
+
+    monkeypatch.setattr(Pipeline, "reconfigure", spy)
+
+    result, errors = await handlers.update_config({"fail_mode": "closed"})
+
+    assert errors is None
+    assert result is not None
+    assert len(seen) == 1  # routed through reconfigure, not a bare _config assignment
+    assert seen[0].fail_mode == "closed"
+    assert pipe.config.fail_mode == "closed"  # live config actually swapped

--- a/tests/test_guard_reconfigure.py
+++ b/tests/test_guard_reconfigure.py
@@ -1,0 +1,193 @@
+"""PET-126: ToolCallGuard / SpawnBudget / LineageRegistry live reconfigure.
+
+The gateway constructs its OWN tracker, guard, and lineage registry beyond the
+pipeline (Decision 4), so a live reload must reconfigure all of them. These tests
+pin: delegate-set recognition, fan-out window resize (counters preserved), tracker
+propagation, the two-phase D8 validation gate, the immutable session_secret, and
+lineage-bound rebinding with edge preservation.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+from petasos.session.frequency import FrequencyTracker
+from petasos.session.guard import SpawnBudget, ToolCallGuard
+from petasos.session.lineage import LineageRegistry
+from petasos.session.profiles import ResolvedProfile
+
+
+def _cfg(**overrides: object) -> PetasosConfig:
+    defaults: dict[str, object] = {
+        "frequency_enabled": True,
+        "escalation_enabled": True,
+        "tool_guard_enabled": True,
+    }
+    defaults.update(overrides)
+    return PetasosConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _profile(*, tool_exempt_list: frozenset[str] = frozenset()) -> ResolvedProfile:
+    return ResolvedProfile(
+        name="test",
+        suppress_rules=frozenset(),
+        severity_overrides=MappingProxyType({}),
+        confidence_floor=0.0,
+        tier_thresholds=None,
+        pii_entities_extra=(),
+        tool_exempt_list=tool_exempt_list,
+        tool_alias_map=MappingProxyType({}),
+    )
+
+
+def _guard(
+    *, config: PetasosConfig | None = None, profile: ResolvedProfile | None = None
+) -> ToolCallGuard:
+    cfg = config or _cfg()
+    pipe = Pipeline(config=cfg)
+    tracker = FrequencyTracker(cfg)
+    return ToolCallGuard(pipe, tracker, cfg, profile=profile)
+
+
+async def test_guard_apply_config_updates_delegate_set() -> None:
+    # Regression for PET-126: the gateway guard caches the normalized delegate set
+    # at construction; a reload must recompute it so the fan-out gate tracks the
+    # new tool name and releases the old one.
+    guard = _guard(
+        config=_cfg(
+            delegate_fanout_enabled=True,
+            delegate_max_fanout_per_window=1,
+            delegate_tool_names=("delegate_task",),
+        )
+    )
+    guard.apply_config(
+        _cfg(
+            delegate_fanout_enabled=True,
+            delegate_max_fanout_per_window=1,
+            delegate_tool_names=("spawn_agent",),
+        )
+    )
+
+    # The old delegate is no longer gated: repeated calls stay allowed.
+    assert (await guard.evaluate("delegate_task", {}, "s1")).allowed
+    assert (await guard.evaluate("delegate_task", {}, "s1")).allowed
+
+    # The new delegate is gated: the 2nd call exceeds the budget of 1.
+    assert (await guard.evaluate("spawn_agent", {}, "s2")).allowed
+    blocked = await guard.evaluate("spawn_agent", {}, "s2")
+    assert not blocked.allowed
+    assert "fan-out" in blocked.reason
+
+
+def test_guard_apply_config_resizes_fanout_window_preserving_counters() -> None:
+    guard = _guard(config=_cfg(delegate_fanout_window_seconds=60.0))
+    budget = guard._spawn_budget
+    assert budget.try_consume("sess", cap=5, now=100.0) is True
+    assert "sess" in budget._events
+    assert budget._last_sweep == 100.0
+
+    guard.apply_config(_cfg(delegate_fanout_window_seconds=10.0))
+
+    # set_window rebinds _window only; counters/sweep state are preserved.
+    assert budget._window == 10.0
+    assert "sess" in budget._events
+    assert budget._last_sweep == 100.0
+
+    # An event from t=100 is in-window under the old 60s window but expires under
+    # the shrunk 10s window: at t=111 it is evicted, so a cap-1 consume succeeds.
+    assert budget.try_consume("sess", cap=1, now=111.0) is True
+
+
+def test_guard_set_window_evicts_under_shrunk_window_directly() -> None:
+    # Focused SpawnBudget unit: a timestamp inside the old window is evicted once
+    # the window shrinks below its age (post-resize eviction).
+    budget = SpawnBudget(60.0)
+    assert budget.try_consume("s", cap=1, now=100.0) is True
+    # Under the 60s window, t=130 still sees the t=100 event -> cap-1 blocks.
+    assert budget.try_consume("s", cap=1, now=130.0) is False
+    budget.set_window(10.0)
+    # Under the 10s window, the t=100 event is 30s stale at t=130 -> evicted.
+    assert budget.try_consume("s", cap=1, now=130.0) is True
+
+
+def test_guard_apply_config_propagates_to_its_tracker() -> None:
+    # Decision 4: the guard owns a SEPARATE tracker; apply_config must reconfigure
+    # it (a frequency_weights change must change the guard tracker's scoring).
+    guard = _guard(config=_cfg(frequency_weights={"x": 5.0}))
+    tracker = guard._frequency_tracker
+    r1 = tracker.update("s1", ["x"])
+    assert r1.current_score == 5.0
+
+    guard.apply_config(_cfg(frequency_weights={"x": 25.0}))
+
+    assert tracker._config is guard._config  # tracker rebound to the guard's config
+    r2 = tracker.update("s1", ["x"])
+    assert r2.current_score > r1.current_score + 20  # ~5 (decayed) + 25 new weight
+
+
+def test_guard_validate_config_d8_violation_is_atomic() -> None:
+    # A delegate that is also profile-exempt would skip the tier ladder (D8).
+    # validate_config raises; apply_config (which calls it first) mutates nothing.
+    prof = _profile(tool_exempt_list=frozenset({"spawn_agent"}))
+    guard = _guard(config=_cfg(delegate_tool_names=("delegate_task",)), profile=prof)
+    bad = _cfg(delegate_tool_names=("spawn_agent",))
+
+    with pytest.raises(ValueError):
+        guard.validate_config(bad)
+
+    before_config = guard._config
+    before_delegates = guard._delegate_tool_names
+    with pytest.raises(ValueError):
+        guard.apply_config(bad)
+
+    assert guard._config is before_config
+    assert guard._delegate_tool_names == before_delegates
+    assert "spawn_agent" not in guard._delegate_tool_names
+
+
+def test_guard_apply_config_preserves_session_secret() -> None:
+    # A reload cfg carrying a differing/None session_secret must NOT rebind the
+    # guard tracker's _session_secret (FREQ-03, Decision 2): live tokens still
+    # verify and sessions do not flip to tier3.
+    secret = b"k" * 32
+    cfg = _cfg(session_secret=secret)
+    pipe = Pipeline(config=cfg, host_id="host-1")
+    tracker = FrequencyTracker(cfg)
+    guard = ToolCallGuard(pipe, tracker, cfg)
+
+    token = tracker.mint_token("sess", "host-1")
+    tracker.update(token, [])
+    assert guard._read_state("sess") is not None  # mint path works
+
+    # Presence flip to None.
+    guard.apply_config(_cfg(session_secret=None))
+    assert tracker._session_secret == secret  # immutable
+    assert guard._config.session_secret == secret  # merge-preserved
+    assert tracker.get_state(token) is not None  # token still verifies
+    assert guard._derive_tier("sess") != "tier3"  # no fail-secure flip
+
+    # A differing non-None secret is likewise preserved.
+    guard.apply_config(_cfg(session_secret=b"different" * 4))
+    assert tracker._session_secret == secret
+    assert guard._config.session_secret == secret
+    assert guard._derive_tier("sess") != "tier3"
+
+
+def test_lineage_registry_apply_config_updates_bounds() -> None:
+    # Changing lineage bounds via apply_config is observed by the next ancestor
+    # walk; existing edges survive.
+    reg = LineageRegistry(PetasosConfig(lineage_max_depth=2))
+    reg.register("a", "b")
+    reg.register("b", "c")
+    reg.register("c", "d")
+    assert reg.ancestors("a") == ["b", "c"]  # bounded to depth 2
+
+    reg.apply_config(PetasosConfig(lineage_max_depth=8))
+
+    assert reg._max_depth == 8
+    assert reg.ancestors("a") == ["b", "c", "d"]  # deeper walk after reconfigure
+    assert reg._edges  # edges preserved across reconfigure

--- a/tests/test_pipeline_reconfigure.py
+++ b/tests/test_pipeline_reconfigure.py
@@ -1,0 +1,246 @@
+"""PET-126: Pipeline.reconfigure hot-applies config to a live pipeline instance.
+
+Each test pins a vector that silently failed before: a Config Editor save swapped
+``pipeline._config`` but left subcomponents (FrequencyTracker scalars, AuditEmitter
+/ AlertManager config refs, the MinimalScanner decode flag) on the boot-time
+config. ``reconfigure`` propagates into all of them on the SAME instance without
+resetting accumulated session state.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from petasos._types import PipelineResult, ScanFinding, Severity
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import MinimalScanner
+
+
+def _pipe(config: PetasosConfig, *, scanner: MinimalScanner | None = None) -> Pipeline:
+    return Pipeline(scanners=[scanner or MinimalScanner()], config=config)
+
+
+def _pii_finding() -> ScanFinding:
+    return ScanFinding(
+        rule_id="petasos.presidio.person",
+        finding_type="pii",
+        severity=Severity.LOW,
+        confidence=0.9,
+        message="pii",
+        scanner_name="minimal",
+    )
+
+
+# ── frequency / escalation scalars (pins frequency.py cached-scalar staleness) ──
+
+
+def test_reconfigure_frequency_takes_effect_same_instance() -> None:
+    # Regression for PET-126: FrequencyTracker cached frequency_half_life_seconds /
+    # rolling_threshold as scalars at construction; a _config swap never updated them.
+    pipe = _pipe(PetasosConfig(frequency_half_life_seconds=60.0, rolling_threshold=10))
+    assert pipe._frequency_tracker._half_life == 60.0
+    assert pipe._frequency_tracker._rolling_threshold == 10
+
+    pipe.reconfigure(PetasosConfig(frequency_half_life_seconds=5.0, rolling_threshold=3))
+
+    assert pipe._frequency_tracker._half_life == 5.0
+    assert pipe._frequency_tracker._rolling_threshold == 3
+    assert pipe.config.frequency_half_life_seconds == 5.0
+
+
+def test_reconfigure_audit_verbosity_takes_effect() -> None:
+    # Regression for PET-126: AuditEmitter read audit_verbosity off a STALE _config.
+    pipe = _pipe(PetasosConfig(audit_verbosity="standard"))
+    result = PipelineResult(safe=True, findings=(), scanner_results=())
+
+    ev1 = pipe._audit_emitter.emit(result, "s1", None)
+    assert "findings" in ev1.payload  # standard verbosity carries the findings list
+
+    pipe.reconfigure(PetasosConfig(audit_verbosity="minimal"))
+
+    ev2 = pipe._audit_emitter.emit(result, "s1", None)
+    assert "findings" not in ev2.payload  # minimal verbosity drops it
+
+
+def test_reconfigure_alert_threshold_takes_effect() -> None:
+    # Regression for PET-126: AlertManager held a stale _config; alert_* thresholds
+    # never changed live. A single PII finding crosses a lowered volume threshold.
+    pipe = _pipe(PetasosConfig(alert_pii_volume_threshold=20))
+    am = pipe._alert_manager
+    result = PipelineResult(safe=True, findings=(_pii_finding(),), scanner_results=())
+
+    alerts = am.evaluate(result, "s1", None)
+    assert not any(a.rule_id == "pii_volume_spike" for a in alerts)
+
+    pipe.reconfigure(PetasosConfig(alert_pii_volume_threshold=1))
+
+    alerts2 = am.evaluate(result, "s1", None)
+    assert any(a.rule_id == "pii_volume_spike" for a in alerts2)
+
+
+def test_reconfigure_alert_ring_buffer_capacity_rebuilds_keeping_newest() -> None:
+    # A capacity shrink rebuilds _pii_ring_buffer retaining the MOST-recent items
+    # (ring-buffer recency), not the oldest.
+    pipe = _pipe(PetasosConfig(alert_ring_buffer_capacity=10))
+    am = pipe._alert_manager
+    for i in range(10):
+        am._pii_ring_buffer.append((float(i), i))
+
+    pipe.reconfigure(
+        PetasosConfig(
+            alert_ring_buffer_capacity=3,
+            alert_rapid_fire_count=3,
+            alert_cross_session_burst_count=3,
+        )
+    )
+
+    assert am._pii_ring_buffer.maxlen == 3
+    assert [count for _ts, count in am._pii_ring_buffer] == [7, 8, 9]
+
+
+def test_reconfigure_decode_payloads_changes_minimal_scanner() -> None:
+    # Flipping decode_encoded_payloads reaches the live MinimalScanner; a
+    # caller-supplied scanner keeps its other tunables AND its object identity.
+    scanner = MinimalScanner(
+        max_payload_bytes=12_345,
+        suppress_rules=frozenset({"petasos.syntactic.encoding.base64"}),
+        decode_encoded_payloads=True,
+    )
+    pipe = _pipe(PetasosConfig(decode_encoded_payloads=True), scanner=scanner)
+    assert pipe._minimal_scanner is scanner
+    assert scanner._decode_encoded_payloads is True
+
+    pipe.reconfigure(PetasosConfig(decode_encoded_payloads=False))
+
+    assert pipe._minimal_scanner is scanner  # identity preserved (not rebuilt)
+    assert scanner._decode_encoded_payloads is False
+    assert scanner._max_payload_bytes == 12_345  # other tunables untouched
+    assert "petasos.syntactic.encoding.base64" in scanner._suppress_rules
+
+
+def test_reconfigure_preserves_session_state() -> None:
+    # Drive a session into tier1, then reconfigure; counters must survive (no reset).
+    pipe = _pipe(PetasosConfig(frequency_weights={"r": 20.0}))
+    tracker = pipe._frequency_tracker
+    r = tracker.update("sess", ["r"])
+    assert r.current_score == 20.0
+    assert r.tier == "tier1"  # 20 >= tier1_threshold 15
+    assert tracker.size == 1
+
+    pipe.reconfigure(PetasosConfig(frequency_weights={"r": 20.0}, frequency_half_life_seconds=5.0))
+
+    assert tracker.size == 1  # session not dropped
+    state = tracker.get_state("sess")
+    assert state is not None
+    assert state.last_score == 20.0  # accumulated score preserved
+
+
+def test_reconfigure_session_secret_noop_with_warning(caplog: pytest.LogCaptureFixture) -> None:
+    secret = b"s" * 32
+    pipe = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(session_secret=secret),
+        host_id="h1",
+    )
+    tracker = pipe._frequency_tracker
+    token = tracker.mint_token("sess", "h1")
+    tracker.update(token, [])
+
+    # A differing non-None secret is ignored (live preserved) and warns once.
+    with caplog.at_level(logging.WARNING, logger="petasos.pipeline"):
+        pipe.reconfigure(PetasosConfig(session_secret=b"d" * 32))
+    warnings = [r for r in caplog.records if "session_secret" in r.getMessage()]
+    assert len(warnings) == 1
+    assert pipe.config.session_secret == secret
+    assert tracker._session_secret == secret  # never rebound (Decision 2)
+    assert tracker.get_state(token) is not None  # minted token still verifies
+
+    # An absent/None secret preserves silently (no warning).
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="petasos.pipeline"):
+        pipe.reconfigure(PetasosConfig(session_secret=None, frequency_half_life_seconds=7.0))
+    assert not [r for r in caplog.records if "session_secret" in r.getMessage()]
+    assert pipe.config.session_secret == secret
+    assert tracker._session_secret == secret
+
+
+def test_reconfigure_tombstone_cap_shrink_trims_immediately() -> None:
+    pipe = _pipe(PetasosConfig(max_terminated_tombstones=100))
+    tracker = pipe._frequency_tracker
+    for i in range(5):
+        tracker.terminate_session(f"s{i}")
+    assert tracker.tombstone_count == 5
+
+    pipe.reconfigure(PetasosConfig(max_terminated_tombstones=2))
+
+    assert tracker.tombstone_count == 2  # trimmed on apply, not lazily
+
+
+@pytest.mark.parametrize(
+    "bad_weights",
+    [
+        {"a.*.b": 1.0},  # glob '*' in a non-terminal position
+        {"x": -1.0},  # negative weight
+        {"y": float("inf")},  # non-finite weight
+    ],
+)
+def test_reconfigure_atomic_on_invalid_weights(bad_weights: dict[str, float]) -> None:
+    pipe = _pipe(PetasosConfig(frequency_half_life_seconds=60.0, audit_verbosity="standard"))
+    before = pipe.config
+
+    with pytest.raises(ValueError):
+        pipe.reconfigure(
+            PetasosConfig(
+                frequency_half_life_seconds=5.0,
+                frequency_weights=bad_weights,
+                audit_verbosity="verbose",
+            )
+        )
+
+    # The fail-prone tracker step runs first, so nothing downstream was touched.
+    assert pipe.config is before
+    assert pipe._frequency_tracker._half_life == 60.0
+    assert pipe._audit_emitter._config.audit_verbosity == "standard"
+
+
+def test_reconfigure_profile_switch_takes_effect() -> None:
+    # A config-driven profile follows profile_name on reconfigure (Decision 7).
+    pipe = _pipe(PetasosConfig(profile_name="general"))
+    assert pipe._default_profile is not None
+    assert pipe._default_profile.name == "general"
+
+    pipe.reconfigure(PetasosConfig(profile_name="research"))
+
+    assert pipe._default_profile is not None
+    assert pipe._default_profile.name == "research"
+
+
+def test_reconfigure_keeps_constructor_pinned_profile() -> None:
+    # A constructor-pinned profile is preserved across a profile_name change.
+    pipe = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(), profile="general")
+    assert pipe._default_profile is not None
+    assert pipe._default_profile.name == "general"
+
+    pipe.reconfigure(PetasosConfig(profile_name="research"))
+
+    assert pipe._default_profile is not None
+    assert pipe._default_profile.name == "general"  # pin wins over config
+
+
+def test_reconfigure_rejects_subfloor_or_unordered_tiers() -> None:
+    # The Tier-3 floor / ascending-order invariant runs in __post_init__, which
+    # from_dict (console + reload build path) re-runs BEFORE reconfigure can swap.
+    # An invalid tier config can therefore never be built to hand to reconfigure.
+    pipe = _pipe(PetasosConfig())
+    before = pipe.config
+    base = before.to_dict()
+
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict({**base, "tier3_threshold": 10.0})  # below TIER3_FLOOR
+    with pytest.raises(ValueError):
+        PetasosConfig.from_dict({**base, "tier1_threshold": 40.0})  # tier1 > tier2
+
+    assert pipe.config is before  # never reached reconfigure with an invalid config

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -130,6 +130,9 @@ def _drive(
     stub_guard = type("G", (), {"evaluate": lambda self, *a, **k: None})()
     monkeypatch.setattr(ref, "_guard", stub_guard)
     monkeypatch.setattr(ref, "_run_async", lambda coro: guard_result)
+    # PET-126: _pre_tool_call now checks for a live config.yaml change; neutralize it
+    # here so these egress tests stay isolated from the machine's real config.
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
     return ref._pre_tool_call(tool_name, args or {"text": "x"}, task_id="s1")
 
 

--- a/tests/test_subagent_plugin_wiring.py
+++ b/tests/test_subagent_plugin_wiring.py
@@ -63,6 +63,9 @@ def _prep_init(mod: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mod, "_init_error", None)
     monkeypatch.setattr(mod, "_pipeline", None)
     monkeypatch.setattr(mod, "_guard", None)
+    # PET-126: _pre_tool_call now checks for a live config.yaml change; neutralize it
+    # so these wiring tests stay isolated from the machine's real config.
+    monkeypatch.setattr(mod, "_maybe_reconfigure", lambda: None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `Pipeline.reconfigure(new_config)` — one propagation primitive that atomically swaps `_config` and pushes the new config into every subcomponent that cached it (FrequencyTracker / AuditEmitter / AlertManager / MinimalScanner decode), without resetting accumulated session state.
- Extends the PET-111 cross-process idiom: a new `console/_reload.py` TTL + `(mtime_ns, size)`-gated reader and gateway wiring so the Hermes gateway picks up a `config.yaml` change on a running session (pipeline + guard + lineage + egress), fail-safe to last-good.
- Routes `ConsoleHandlers.update_config` through `reconfigure` so the standalone console path is fixed by the same primitive (no more bare `self.pipeline._config = validated`).

Closes the bug where an operator loosened a frequency/escalation/audit/alert knob mid-session and saw nothing change: those fields silently did not take effect until a new session.

## Layered defense / atomicity
- **In-process**: `reconfigure` merge-preserves the restart-required `session_secret` (warn-on-differing-non-None, never a silent half-apply), applies the only fail-prone step (the `frequency_weights` re-parse) **first** so a malformed map aborts before any state is touched, then the infallible steps, then commits the swap + re-resolves the profile with constructor precedence.
- **Cross-object (gateway)**: `_apply_reconfigure` is two-phase — `guard.validate_config` (D8 overlap + weight trial, no mutation) before any commit, then `pipeline.reconfigure` + `guard.apply_config` + `lineage.apply_config` + egress recompute, as one loop-serialized unit. `session_secret` is held immutable at both the tracker and guard level (FREQ-03).
- **D-WIN**: a wiped/empty `petasos:` section is a no-op (keep last-good), never an all-defaults reset. Peek + commit-on-success means a failed apply is retried, never silently pinning a stale config.

## Files changed

| File | Change |
|------|--------|
| `petasos/pipeline.py` | Adds `reconfigure`; stores `_profile_arg` for re-resolution |
| `petasos/session/frequency.py` | Adds `apply_config` (staged weight parse, commit under `_lock`, immutable secret, tombstone-cap trim) |
| `petasos/session/guard.py` | Adds `validate_config` + `apply_config`; `SpawnBudget.set_window` |
| `petasos/session/lineage.py` | Adds `apply_config` (rebind bounds, preserve edges) |
| `petasos/session/audit.py`, `alerting.py` | Adds `apply_config` (rebind `_config`; alerting rebuilds the PII ring buffer on capacity change keeping newest) |
| `petasos/scanners/minimal.py` | Adds `set_decode_encoded_payloads` (in-place, preserves identity/tunables) |
| `petasos/console/_reload.py` | New: cross-process change reader (peek + commit-on-success, same-tick guard, D-WIN) |
| `docs/deployment/reference_plugin/__init__.py` | `_build_config_from_section`, `_apply_reconfigure`, `_maybe_reconfigure`, rate-limited attribution/failure logs |
| `petasos/console/server.py` | `update_config` routes through `reconfigure` |
| `tests/test_pipeline_reconfigure.py`, `test_guard_reconfigure.py`, `test_console_reload.py`, `test_console_server.py` | New regression tests |
| `tests/test_reference_plugin_egress.py`, `test_subagent_plugin_wiring.py` | Neutralize the new reconfigure check in pre-existing `_pre_tool_call` paths |

## Test plan
- [x] `C:\python310\python.exe -m pytest -p no:cacheprovider -k "not test_default_ignorable_rejected"` — 1705 passed, 41 skipped, 1 deselected, 1 xfailed (full output: docs/specs/TODO/PET-126.test-output.txt)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy --strict .` — clean
- [x] `test_default_ignorable_rejected` deselected (pre-existing local 3.10 / Unicode-13 failure, unrelated)

## Security note (PET-126 Decision 8)
This widens the PET-111 live re-read from one bit to the whole hot-swappable config. It adds **no** new guard enforcement and must not regress the PET-125 config-out-of-reach boundary (doc-led; guard path-blocklisting was rejected). Each applied cross-process reconfigure emits a rate-limited attribution WARNING. Do not present the broadened re-read as fully shipped without PET-125's boundary in view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live configuration hot-reload: detects changes and reconfigures the running pipeline, guards, and related components without restart.
  * Runtime reconfiguration now updates frequency tuning, guard validation/delegate rules, audit verbosity, alert thresholds/ring buffer capacity, and scanner decode behavior.
  * Environment overlays support for secrets/hash settings during configuration builds.
* **Bug Fixes**
  * Reload/apply failures keep the last known-good configuration and avoid blocking tool calls; reload failure warnings are rate-limited.
* **Tests**
  * Added coverage for reload change detection (including edge cases), atomic multi-phase reconfiguration, secret preservation, and rate-limited failure logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->