### PR TITLE
feat(pet-13): collapse Config Editor sections by default; About copy

### DIFF
--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -654,7 +654,9 @@ class ConfigSection:
 
 
 # Ordered tuple — tuple position IS the canonical render order.
-# Common controls first/open (PET-114 D3), advanced groups after, collapsed.
+# Every section defaults collapsed: the Config Editor opens fully collapsed so
+# each group's detail is requested on click (supersedes PET-114 D3's open-first
+# five). Tuple position is still the canonical render order.
 # The 11 keys are exactly the in-use `section` values on the _FIELD_META fields.
 # The "unknown" missing-metadata sentinel is deliberately NOT a registry entry:
 # a field that ever synthesizes section="unknown" is rendered by the frontend's
@@ -667,7 +669,7 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
         "Pick a ready-made settings bundle for your use case (coding agent,"
         " customer service, and so on) instead of tuning every knob by hand."
         " Start here if you are not sure what to change.",
-        default_collapsed=False,
+        default_collapsed=True,
     ),
     ConfigSection(
         "anonymization",
@@ -675,7 +677,7 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
         "Mask personal details (names, emails, card numbers) the scanners find"
         " so they do not pass through in the clear. Leave on if your agent"
         " handles real user data.",
-        default_collapsed=False,
+        default_collapsed=True,
     ),
     ConfigSection(
         "fail_mode",
@@ -683,7 +685,7 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
         "Choose what happens to a message when a scanner crashes or times out:"
         " block it, let it through, or block only on a hard failure. The safe"
         " default blocks on failure.",
-        default_collapsed=False,
+        default_collapsed=True,
     ),
     ConfigSection(
         "tool_guard",
@@ -691,7 +693,7 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
         "Check the tools your agent tries to call and cap how fast it can spawn"
         " sub-agents, before any of it runs. Tighten this for agents that touch"
         " the file system or the shell.",
-        default_collapsed=False,
+        default_collapsed=True,
     ),
     ConfigSection(
         "scanning",
@@ -699,7 +701,7 @@ _SECTION_REGISTRY: typing.Final[tuple[ConfigSection, ...]] = (
         "The core scan settings: which direction to scan (incoming, outgoing, or"
         " both) and how widely to look for personal data. Also sets per-scanner"
         " time limits and when to stop calling one that keeps failing.",
-        default_collapsed=False,
+        default_collapsed=True,
     ),
     ConfigSection(
         "normalization",

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1759,7 +1759,10 @@
         Pet.h("div", { className: "mono", dataset: { petVer: "1" }, ariaBusy: true, ariaLabel: "Loading version",
                        style: { fontSize: "11px", color: "var(--tx-faint)", marginTop: "4px" } },
           Pet.skel(48, 11)),
-        Pet.h("span", { className: "pill ok", style: { marginTop: "8px", height: "18px", fontSize: "10px" } }, "MIT License")
+        Pet.h("span", { className: "pill ok", style: { marginTop: "8px", height: "18px", fontSize: "10px" } }, "MIT License"),
+        Pet.h("p", { style: { fontSize: "12.5px", color: "var(--tx-mut)", lineHeight: "1.6", margin: "12px 0 0", maxWidth: "440px" } },
+          "Thank you for checking out the plugin! It is my hope that it helps extend trust to your agents, and assists you in enforcing your guardrails. May your Hermes Agent travel long and well."
+        )
       ),
     }));
 
