### PR TITLE
fix(pet-77): wire block-message formatter into the reference plugin shim

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -26,6 +26,10 @@ from typing import TYPE_CHECKING, Any
 
 from petasos._types import Severity  # PET-112: dep-light (enum + dataclasses, no ML imports)
 from petasos.normalize import canonicalize_tool_name  # PET-118: dep-light (re + unicodedata)
+from petasos.session.formatting import (  # PET-77: dep-light (string formatting over dataclasses)
+    format_block_message,
+    format_content_block,
+)
 
 if TYPE_CHECKING:
     from petasos import PetasosConfig
@@ -577,7 +581,9 @@ def _fallback_pre_tool_call(
                 )
                 return {
                     "action": "block",
-                    "message": (f"Security scan (init in progress): {worst.message}"),
+                    # PET-77: route through the library formatter (contract: [BLOCKED by Petasos]
+                    # prefix, tool name, NOT executed, top-finding clause).
+                    "message": format_content_block("init", tool_name, result.findings),
                 }
     except Exception as exc:
         logger.debug("Fallback scan failed: %s — allowing", exc)
@@ -751,16 +757,16 @@ def _pre_tool_call(
         )
         return {
             "action": "block",
-            "message": (
-                "All tool calls blocked for this session by security policy (Tier 3 escalation)."
-            ),
+            "message": format_block_message(result, tool_name),  # PET-77
         }
 
     if not result.allowed:
         logger.warning(
             "PETASOS_BLOCK tool=%s session=%s reason=%s", tool_name, session_id, result.reason
         )
-        return {"action": "block", "message": result.reason}
+        # PET-77: route through the formatter so internal reason strings (exempt-with-scan,
+        # tier2: tool calls blocked, ...) never reach the model.
+        return {"action": "block", "message": format_block_message(result, tool_name)}
 
     # PET-112: read-only tools never take a content block (both old blocks were
     # _is_dangerous-gated; preserved exactly).
@@ -784,9 +790,7 @@ def _pre_tool_call(
         )
         return {
             "action": "block",
-            "message": (
-                "Parameter scan unavailable (scanner degraded) — blocked by fail-mode policy."
-            ),
+            "message": format_content_block("degraded", tool_name, tuple(blocking)),  # PET-77
         }
 
     # 2. Non-PII finding (injection/command/structural/credential) at HIGH+ -> block ALL
@@ -802,7 +806,7 @@ def _pre_tool_call(
         )
         return {
             "action": "block",
-            "message": f"Parameter scan flagged unsafe content: {worst.message}",
+            "message": format_content_block("non_pii_param", tool_name, tuple(non_pii_blocking)),
         }
 
     # 3. PII at HIGH+ -> block ONLY egress sinks (D-EGRESS). Internal tools are exempt, so
