### PR TITLE
fix(pet-130): bind gateway armed/reload reads to session-bound config

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -29,6 +29,7 @@ from petasos.normalize import canonicalize_tool_name  # PET-118: dep-light (re +
 
 if TYPE_CHECKING:
     from petasos import PetasosConfig
+    from petasos.console._paths import HermesConfigResolution
 
 logger = logging.getLogger("petasos.plugin")
 
@@ -43,6 +44,21 @@ _init_lock = threading.Lock()
 _initialized = False
 _init_error: str | None = None
 _session_ids: dict[int, str] = {}
+
+# PET-130: the gateway's session-bound config resolution, captured once at the top
+# of register() from the operator-trusted boot environment and pinned for the
+# process lifetime. _is_armed() and _maybe_reconfigure() pass it to the armed/reload
+# readers so a profile session never re-resolves to the global config mid-session.
+# None means capture has not run (or failed) -> the readers fall back to an ambient
+# per-call resolve. Never re-derived from in-session-mutable state (PET-125).
+_session_resolution: HermesConfigResolution | None = None
+
+
+def _reset_session_resolution() -> None:
+    """Test seam — drop the pinned resolution (mirrors _reset_disarm_log)."""
+    global _session_resolution
+    _session_resolution = None
+
 
 # PET-111: live arm/disarm. _pre_tool_call/_post_tool_call re-read petasos.enabled
 # per call (mtime+size+TTL-cached in petasos.console._armed) rather than latching
@@ -201,11 +217,16 @@ def _run_async(coro):
 # ---------------------------------------------------------------------------
 
 
-def _load_config() -> dict[str, Any]:
-    """Read petasos: section from the resolved Hermes config.yaml."""
+def _load_config(res: HermesConfigResolution | None = None) -> dict[str, Any]:
+    """Read petasos: section from the resolved Hermes config.yaml.
+
+    PET-130: ``res`` is the boot-captured resolution; when supplied, boot resolves
+    exactly once (the same file the armed/reload reads are pinned to). When ``None``,
+    resolve from environment as before.
+    """
     from petasos.console._paths import read_petasos_section, resolve_hermes_config_path
 
-    res = resolve_hermes_config_path()
+    res = res if res is not None else resolve_hermes_config_path()
     logger.info("loading config from %s [tier=%s]", res.path, res.tier)
     if res.warning:
         logger.warning("Hermes profile resolution: %s", res.warning)