@@ -1784,7 +1787,9 @@
         Pet.h("img", { className: "support-coffee", src: Pet.asset("img/coffee.webp"), alt: "A robot enjoying a hot cup of coffee" }),
         Pet.h("div", { style: { fontSize: "15px", fontWeight: "700", color: "var(--tx-bright)", marginBottom: "8px" } }, "Did Petasos prevent a disaster?"),
         Pet.h("div", { style: { fontSize: "12.5px", color: "var(--tx-mut)", lineHeight: "1.6", maxWidth: "400px", margin: "0 auto 16px" } },
-          "Every feature is free, forever. If this saved your team from a bad day, a coffee keeps the lights on."
+          "Every feature is free, forever.",
+          Pet.h("br"),
+          "If this saved your team from a bad day, a coffee keeps the lights on."
         ),
         Pet.h("a", { href: "https://github.com/sponsors/Vigil-Harbor", target: "_blank", rel: "noopener", className: "btn btn-primary", style: { textDecoration: "none", display: "inline-flex" } },
           Pet.Icon("caduceus"), " Buy us a coffee"

--- a/tests/test_config_meta.py
+++ b/tests/test_config_meta.py
@@ -29,6 +29,8 @@ _EXPECTED_SECTION_ORDER = [
     "alerting",
     "session",
 ]
+# Historical PET-114 D3 common/advanced partition. All sections now default
+# collapsed (see test_all_sections_default_collapsed); kept as the full key set.
 _ADVANCED_SECTIONS = {"normalization", "escalation", "frequency", "audit", "alerting", "session"}
 _COMMON_SECTIONS = {"profiles", "anonymization", "fail_mode", "tool_guard", "scanning"}
 
@@ -197,10 +199,9 @@ def test_section_registry_frozen_and_ordered() -> None:
     assert [s["key"] for s in sections] == _EXPECTED_SECTION_ORDER
     assert [s["key"] for s in generate_section_metadata()] == _EXPECTED_SECTION_ORDER
 
-    # Open-first coupling: the open sections are exactly the leading five.
-    assert [s["key"] for s in sections if not s["default_collapsed"]] == [
-        s["key"] for s in sections
-    ][:5]
+    # All sections default collapsed: the editor opens fully collapsed so each
+    # group is revealed on click (supersedes PET-114 D3's open-first five).
+    assert [s["key"] for s in sections if not s["default_collapsed"]] == []
 
     # Exact coverage (no drift): registry keys == the in-use field sections —
     # kills both a missing registry entry and a dead registry entry with no fields.
@@ -209,13 +210,13 @@ def test_section_registry_frozen_and_ordered() -> None:
     }
 
 
-def test_advanced_sections_default_collapsed() -> None:
-    # Brief-required: advanced sections carry the collapsed flag; common ones open.
+def test_all_sections_default_collapsed() -> None:
+    # Every section defaults collapsed: the Config Editor opens fully collapsed
+    # so each group's detail is requested on click. Supersedes PET-114 D3's
+    # common-open / advanced-collapsed partition.
     by_key = {s["key"]: s for s in generate_section_metadata()}
-    for key in _ADVANCED_SECTIONS:
+    for key in _COMMON_SECTIONS | _ADVANCED_SECTIONS:
         assert by_key[key]["default_collapsed"] is True, f"{key} should default collapsed"
-    for key in _COMMON_SECTIONS:
-        assert by_key[key]["default_collapsed"] is False, f"{key} should default open"
 
 
 def test_section_metadata_entry_shape() -> None:


### PR DESCRIPTION
Part of the standing PET-13 Console umbrella. Rebased onto current master (a37a5d6).

## Changes
- **Config Editor opens fully collapsed.** All 11 sections now default to `default_collapsed=True` (supersedes PET-114 D3's open-first-five partition); each group's detail is requested on click.
- **About panel thank-you copy.** A short message under the MIT License pill, integrated on top of PET-127's `[data-pet-ver]` skeleton version anchor (kept) and PET-128's About links.
- **Support card line break.** Splits "Every feature is free, forever." onto its own line above the coffee ask.

## Files
- `petasos/console/_config_meta.py`: flip the 5 common sections to collapsed.
- `petasos/console/static/petasos.js`: About thank-you paragraph, Support card line break.
- `tests/test_config_meta.py`: guard tests updated to assert all sections collapsed (replaces the advanced-only assertion).

## Rebase conflict resolution
The only conflict was the About version line. Kept master's PET-127 skeleton version anchor and appended the PET-13 thank-you message; did not revert the anchor to the old `"v..."` text.

## Test
`pytest tests/test_config_meta.py`: 18 passed, including the strict "zero non-collapsed sections" partition assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Interface**
  * Configuration Editor sections now default to the collapsed state, reducing initial visual clutter and providing a cleaner, more streamlined interface view.
  * The About panel's license display has been enhanced to include an extended thank-you message alongside the MIT License information.
  * Support section donation messaging has been reformatted with strategic line breaks for improved readability and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->