@@ -817,7 +821,7 @@ def _pre_tool_call(
         )
         return {
             "action": "block",
-            "message": f"Security finding (PII, {worst.severity.name}): {worst.message}",
+            "message": format_content_block("pii_egress", tool_name, tuple(pii_blocking)),
         }
 
     return None

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -19,6 +19,7 @@ from petasos.session.audit import AuditEmitter
 from petasos.session.escalation import max_tier
 from petasos.session.formatting import (
     format_block_message,
+    format_content_block,
     format_pipeline_block_message,
     shorten_rule_id,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "FrequencyUpdateResult",
     "GuardResult",
     "format_block_message",
+    "format_content_block",
     "format_pipeline_block_message",
     "LicenseClaims",
     "LicenseState",

--- a/petasos/session/__init__.py
+++ b/petasos/session/__init__.py
@@ -11,6 +11,7 @@ from petasos.session.escalation import (
 )
 from petasos.session.formatting import (
     format_block_message,
+    format_content_block,
     format_pipeline_block_message,
     shorten_rule_id,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "LineageRegistry",
     "max_tier",
     "format_block_message",
+    "format_content_block",
     "format_pipeline_block_message",
     "LicenseClaims",
     "LicenseState",

--- a/petasos/session/formatting.py
+++ b/petasos/session/formatting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from petasos._types import PipelineResult, ScanFinding, Severity
 
@@ -20,6 +20,19 @@ _STRIP_PREFIX = "petasos.syntactic."
 _PREFIX = "[BLOCKED by Petasos]"
 
 _MAX_MESSAGE_LEN = 200
+
+# PET-77: the reference-plugin content-scan / init-fallback block sites fire after the
+# guard has returned allowed=True (or operate outside GuardResult), so they cannot reuse
+# format_block_message. format_content_block is keyed on the block decision the shim
+# already made (one of these paths) plus the findings that drove it.
+ContentBlockPath = Literal["init", "degraded", "non_pii_param", "pii_egress"]
+
+_CONTENT_REASON: dict[str, str] = {
+    "init": "Blocked by the initialization-time security scan.",
+    "degraded": "Parameter scan unavailable (scanner degraded); blocked by fail-mode policy.",
+    "non_pii_param": "Unsafe content detected in the tool parameters.",
+    "pii_egress": "Sensitive data (PII) was about to leave via this tool; the call was stopped.",
+}
 
 
 def shorten_rule_id(rule_id: str) -> str:
@@ -102,6 +115,32 @@ def format_pipeline_block_message(result: PipelineResult) -> str:
 
     clause = _top_finding_clause(result.findings)
     msg = f"{_PREFIX} Message blocked — content not forwarded."
+    if clause:
+        msg += " " + clause
+    return msg
+
+
+def format_content_block(
+    path: ContentBlockPath,
+    tool_name: str,
+    findings: tuple[ScanFinding, ...],
+) -> str:
+    """Format a model-facing block message for a reference-plugin content-scan or
+    init-fallback block.
+
+    Keyed on the block decision the shim already made (``path``) plus the findings
+    that drove it, because these sites fire after the guard has returned
+    ``allowed=True`` (or outside ``GuardResult`` entirely) and so cannot reuse
+    ``format_block_message`` (which returns ``""`` for an allowed result).
+
+    The reason lookup is fail-closed: an out-of-set ``path`` (a wiring typo in a
+    caller that mypy does not type-check at the import boundary) degrades to a valid
+    ``[BLOCKED by Petasos]`` message rather than raising, honoring the
+    pipeline-never-throws invariant.
+    """
+    reason = _CONTENT_REASON.get(path, "Blocked by a security policy.")
+    clause = _top_finding_clause(findings)
+    msg = f"{_PREFIX} Tool '{tool_name}' was NOT executed. {reason}"
     if clause:
         msg += " " + clause
     return msg

--- a/tests/test_reference_plugin_block_messages.py
+++ b/tests/test_reference_plugin_block_messages.py
@@ -1,0 +1,407 @@
+"""PET-77: the reference plugin shim must return the [BLOCKED by Petasos] contract.
+
+The block-message formatter (``petasos/session/formatting.py``) was built and tested
+as a library module in PR #50, but the shim that actually returns block messages to
+the model was never wired to it: every block site emitted a raw, unattributed string
+(``Security finding (PII, ...)``, ``Parameter scan flagged unsafe content: ...``,
+``result.reason``, ...). The model could not tell a tool was blocked and confabulated.
+
+This module is the regression + deploy-parity guard the original close lacked:
+
+  A. Contract tests drive ``_pre_tool_call`` / ``_fallback_pre_tool_call`` down each of
+     the six block sites and assert the formatted, attributed message.
+  B. Deploy-parity tests read the in-repo shim source and assert the formatter is
+     imported and called at every site, so a future edit cannot silently regress the
+     contract (mirrors the PET-106 ``tests/test_ci_extras_lanes.py`` invariant style).
+
+Backend-free: the guard is stubbed and ``_run_async`` is monkeypatched, exactly like
+``tests/test_reference_plugin_egress.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from petasos import GuardResult, ScanFinding, ScanResult, Severity
+from petasos.normalize import canonicalize_tool_name
+
+if TYPE_CHECKING:
+    import types
+
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+_PREFIX = "[BLOCKED by Petasos]"
+_EGRESS = frozenset({canonicalize_tool_name(t) for t in ("send_email", "http_request")})
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PETASOS_LICENSE_KEY", "PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet77", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Finding + GuardResult builders (mirror tests/test_reference_plugin_egress.py)
+# ---------------------------------------------------------------------------
+
+
+def _pii(severity: Severity, *, confidence: float = 0.9) -> ScanFinding:
+    return ScanFinding(
+        rule_id="petasos.presidio.person",
+        finding_type="pii",
+        severity=severity,
+        confidence=confidence,
+        message=f"PII detected: PERSON ({severity.name})",
+        scanner_name="presidio",
+    )
+
+
+def _non_pii(
+    finding_type: str, severity: Severity = Severity.HIGH, *, message: str | None = None
+) -> ScanFinding:
+    return ScanFinding(
+        rule_id=f"petasos.{finding_type or 'unknown'}.x",
+        finding_type=finding_type,
+        severity=severity,
+        confidence=0.9,
+        message=message if message is not None else f"{finding_type or 'untyped'} finding",
+        scanner_name="minimal",
+    )
+
+
+def _guard_result(
+    *,
+    findings: tuple[ScanFinding, ...] = (),
+    tier: str = "none",
+    allowed: bool = True,
+    reason: str = "allowed",
+    param_scan_unsafe: bool = False,
+    param_scan_degraded: bool = False,
+) -> GuardResult:
+    return GuardResult(
+        allowed=allowed,
+        reason=reason,
+        findings=findings,
+        tier=tier,
+        param_scan_unsafe=param_scan_unsafe,
+        param_scan_degraded=param_scan_degraded,
+    )
+
+
+def _drive(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    guard_result: GuardResult,
+    *,
+    egress: frozenset[str] = _EGRESS,
+    args: dict[str, object] | None = None,
+) -> Any:
+    """Drive ``_pre_tool_call`` against a crafted GuardResult on a freshly imported,
+    post-init, armed plugin module. Returns the block dict or None."""
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_egress_sink_tools", egress)
+    stub_guard = type("G", (), {"evaluate": lambda self, *a, **k: None})()
+    monkeypatch.setattr(ref, "_guard", stub_guard)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: guard_result)
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+    return ref._pre_tool_call(tool_name, args or {"text": "x"}, task_id="s1")
+
+
+def _drive_fallback(
+    monkeypatch: pytest.MonkeyPatch, tool_name: str, finding: ScanFinding | None
+) -> Any:
+    """Drive ``_fallback_pre_tool_call`` (the init-window path) with a stub scanner."""
+    ref = _import_reference_plugin()
+
+    class _Stub:
+        name = "minimal"
+
+        async def scan(
+            self, text: str, *, direction: str = "inbound", session_id: str | None = None
+        ) -> ScanResult:
+            return ScanResult(scanner_name="minimal", findings=(finding,) if finding else ())
+
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+    monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: _Stub())
+    return ref._fallback_pre_tool_call(tool_name, {"text": "x"}, "s1")
+
+
+# ---------------------------------------------------------------------------
+# A. Contract tests — one per enforcement path
+# ---------------------------------------------------------------------------
+
+
+def test_tier3_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: tier3 termination carries the contract (was raw
+    # "All tool calls blocked ... (Tier 3 escalation).").
+    out = _drive(
+        monkeypatch,
+        "read_file",  # tier3 is checked before the dangerous-tool gate
+        _guard_result(tier="tier3", allowed=False, reason="session terminated (tier3)"),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "read_file" in msg and "NOT executed" in msg
+    assert "tier3" in msg and "All tool calls are blocked" in msg
+    assert "Tier 3 escalation" not in msg  # the old raw string is gone
+
+
+def test_explicit_block_tier2_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: an explicit (not-allowed) tier2 block routes through the
+    # formatter; the internal reason string must not appear.
+    out = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(
+            allowed=False,
+            tier="tier2",
+            reason="tier2: tool calls blocked",
+            findings=(_non_pii("injection", Severity.HIGH),),
+        ),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "tier2" in msg
+    assert "Top finding:" in msg and "(HIGH)" in msg
+    assert "tier2: tool calls blocked" not in msg
+
+
+def test_explicit_block_catch_all_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: the L763 result.reason leak (exempt-with-scan, allowed, ...)
+    # is replaced by a contract message via the catch-all formatter branch.
+    out = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(allowed=False, reason="exempt-with-scan"),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "exempt-with-scan" not in msg
+
+
+def test_degraded_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: the scanner-degraded fail-mode block carries the contract.
+    out = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(param_scan_unsafe=True, param_scan_degraded=True),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "degraded" in msg.lower()
+    assert "Top finding:" not in msg  # no blocking findings on this sub-path
+
+
+def test_non_pii_param_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: a non-PII HIGH+ param finding blocks with the contract
+    # (was raw "Parameter scan flagged unsafe content: ...").
+    out = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(findings=(_non_pii("injection", Severity.HIGH),), param_scan_unsafe=True),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "injection" in msg and "(HIGH)" in msg
+    assert "Parameter scan flagged unsafe content" not in msg
+
+
+def test_pii_egress_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: a PII finding to an egress sink blocks with the contract
+    # (was raw "Security finding (PII, ...)").
+    out = _drive(
+        monkeypatch,
+        "send_email",
+        _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "send_email" in msg and "NOT executed" in msg
+    assert "(CRITICAL)" in msg and "PII" in msg
+    assert "Security finding (PII," not in msg
+
+
+def test_init_fallback_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: the init-window fallback block carries the contract
+    # (was raw "Security scan (init in progress): ...").
+    out = _drive_fallback(monkeypatch, "write_file", _non_pii("injection", Severity.CRITICAL))
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "Top finding:" in msg
+    assert "Security scan (init in progress)" not in msg
+
+
+def test_no_internal_reason_strings_leak(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: no internal reason string or raw block string reaches the
+    # model across every enforcement path, AND a unique sentinel reason is never echoed
+    # (pins the structural "reason is never echoed" property, not just the known strings).
+    messages: list[str] = []
+    messages.append(
+        _drive(
+            monkeypatch,
+            "read_file",
+            _guard_result(tier="tier3", allowed=False, reason="session terminated (tier3)"),
+        )["message"]
+    )
+    messages.append(
+        _drive(
+            monkeypatch,
+            "write_file",
+            _guard_result(
+                allowed=False,
+                tier="tier2",
+                reason="tier2: tool calls blocked",
+                findings=(_non_pii("injection", Severity.HIGH),),
+            ),
+        )["message"]
+    )
+    messages.append(
+        _drive(monkeypatch, "write_file", _guard_result(allowed=False, reason="exempt-with-scan"))[
+            "message"
+        ]
+    )
+    messages.append(
+        _drive(
+            monkeypatch,
+            "write_file",
+            _guard_result(param_scan_unsafe=True, param_scan_degraded=True),
+        )["message"]
+    )
+    messages.append(
+        _drive(
+            monkeypatch,
+            "write_file",
+            _guard_result(
+                findings=(_non_pii("injection", Severity.HIGH),), param_scan_unsafe=True
+            ),
+        )["message"]
+    )
+    messages.append(
+        _drive(
+            monkeypatch,
+            "send_email",
+            _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
+        )["message"]
+    )
+    messages.append(
+        _drive_fallback(monkeypatch, "write_file", _non_pii("injection", Severity.CRITICAL))[
+            "message"
+        ]
+    )
+
+    forbidden = (
+        "exempt-with-scan",
+        "tier2: tool calls blocked",
+        "invalid tool name",
+        "param_scan_unsafe",
+        "Security finding (PII,",
+        "Parameter scan flagged",
+        "Security scan (init in progress)",
+    )
+    for msg in messages:
+        for token in forbidden:
+            assert token not in msg, f"internal/raw string {token!r} leaked into: {msg!r}"
+
+    # Structural canary: an arbitrary reason on a not-allowed result is never echoed.
+    sentinel = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(allowed=False, reason="SENTINEL_LEAK_CANARY_xyz"),
+    )["message"]
+    assert "SENTINEL_LEAK_CANARY_xyz" not in sentinel
+
+
+def test_finding_message_truncated_in_shim_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-77: the 200-char finding-message truncation is enforced end-to-end
+    # through the shim. Homogeneous fill makes the boundary assertion deterministic.
+    out = _drive(
+        monkeypatch,
+        "write_file",
+        _guard_result(
+            findings=(_non_pii("injection", Severity.HIGH, message="X" * 500),),
+            param_scan_unsafe=True,
+        ),
+    )
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert "X" * 200 in msg
+    assert "…" in msg
+    assert "X" * 201 not in msg
+
+
+# ---------------------------------------------------------------------------
+# B. Deploy-parity guard — the shim source must import AND call the formatter
+# ---------------------------------------------------------------------------
+
+
+def _shim_source() -> str:
+    return _REF_PLUGIN_PATH.read_text(encoding="utf-8")
+
+
+def test_shim_imports_formatter() -> None:
+    # Regression for PET-77: the in-repo shim imports the library formatter.
+    src = _shim_source()
+    assert "from petasos.session.formatting import" in src
+    assert "format_block_message" in src
+    assert "format_content_block" in src
+
+
+def test_shim_emits_branding() -> None:
+    # Regression for PET-77: no surviving raw block string from the six-site catalog
+    # (the original close shipped these; their reappearance is a silent regression).
+    src = _shim_source()
+    raw_catalog = (
+        "Security finding (PII,",
+        "Parameter scan flagged unsafe content:",
+        "Security scan (init in progress):",
+        "Tier 3 escalation",
+        '"message": result.reason',
+    )
+    for raw in raw_catalog:
+        assert raw not in src, f"raw block string {raw!r} survives in the shim"
+
+
+def test_shim_routes_every_block_site_through_formatter() -> None:
+    # Regression for PET-77: each of the six block sites must route through the formatter.
+    # Counting call occurrences closes the hole B2 leaves open (a NEW ad-hoc f-string at a
+    # single site would pass B2 but drop the count below six).
+    src = _shim_source()
+    call_sites = src.count("format_block_message(") + src.count("format_content_block(")
+    assert call_sites >= 6, f"expected >=6 formatter call sites in the shim, found {call_sites}"

--- a/tests/test_reference_plugin_block_messages.py
+++ b/tests/test_reference_plugin_block_messages.py
@@ -20,6 +20,7 @@ Backend-free: the guard is stubbed and ``_run_async`` is monkeypatched, exactly 
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import importlib.util
 from pathlib import Path
@@ -400,8 +401,17 @@ def test_shim_emits_branding() -> None:
 
 def test_shim_routes_every_block_site_through_formatter() -> None:
     # Regression for PET-77: each of the six block sites must route through the formatter.
-    # Counting call occurrences closes the hole B2 leaves open (a NEW ad-hoc f-string at a
-    # single site would pass B2 but drop the count below six).
-    src = _shim_source()
-    call_sites = src.count("format_block_message(") + src.count("format_content_block(")
+    # Counting call sites closes the hole B2 leaves open (a NEW ad-hoc f-string at a single
+    # site would pass B2 but drop the count below six). Parse the AST and count real Call
+    # nodes so the names appearing in the import, comments, or string literals are not
+    # miscounted (a raw src.count() would inflate the total and could mask a removed site).
+    tree = ast.parse(_shim_source())
+    targets = {"format_block_message", "format_content_block"}
+    call_sites = sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in targets
+    )
     assert call_sites >= 6, f"expected >=6 formatter call sites in the shim, found {call_sites}"

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -158,7 +158,11 @@ def test_pii_finding_blocks_egress_tool(monkeypatch: pytest.MonkeyPatch) -> None
         _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True),
     )
     assert out is not None and out["action"] == "block"
-    assert out["message"].startswith("Security finding (PII, CRITICAL)")
+    # PET-77: block messages now carry the [BLOCKED by Petasos] contract (was a raw
+    # "Security finding (PII, ...)" string straight from the shim).
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+    assert "send_email" in out["message"] and "NOT executed" in out["message"]
+    assert "(CRITICAL)" in out["message"] and "PII" in out["message"]
 
     out_high = _drive(
         monkeypatch,
@@ -166,7 +170,9 @@ def test_pii_finding_blocks_egress_tool(monkeypatch: pytest.MonkeyPatch) -> None
         _guard_result(findings=(_pii(Severity.HIGH),), param_scan_unsafe=True),
     )
     assert out_high is not None and out_high["action"] == "block"
-    assert out_high["message"].startswith("Security finding (PII, HIGH)")
+    assert out_high["message"].startswith("[BLOCKED by Petasos]")
+    assert "http_request" in out_high["message"]
+    assert "(HIGH)" in out_high["message"] and "PII" in out_high["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +200,9 @@ def test_namespaced_egress_variant_still_pii_blocked(monkeypatch: pytest.MonkeyP
             egress=_SEND_EMAIL_CANON,
         )
         assert out is not None and out["action"] == "block", f"{variant!r} should block"
-        assert out["message"].startswith("Security finding (PII, CRITICAL)")
+        # PET-77: contract-formatted message (was raw "Security finding (PII, ...)").
+        assert out["message"].startswith("[BLOCKED by Petasos]")
+        assert "(CRITICAL)" in out["message"] and "PII" in out["message"]
 
 
 def test_namespaced_readonly_variant_not_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -279,7 +287,9 @@ def test_camelcase_egress_variant_still_pii_blocked(monkeypatch: pytest.MonkeyPa
             egress=_SEND_EMAIL_CANON,
         )
         assert out is not None and out["action"] == "block", f"{variant!r} should block"
-        assert out["message"].startswith("Security finding (PII, CRITICAL)")
+        # PET-77: contract-formatted message (was raw "Security finding (PII, ...)").
+        assert out["message"].startswith("[BLOCKED by Petasos]")
+        assert "(CRITICAL)" in out["message"] and "PII" in out["message"]
 
 
 def test_camelcase_readonly_variant_not_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -320,7 +330,9 @@ def test_single_underscore_namespace_requires_full_wire_name(
         egress=full_wire,
     )
     assert out is not None and out["action"] == "block"
-    assert out["message"].startswith("Security finding (PII, CRITICAL)")
+    # PET-77: contract-formatted message (was raw "Security finding (PII, ...)").
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+    assert "(CRITICAL)" in out["message"] and "PII" in out["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -335,7 +347,9 @@ def test_injection_still_blocks_all_dangerous_tools(monkeypatch: pytest.MonkeyPa
         )
         out = _drive(monkeypatch, tool, gr)
         assert out is not None and out["action"] == "block", f"{tool} should block injection"
-        assert out["message"].startswith("Parameter scan flagged unsafe content")
+        # PET-77: contract-formatted message (was raw "Parameter scan flagged unsafe content").
+        assert out["message"].startswith("[BLOCKED by Petasos]")
+        assert "NOT executed" in out["message"] and "(HIGH)" in out["message"]
 
 
 def test_non_pii_types_block_all_dangerous(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -345,7 +359,9 @@ def test_non_pii_types_block_all_dangerous(monkeypatch: pytest.MonkeyPatch) -> N
         gr = _guard_result(findings=(_non_pii(ftype, Severity.HIGH),), param_scan_unsafe=True)
         out = _drive(monkeypatch, "write_file", gr)
         assert out is not None and out["action"] == "block", f"finding_type={ftype!r} should block"
-        assert out["message"].startswith("Parameter scan flagged unsafe content")
+        # PET-77: contract-formatted message (was raw "Parameter scan flagged unsafe content").
+        assert out["message"].startswith("[BLOCKED by Petasos]")
+        assert "NOT executed" in out["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -396,7 +412,9 @@ def test_fallback_ordinal_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: crit_scanner)
     out = ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1")
     assert out is not None and out["action"] == "block"
-    assert out["message"].startswith("Security scan (init in progress)")
+    # PET-77: contract-formatted message (was raw "Security scan (init in progress): ...").
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+    assert "write_file" in out["message"] and "NOT executed" in out["message"]
 
     # MEDIUM finding → no block (ordinal gate).
     med_scanner = _make_scanner(_non_pii("injection", Severity.MEDIUM))
@@ -496,7 +514,9 @@ def test_tier3_and_not_allowed_unchanged(monkeypatch: pytest.MonkeyPatch) -> Non
         _guard_result(tier="tier3", allowed=False, reason="session terminated (tier3)"),
     )
     assert out_t3 is not None and out_t3["action"] == "block"
-    assert "Tier 3" in out_t3["message"]
+    # PET-77: tier3 message now carries the contract (was raw "...(Tier 3 escalation).").
+    assert out_t3["message"].startswith("[BLOCKED by Petasos]")
+    assert "tier3" in out_t3["message"] and "NOT executed" in out_t3["message"]
 
     out_blocked = _drive(
         monkeypatch,
@@ -504,7 +524,12 @@ def test_tier3_and_not_allowed_unchanged(monkeypatch: pytest.MonkeyPatch) -> Non
         _guard_result(allowed=False, reason="tier2: tool calls blocked"),
     )
     assert out_blocked is not None and out_blocked["action"] == "block"
-    assert out_blocked["message"] == "tier2: tool calls blocked"
+    # PET-77: the not-allowed block is routed through format_block_message. This fixture
+    # carries tier="none" (default), so the formatter takes the catch-all branch; the key
+    # guarantee is that the internal reason string never reaches the model.
+    assert out_blocked["message"].startswith("[BLOCKED by Petasos]")
+    assert "NOT executed" in out_blocked["message"]
+    assert "tier2: tool calls blocked" not in out_blocked["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- PET-77 (reopened): PR #50 built and tested the `[BLOCKED by Petasos]` block-message formatter as a library module but never wired it into the reference plugin shim. Every block site returned a raw, unattributed string (`Security finding (PII, ...)`, `result.reason`, `Security scan (init in progress): ...`), so the model could not tell a tool was blocked and confabulated the outcome.
- Routes all six shim block sites through the formatter: `format_block_message` for the two `GuardResult`-keyed sites (tier3, explicit block), and a new `format_content_block()` for the four content-scan / init-fallback sites that fire after the guard returns `allowed=True`.
- Closes the `result.reason` leak (internal strings like `exempt-with-scan`, `tier2: tool calls blocked` no longer reach the model).
- Adds a deploy-parity guard so a Done ticket cannot silently regress again (the gap the original close had).

## Layered defense (why the guard is three tests, not one)
- **B1** asserts the shim imports the formatter.
- **B2** asserts none of the five known raw strings survive in the shim source.
- **B3** asserts ≥6 formatter call-sites in the shim, so a *new* ad-hoc f-string at a single site (wording not in B2's catalog) still trips the guard. B1+B2 alone left that hole open.

## Files changed

| File | Change |
|------|--------|
| `petasos/session/formatting.py` | Adds `format_content_block(path, tool_name, findings)` + `ContentBlockPath` + `_CONTENT_REASON`; fail-closed reason lookup (honors pipeline-never-throws) |
| `petasos/__init__.py` | Exports `format_content_block` (import + `__all__`) |
| `petasos/session/__init__.py` | Exports `format_content_block` (import + `__all__`) |
| `docs/deployment/reference_plugin/__init__.py` | Wires all six block sites through the formatter; module-level dep-light import |
| `tests/test_reference_plugin_block_messages.py` | New: per-path contract tests (A1–A9), no-leak sentinel canary, 200-char truncation, B1–B3 deploy-parity guard |
| `tests/test_reference_plugin_egress.py` | Updates assertions that pinned the old raw strings to the new contract (block/allow behavior unchanged) |

## Test plan
- [x] Focused: `python -m pytest tests/test_formatting.py tests/test_reference_plugin_egress.py tests/test_reference_plugin_block_messages.py -v` — 63/63 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --strict .` — no issues in 126 files (confirms the shim's `Literal` call sites are type-checked)
- [x] Full suite: `python -m pytest` — 1743 passed, 41 skipped, 1 xfailed, **2 deselected pre-existing failures unrelated to PET-77**:
  - `test_default_ignorable_rejected` — local Py3.10 Unicode 13-vs-14 (documented)
  - `test_get_about` — stale `0.1.0` vs package `__version__` `0.1.1`, left by the 0.1.1 release commit (worth a tiny separate fix)
- [ ] Post-merge: re-copy `docs/deployment/reference_plugin/__init__.py` to the hand-synced install path (`%LOCALAPPDATA%\hermes\plugins\petasos\__init__.py`) to resolve the live-session drift the reopen evidence showed.

> Note: spec/test-output artifacts live under the gitignored `docs/specs/` (internal, kept in the wiki), so they are intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared formatter utilities to generate standardized, branded “blocked” messages for reference-plugin scenarios, including init-fallback and content-scan block paths.

* **Bug Fixes**
  * Updated the reference-plugin shim to route all blocked response messages through the shared formatter, improving consistency and reducing chances of exposing internal/raw reason text.

* **Tests**
  * Added regression and deploy-parity tests validating block-message content across multiple enforcement paths, including truncation behavior and leak-prevention.
  * Updated egress-related assertions to match the new standardized message format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->