@@ -585,11 +606,17 @@ def _fallback_pre_tool_call(
 
 
 def _is_armed() -> bool:
-    """PET-111: True unless the operator set petasos.enabled=false. Fail-secure True."""
+    """PET-111: True unless the operator set petasos.enabled=false. Fail-secure True.
+
+    PET-130: reads through the session-bound resolution captured at boot so a
+    profile session honors a disarm written to its own config rather than re-reading
+    the global. ``_session_resolution`` is None until register() captures it, in which
+    case read_armed falls back to an ambient per-call resolve.
+    """
     try:
         from petasos.console._armed import read_armed
 
-        return read_armed()
+        return read_armed(_session_resolution)
     except Exception:
         return True  # never fail open into disarmed
 
@@ -694,7 +721,9 @@ def _maybe_reconfigure() -> None:
     except Exception:
         return
 
-    changed = read_changed_section()
+    # PET-130: peek and commit MUST share the same session-bound resolution so the
+    # committed key and section describe one file.
+    changed = read_changed_section(_session_resolution)
     if changed is None:
         return
     section, key = changed
@@ -708,7 +737,7 @@ def _maybe_reconfigure() -> None:
     except Exception as exc:
         _log_reload_failure(f"apply failed: {exc}")
         return  # keep last-good; not committed -> retried next call
-    commit_seen(key)
+    commit_seen(key, _session_resolution)
     _log_reconfigure_applied()
 
 
@@ -885,10 +914,35 @@ def _try_register_hook(ctx, name: str, handler) -> bool:
 
 
 def register(ctx) -> None:
-    global _config, _subagent_hooks_available
+    global _config, _subagent_hooks_available, _session_resolution
+
+    # PET-130: capture the session-bound resolution FIRST — before any hook is
+    # registered or the init thread starts — so the first _pre_tool_call cannot
+    # observe a None binding and fall back to an ambient resolve. Pre-clear to None
+    # so a re-register whose capture fails cannot leave a stale prior binding. The
+    # binding source is the operator-trusted boot environment, never in-session
+    # state (PET-125 / Decision 2).
+    _session_resolution = None
+    try:
+        from petasos.console._paths import resolve_hermes_config_path
+
+        _session_resolution = resolve_hermes_config_path()
+    except Exception as exc:  # resolve_hermes_config_path never raises; stay safe
+        logger.warning(
+            "PETASOS_ARMED_RESOLUTION tier=unresolved path=ambient: boot capture "
+            "failed (%s); falling back to per-call resolve",
+            exc,
+        )
+    if _session_resolution is not None:
+        # D2: greppable, names the tier + absolute path the armed/reload reads pin to.
+        logger.info(
+            "PETASOS_ARMED_RESOLUTION tier=%s path=%s",
+            _session_resolution.tier,
+            _session_resolution.path,
+        )
 
     try:
-        _config = _load_config()
+        _config = _load_config(_session_resolution)
     except Exception as exc:
         logger.error("Failed to load petasos config: %s", exc)
         _config = {}

--- a/petasos/console/_armed.py
+++ b/petasos/console/_armed.py
@@ -4,6 +4,14 @@ Anchored on ``_paths.resolve_hermes_config_path()`` so the gateway and the
 dashboard agree on which ``config.yaml`` holds the bit. Keeps ``_paths.py`` pure
 (PET-111 Decision 4 — no cache, no writes added there). Fail-secure: read errors
 arm. Never raises out of ``read_armed``/``write_armed``.
+
+PET-130: ``read_armed`` takes an optional ``res`` resolution. The gateway passes
+its boot-pinned resolution so a profile session never re-resolves to the global
+config mid-session; the standalone console passes ``None`` and re-resolves from
+environment. Precondition: the ``(mtime_ns, size)`` cache is keyed by stat
+metadata, not path, so a single process must use one binding consistently
+(gateway always pinned, console always ``None``). If a future surface ever runs
+both in one process, the cache must be re-keyed to include ``res.path``.
 """
 
 from __future__ import annotations
@@ -12,7 +20,11 @@ import threading
 import time
 from typing import Any
 
-from petasos.console._paths import read_petasos_section, resolve_hermes_config_path
+from petasos.console._paths import (
+    HermesConfigResolution,
+    read_petasos_section,
+    resolve_hermes_config_path,
+)
 
 _ARMED_LOCK = threading.Lock()
 _ARMED_TTL_S = 1.0
@@ -27,16 +39,20 @@ def _reset_armed_cache() -> None:
         _ARMED_CACHE = None
 
 
-def read_armed() -> bool:
+def read_armed(res: HermesConfigResolution | None = None) -> bool:
     """Return the effective ``petasos.enabled`` bit. Fail-secure ``True`` on any error.
 
     TTL+mtime+size cache: a hit requires an unchanged ``(mtime_ns, size)`` key AND
     age < ``_ARMED_TTL_S``, so a same-size same-tick rewrite is still observed within
     the TTL. Steady-state cost is one ``os.stat`` per call plus at most one YAML
     parse per second — never a parse per tool call.
+
+    ``res``: when supplied (the PET-130 gateway path), the read uses this
+    boot-pinned resolution and skips the per-call ambient resolve. When ``None``
+    (the standalone console path), it re-resolves from environment as before.
     """
     global _ARMED_CACHE
-    res = resolve_hermes_config_path()
+    res = res if res is not None else resolve_hermes_config_path()
     try:
         st = res.path.stat()
         key = (st.st_mtime_ns, st.st_size)

--- a/petasos/console/_reload.py
+++ b/petasos/console/_reload.py
@@ -19,6 +19,16 @@ the seen key by itself. It returns ``(section, key)`` and the caller calls
 ``commit_seen(key)`` only after a successful apply. A failed apply leaves the key
 uncommitted, so the same change is re-attempted on the next call after the TTL: a
 failed apply can never silently pin a stale config. Never raises.
+
+PET-130: ``read_changed_section`` and ``commit_seen`` take an optional ``res``
+resolution (mirroring ``read_armed``). The gateway passes its boot-pinned
+resolution so the reload reads the same file the armed bit does; the standalone
+console passes ``None`` and re-resolves. The peek and its matching commit MUST be
+passed the identical ``res`` in one cycle, or the committed key and section would
+describe different files. Precondition: the ``(mtime_ns, size)`` cache is keyed by
+stat metadata, not path; a single process must use one binding consistently. If a
+future surface ever runs gateway and console in one process, re-key the cache to
+include ``res.path``.
 """
 
 from __future__ import annotations
@@ -27,7 +37,11 @@ import threading
 import time
 from typing import Any
 
-from petasos.console._paths import read_petasos_section, resolve_hermes_config_path
+from petasos.console._paths import (
+    HermesConfigResolution,
+    read_petasos_section,
+    resolve_hermes_config_path,
+)
 
 _RELOAD_LOCK = threading.Lock()
 _RELOAD_TTL_S = 1.0
@@ -44,8 +58,13 @@ def _reset_reload_cache() -> None:
         _RELOAD_CACHE = None
 
 
-def read_changed_section() -> tuple[dict[str, Any], tuple[int, int]] | None:
+def read_changed_section(
+    res: HermesConfigResolution | None = None,
+) -> tuple[dict[str, Any], tuple[int, int]] | None:
     """Return ``(section, key)`` when the ``petasos:`` section changed, else ``None``.
+
+    ``res``: when supplied (the PET-130 gateway path), use this boot-pinned
+    resolution; when ``None``, re-resolve from environment (standalone console).
 
     ``key = (mtime_ns, size)``. Logic:
 
@@ -65,7 +84,7 @@ def read_changed_section() -> tuple[dict[str, Any], tuple[int, int]] | None:
     """
     global _RELOAD_CACHE
     try:
-        res = resolve_hermes_config_path()
+        res = res if res is not None else resolve_hermes_config_path()
         try:
             st = res.path.stat()
             key = (st.st_mtime_ns, st.st_size)
@@ -97,7 +116,7 @@ def read_changed_section() -> tuple[dict[str, Any], tuple[int, int]] | None:
         return None  # never raises out (fail-safe)
 
 
-def commit_seen(key: tuple[int, int]) -> None:
+def commit_seen(key: tuple[int, int], res: HermesConfigResolution | None = None) -> None:
     """Advance the seen key after a successful apply (commit-on-success).
 
     Re-reads the resolved section so the cached ``(key, section, ts)`` lets a
@@ -105,10 +124,14 @@ def commit_seen(key: tuple[int, int]) -> None:
     compare). Re-applying the same already-validated config is idempotent, so the
     rare race where the file changes again between read and commit costs at most
     one redundant re-apply on the next call rather than a correctness bug.
+
+    ``res`` MUST be the same resolution passed to the matching ``read_changed_section``
+    call (PET-130); otherwise the committed section would be re-read from a different
+    file than the one ``key`` describes.
     """
     global _RELOAD_CACHE
     try:
-        res = resolve_hermes_config_path()
+        res = res if res is not None else resolve_hermes_config_path()
         section = read_petasos_section(res)
     except Exception:
         section = {}

--- a/tests/test_console_armed.py
+++ b/tests/test_console_armed.py
@@ -114,6 +114,38 @@ def test_ttl_forces_reparse_on_unchanged_key(cfg: Path, monkeypatch: pytest.Monk
     assert read_armed() is False  # past TTL -> re-parse observes the flip
 
 
+# ── read_armed: PET-130 session-bound resolution ─────────────────────────────
+
+
+def test_armed_read_uses_session_bound_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-130: a profile session pinned to its own config honors a
+    # disarm written there, even when ambient resolution (HERMES_HOME) would read a
+    # different, still-armed file.
+    from petasos.console._paths import HermesConfigResolution
+
+    root_cfg = tmp_path / "root" / "config.yaml"
+    profile_cfg = tmp_path / "profiles" / "gibson" / "config.yaml"
+    _write_config(root_cfg, petasos_section={"enabled": True})
+    _write_config(profile_cfg, petasos_section={"enabled": False})
+    monkeypatch.setenv("HERMES_HOME", str(root_cfg.parent))
+
+    assert read_armed() is True  # ambient -> root -> armed
+    armed_mod._reset_armed_cache()
+    pinned = HermesConfigResolution(path=profile_cfg, tier="profile")
+    assert read_armed(pinned) is False  # session-bound -> profile -> disarmed
+
+
+def test_armed_read_with_res_fails_secure_on_missing_path(tmp_path: Path) -> None:
+    # Regression for PET-130: a pinned resolution whose file is missing still arms
+    # (the fail-secure floor must not weaken on the res path).
+    from petasos.console._paths import HermesConfigResolution
+
+    missing = HermesConfigResolution(path=tmp_path / "nope" / "config.yaml", tier="profile")
+    assert read_armed(missing) is True
+
+
 # ── write_armed: preserve, create, fail-safe ─────────────────────────────────
 
 

--- a/tests/test_console_reload.py
+++ b/tests/test_console_reload.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
     import types
     from collections.abc import Iterator
 
+    from petasos.console._paths import Tier
+
 
 _REF_PLUGIN_PATH = (
     Path(__file__).resolve().parent.parent
@@ -245,3 +247,158 @@ def test_reload_failure_log_rate_limited(
 
     fails = [r for r in caplog.records if "PETASOS_RELOAD_FAILED" in r.getMessage()]
     assert len(fails) == 1  # rate-limited to one per 30s window, not one per call
+
+
+# ── PET-130: gateway session-bound armed/reload resolution ───────────────────
+
+
+class _FakeCtx:
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+    def register_hook(self, name: str, fn: Any) -> None:
+        self.registered.append(name)
+
+
+def _make_resolution(path: Path, tier: Tier) -> Any:
+    from petasos.console._paths import HermesConfigResolution
+
+    return HermesConfigResolution(path=path, tier=tier)
+
+
+def _split_armed(
+    tmp_path: Path, *, profile_enabled: bool, root_enabled: bool
+) -> tuple[Path, Path]:
+    root_cfg = tmp_path / "root" / "config.yaml"
+    profile_cfg = tmp_path / "profiles" / "gibson" / "config.yaml"
+    _write_config(root_cfg, {"enabled": root_enabled})
+    _write_config(profile_cfg, {"enabled": profile_enabled})
+    return root_cfg, profile_cfg
+
+
+def test_reload_shares_session_bound_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-130: the reload reader pinned to the session's profile reads
+    # AND commits against the profile config even when ambient (HERMES_HOME) resolves
+    # to root. The negative arm proves the res argument is load-bearing (the peek/
+    # commit pairing invariant) rather than passing vacuously.
+    root_cfg = tmp_path / "root" / "config.yaml"
+    profile_cfg = tmp_path / "profiles" / "gibson" / "config.yaml"
+    _write_config(root_cfg, {"profile_name": "root_profile"})
+    _write_config(profile_cfg, {"profile_name": "gibson_profile"})
+    monkeypatch.setenv("HERMES_HOME", str(root_cfg.parent))  # ambient -> root
+
+    pinned = _make_resolution(profile_cfg, "profile")
+    changed = read_changed_section(pinned)
+    assert changed is not None
+    section, key = changed
+    assert section.get("profile_name") == "gibson_profile"  # profile, not root
+
+    commit_seen(key, pinned)
+    assert reload_mod._RELOAD_CACHE is not None
+    assert reload_mod._RELOAD_CACHE[1].get("profile_name") == "gibson_profile"
+
+    # Drop the res on commit: it re-resolves to ambient root and caches the WRONG
+    # section -> the test fails here if the res argument were ever dropped.
+    reload_mod._reset_reload_cache()
+    commit_seen(key)
+    assert reload_mod._RELOAD_CACHE is not None
+    assert reload_mod._RELOAD_CACHE[1].get("profile_name") == "root_profile"
+
+
+def test_profile_disarm_honored_over_global_armed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-130 (headline): profile disarmed (enabled:false) + global
+    # armed (enabled:true); a gateway pinned to the profile reads DISARMED and passes
+    # the next tool call through.
+    import petasos.console._armed as armed_mod
+
+    ref = _import_reference_plugin()
+    root_cfg, profile_cfg = _split_armed(tmp_path, profile_enabled=False, root_enabled=True)
+    monkeypatch.setenv("HERMES_HOME", str(root_cfg.parent))  # ambient -> root (armed)
+    armed_mod._reset_armed_cache()
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(profile_cfg, "profile"))
+    ref._reset_disarm_log()
+
+    assert ref._is_armed() is False  # pinned to profile -> disarmed
+    assert ref._pre_tool_call("shell", {"cmd": "x"}, task_id="s1") is None  # pass-through
+
+
+def test_disarm_emits_disarmed_log_within_one_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-130: unequipping (profile enabled:false, gateway pinned to it)
+    # emits exactly one PETASOS_DISARMED line and passes the very next call through.
+    import petasos.console._armed as armed_mod
+
+    ref = _import_reference_plugin()
+    _root_cfg, profile_cfg = _split_armed(tmp_path, profile_enabled=False, root_enabled=True)
+    armed_mod._reset_armed_cache()
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(profile_cfg, "profile"))
+    ref._reset_disarm_log()
+
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        assert ref._pre_tool_call("shell", {"cmd": "x"}, task_id="s1") is None
+
+    disarmed = [r for r in caplog.records if "PETASOS_DISARMED" in r.getMessage()]
+    assert len(disarmed) == 1
+
+
+def test_armed_resolution_logged_at_boot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-130 (D2): register() captures the session resolution and emits
+    # a greppable line naming tier + path; the logged path equals the config-load path.
+    ref = _import_reference_plugin()
+    profile_dir = tmp_path / "profiles" / "gibson"
+    _write_config(profile_dir / "config.yaml", {"enabled": True})
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # neutralize bg thread
+
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ref.register(_FakeCtx())
+
+    res_lines = [
+        r.getMessage() for r in caplog.records if "PETASOS_ARMED_RESOLUTION" in r.getMessage()
+    ]
+    assert len(res_lines) == 1
+    assert "tier=hermes_home" in res_lines[0]
+    assert str(profile_dir / "config.yaml") in res_lines[0]
+
+    assert ref._session_resolution is not None
+    assert ref._session_resolution.path == profile_dir / "config.yaml"
+    load_lines = [
+        r.getMessage() for r in caplog.records if "loading config from" in r.getMessage()
+    ]
+    assert len(load_lines) == 1
+    assert str(profile_dir / "config.yaml") in load_lines[0]  # one file, not two
+
+
+def test_wrong_boot_resolution_stays_armed_and_logs_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-130 (corollary): if the gateway boots under the root/global
+    # config (wrong) while the disarm lives in the profile, pinning preserves the wrong
+    # file -> stays ARMED, but the D2 boot log names the root path loudly (a one-line
+    # diagnosis, not a silent correction). The Hermes-launch fix is out of scope.
+    import petasos.console._armed as armed_mod
+
+    ref = _import_reference_plugin()
+    root_cfg, _profile_cfg = _split_armed(tmp_path, profile_enabled=False, root_enabled=True)
+    armed_mod._reset_armed_cache()
+    monkeypatch.setenv("HERMES_HOME", str(root_cfg.parent))  # boots under root
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)
+
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ref.register(_FakeCtx())
+
+    assert ref._session_resolution is not None
+    assert ref._session_resolution.path == root_cfg  # booted under the global config
+    assert ref._is_armed() is True  # profile disarm NOT honored under a wrong boot
+    res_lines = [
+        r.getMessage() for r in caplog.records if "PETASOS_ARMED_RESOLUTION" in r.getMessage()
+    ]
+    assert len(res_lines) == 1
+    assert str(root_cfg) in res_lines[0]  # names the wrong (root) file -> greppable

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -655,8 +655,9 @@ def test_disarm_emits_rate_limited_warning(
     mod = _import_reference_plugin()
     # _is_armed() resolves read_armed via a function-local import from
     # petasos.console._armed, so patch the source there — NOT mod.read_armed, which
-    # does not exist on the plugin module.
-    monkeypatch.setattr("petasos.console._armed.read_armed", lambda: False)
+    # does not exist on the plugin module. PET-130: _is_armed now calls
+    # read_armed(_session_resolution), so the stub accepts the optional arg.
+    monkeypatch.setattr("petasos.console._armed.read_armed", lambda res=None: False)
     mod._reset_disarm_log()
 
     with caplog.at_level(logging.WARNING, logger=mod.logger.name):

--- a/tests/test_subagent_plugin_wiring.py
+++ b/tests/test_subagent_plugin_wiring.py
@@ -76,7 +76,7 @@ def _prep_init(mod: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
 class TestHookRegistration:
     def test_both_hooks_registered_marks_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
         ref = _import_reference_plugin()
-        monkeypatch.setattr(ref, "_load_config", lambda: {})
+        monkeypatch.setattr(ref, "_load_config", lambda res=None: {})
         monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # neutralize bg thread
         ctx = _FakeCtx()
         ref.register(ctx)
@@ -85,7 +85,7 @@ class TestHookRegistration:
 
     def test_stop_hook_rejected_degrades_to_C(self, monkeypatch: pytest.MonkeyPatch) -> None:
         ref = _import_reference_plugin()
-        monkeypatch.setattr(ref, "_load_config", lambda: {})
+        monkeypatch.setattr(ref, "_load_config", lambda res=None: {})
         monkeypatch.setattr(ref, "_deferred_init", lambda: None)
         ctx = _FakeCtx(reject={"subagent_stop"})
         ref.register(ctx)


### PR DESCRIPTION
## Summary
- The gateway now pins its armed and live-reload config reads to the `HermesConfigResolution` captured once at boot, so a profile session honors a disarm written to its own `config.yaml` instead of re-reading the global config mid-session.
- `read_armed`, `read_changed_section`, and `commit_seen` gain an optional boot-pinned `res`; `None` preserves the standalone console's per-call ambient re-resolve.
- `register()` captures `_session_resolution` first (operator-trusted boot env, agent-unreachable per PET-125) and logs a greppable `PETASOS_ARMED_RESOLUTION tier=... path=...` line so a future divergence is a one-line diagnosis instead of a post-mortem block-rate.

## Why
Field repro (gibson profile session): 40/88 tool results blocked after the operator set Unequipped, with zero `PETASOS_DISARMED` lines. The disarm persisted to the profile `config.yaml` (`enabled:false`) but the running gateway re-resolved its path per call from process environment and read the global `config.yaml` (`enabled:true`); fail-secure defaults then masked the mismatch as armed. Pinning the gateway to its boot resolution closes the divergence at its source, while the standalone dashboard keeps tracking the ambient active profile. The reload reader moves onto the same binding so the hot-apply path cannot read a different file than the armed bit.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_armed.py` | Adds optional `res` to `read_armed`; module-docstring path-blind-cache precondition |
| `petasos/console/_reload.py` | Adds optional `res` to `read_changed_section` + `commit_seen`; same-`res` peek/commit invariant |
| `docs/deployment/reference_plugin/__init__.py` | Captures `_session_resolution` at register() top, emits the D2 boot log, threads it through `_is_armed` / `_maybe_reconfigure` / `_load_config` |
| `tests/test_console_armed.py` | Session-bound + fail-secure-with-`res` pins |
| `tests/test_console_reload.py` | Reload session-bound pin, headline profile-disarm regression, wrong-boot diagnosis, boot-log assertion |
| `tests/test_reference_plugin_egress.py` | Migrates the disarm-tripwire stub to the `res=None` signature |
| `tests/test_subagent_plugin_wiring.py` | Migrates `_load_config` stubs to the `res=None` signature |

## Test plan
- [x] `python -m pytest tests/test_console_armed.py tests/test_console_reload.py tests/test_plugin_api_paths.py tests/test_reference_plugin_egress.py tests/test_subagent_plugin_wiring.py` — 130/130 pass
- [x] `mypy --strict .` — clean (125 files); `ruff check .` and `ruff format --check .` — clean
- [x] Full suite green except two pre-existing, change-unrelated failures, both deselected: `test_console_validation.py::test_default_ignorable_rejected` (Unicode-13 on local 3.10) and `test_console_handlers.py::test_get_about` (asserts `0.1.0` vs the `0.1.1` release in 719e360) — 1738 passed
- [x] Hot-path cost unchanged or lower: the pinned read skips the per-call ambient resolve (no extra `os.stat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced configuration consistency by pinning settings to a session-bound resolution during initialization, ensuring armed/disarmed checks use the same configuration throughout the session lifecycle.

* **Bug Fixes**
  * Profile-level configuration settings now properly override global settings when determining armed/disarmed state.

* **Tests**
  * Added comprehensive tests verifying consistent configuration handling across different configuration tiers and session boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->