### PR TITLE
fix(pet-131): surface gateway enforcement blocks on the Observability dashboard

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -600,6 +600,16 @@ def _fallback_pre_tool_call(
                     tool_name,
                     worst.rule_id,
                 )
+                # PET-131: a cold-start (init-window) block is still a gateway block the
+                # operator must see — emit it beside the log line like the main path.
+                _emit_enforcement_event(
+                    session_id=_derive_session_id(task_id, kwargs),
+                    tool=tool_name,
+                    event_type="quarantine",
+                    severity=worst.severity.name,
+                    rule_id=worst.rule_id,
+                    reason=worst.message,
+                )
                 return {
                     "action": "block",
                     # PET-77: route through the library formatter (contract: [BLOCKED by Petasos]

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -634,18 +634,68 @@ def _reset_disarm_log() -> None:
         _last_disarm_log = 0.0
 
 
-def _log_disarmed_bypass(tool_name: str) -> None:
-    """Rate-limited WARNING so an operator-disarmed bypass is always attributable."""
+def _log_disarmed_bypass(tool_name: str) -> bool:
+    """Rate-limited WARNING so an operator-disarmed bypass is always attributable.
+
+    PET-131: returns ``True`` iff it actually logged this call (the rate-limit
+    window opened), so the caller can emit a 1:1 enforcement event onto the same
+    clock — the surfaced "bypassed (disarmed)" row and the ``PETASOS_DISARMED`` log
+    line then share one source of truth and one ``_DISARM_LOG_EVERY_S`` cadence.
+    """
     global _last_disarm_log
     now = time.monotonic()
     with _disarm_log_lock:
         if now - _last_disarm_log < _DISARM_LOG_EVERY_S:
-            return
+            return False
         _last_disarm_log = now
     logger.warning(
         "PETASOS_DISARMED tool=%s — enforcement bypassed by operator (Unequipped)",
         tool_name,
     )
+    return True
+
+
+def _emit_enforcement_event(
+    *,
+    session_id: str,
+    tool: str,
+    event_type: str,
+    tier: str | None = None,
+    rule_id: str | None = None,
+    severity: str | None = None,
+    reason: str = "",
+    param_scan_degraded: bool = False,
+    armed: bool = True,
+) -> None:
+    """PET-131: emit a structured enforcement event onto the cross-process spool the
+    dashboard drains, beside the existing decision-point log line (one emit per log
+    line — log and surface share one source of truth, spec D1/D4).
+
+    Self-guarded and fail-open (spec D5): surfacing a block must never gate, delay,
+    or break the tool call, so the whole body is wrapped and swallows everything.
+    The write itself is an O(1) local append (``petasos.console._events``), the same
+    hot-path cost class as the per-call ``read_armed`` file read — not a network
+    call and not a blocking ``await`` on the decision path.
+    """
+    try:
+        from petasos.console._events import emit_enforcement_event
+
+        emit_enforcement_event(
+            {
+                "session_id": session_id,
+                "tool": tool,
+                "event_type": event_type,
+                "tier": tier,
+                "rule_id": rule_id,
+                "severity": severity,
+                "reason": reason,
+                "param_scan_degraded": param_scan_degraded,
+                "direction": "tool_call",
+                "armed": armed,
+            }
+        )
+    except Exception:
+        pass
 
 
 def _reset_reload_logs() -> None:
@@ -754,7 +804,15 @@ def _pre_tool_call(
     # ABOVE _ensure_initialized so it covers the initialized, init-failed, and
     # init-in-progress windows uniformly (a disarmed boot skips the fallback scan).
     if not _is_armed():
-        _log_disarmed_bypass(tool_name)
+        # PET-131: emit a "bypassed (disarmed)" event 1:1 with the rate-limited
+        # PETASOS_DISARMED log line so the operator can confirm "off means off".
+        if _log_disarmed_bypass(tool_name):
+            _emit_enforcement_event(
+                session_id=_derive_session_id(task_id, kwargs),
+                tool=tool_name,
+                event_type="bypassed_disarmed",
+                armed=False,
+            )
         return None
     if not _ensure_initialized():
         if _init_error:
@@ -784,6 +842,9 @@ def _pre_tool_call(
         logger.critical(
             "PETASOS_TIER3 tool=%s session=%s — all tool calls blocked", tool_name, session_id
         )
+        _emit_enforcement_event(
+            session_id=session_id, tool=tool_name, event_type="tier3", tier="tier3"
+        )
         return {
             "action": "block",
             "message": format_block_message(result, tool_name),  # PET-77
@@ -793,8 +854,16 @@ def _pre_tool_call(
         logger.warning(
             "PETASOS_BLOCK tool=%s session=%s reason=%s", tool_name, session_id, result.reason
         )
+        _emit_enforcement_event(
+            session_id=session_id,
+            tool=tool_name,
+            event_type="block",
+            tier=result.tier,
+            reason=result.reason,
+        )
         # PET-77: route through the formatter so internal reason strings (exempt-with-scan,
-        # tier2: tool calls blocked, ...) never reach the model.
+        # tier2: tool calls blocked, ...) never reach the model. (The enforcement event
+        # above carries the raw reason to the OPERATOR dashboard, not the model.)
         return {"action": "block", "message": format_block_message(result, tool_name)}
 
     # PET-112: read-only tools never take a content block (both old blocks were
@@ -817,6 +886,13 @@ def _pre_tool_call(
             tool_name,
             session_id,
         )
+        _emit_enforcement_event(
+            session_id=session_id,
+            tool=tool_name,
+            event_type="quarantine",
+            param_scan_degraded=True,
+            reason="param scan degraded",
+        )
         return {
             "action": "block",
             "message": format_content_block("degraded", tool_name, tuple(blocking)),  # PET-77
@@ -833,6 +909,14 @@ def _pre_tool_call(
             worst.severity.name,
             worst.message,
         )
+        _emit_enforcement_event(
+            session_id=session_id,
+            tool=tool_name,
+            event_type="quarantine",
+            severity=worst.severity.name,
+            rule_id=worst.rule_id,
+            reason=worst.message,
+        )
         return {
             "action": "block",
             "message": format_content_block("non_pii_param", tool_name, tuple(non_pii_blocking)),
@@ -847,6 +931,14 @@ def _pre_tool_call(
             tool_name,
             session_id,
             worst.message,
+        )
+        _emit_enforcement_event(
+            session_id=session_id,
+            tool=tool_name,
+            event_type="quarantine",
+            severity=worst.severity.name,
+            rule_id=worst.rule_id,
+            reason=worst.message,
         )
         return {
             "action": "block",

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -79,7 +79,11 @@ def emit_enforcement_event(event: dict[str, Any]) -> bool:
     """
     try:
         rec = dict(event)
-        rec.setdefault("scan_id", f"e-{uuid.uuid4().hex[:6]}")
+        # Full uuid hex (not a 6-char prefix): enforcement is high-volume (a 45%-block
+        # session mints thousands of ids) and scan_id feeds the frontend seed-dedup, so
+        # adequate entropy avoids cross-event collisions. The `e-` prefix keeps it
+        # distinct from the playground `s-<hex>` keyspace.
+        rec.setdefault("scan_id", f"e-{uuid.uuid4().hex}")
         rec.setdefault("timestamp", time.time())
         line = json.dumps(rec, default=str) + "\n"
         with open(_spool_path(), "a", encoding="utf-8") as f:

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -1,0 +1,160 @@
+"""Cross-process enforcement-event spool — sibling of ``_armed.py`` / ``_reload.py`` (PET-131).
+
+The Hermes gateway runs in a separate process from the dashboard. On every
+block / quarantine / tier3 / disarmed-bypass decision the gateway appends a
+structured enforcement event here; the dashboard drains the spool into its
+``scan_history`` ring buffer + ``scan_result`` SSE stream so live enforcement
+reaches the Observability tab. The only cross-process primitive in this codebase
+is file-based (``_armed.py``/``_reload.py``); this is the third member of that
+family.
+
+Identity model (spec D3): the cross-process event identity is the writer-stamped
+unique ``scan_id`` (prefix ``e-``); the reader's cursor is a **byte offset** into
+the spool, NOT a producer-process seq. A gateway restart would reset a per-process
+seq to 0 and a surviving dashboard high-water marker would then drop every
+post-restart event; a byte offset is restart-independent.
+
+Posture (matches the family):
+
+* **Writer is fail-open.** ``emit_enforcement_event`` returns ``False`` on any
+  error and never raises — surfacing a block must never gate, delay, or break the
+  tool call (spec D5). It is an O(1) append (no full-file rewrite, no ``fsync``);
+  telemetry durability is not worth a per-call fsync, and trimming is the reader's
+  job, off the hot path.
+* **Reader is fail-safe.** ``drain_enforcement_events`` returns
+  ``([], after_offset)`` (keep last-good) on any error and reads strictly forward,
+  so a drained event is surfaced exactly once and no ``scan_id`` seen-set is needed.
+* **Path recomputed per call** over ``resolve_hermes_config_path()`` so a transient
+  dangling-``active_profile`` fallback to the ``root`` tier cannot leave the writer
+  and reader on different files (spec edge F-6).
+
+Never raises out of any public function.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Any
+
+from petasos.console._paths import resolve_hermes_config_path
+
+_SPOOL_FILENAME = "petasos-enforcement.jsonl"
+_ROT_SUFFIX = ".rot"
+
+# Sized well above the motivating burst (~40 blocks / 2h18m, ~300 B/line) and far
+# above one tailer interval's worth at peak rate (spec D4). Module-level so a test
+# can shrink it via _reset_events_state to force rotation.
+SPOOL_CAP_BYTES = 2_000_000
+
+# Test seams (mirror _reset_armed_cache / _reset_reload_cache): point the spool at
+# a temp file and optionally shrink the cap. None => resolve beside the live config.
+_SPOOL_PATH_OVERRIDE: str | None = None
+
+
+def _spool_path() -> str:
+    """Resolve the spool path beside the active config (recomputed per call)."""
+    if _SPOOL_PATH_OVERRIDE is not None:
+        return _SPOOL_PATH_OVERRIDE
+    res = resolve_hermes_config_path()
+    return os.path.join(str(res.path.parent), _SPOOL_FILENAME)
+
+
+def _reset_events_state(path: str | None = None, cap: int | None = None) -> None:
+    """Test seam: point the spool at *path* (and optionally set the byte cap)."""
+    global _SPOOL_PATH_OVERRIDE, SPOOL_CAP_BYTES
+    _SPOOL_PATH_OVERRIDE = path
+    if cap is not None:
+        SPOOL_CAP_BYTES = cap
+
+
+def emit_enforcement_event(event: dict[str, Any]) -> bool:
+    """Append one enforcement event as a JSONL line. O(1), fail-open.
+
+    Stamps a unique ``scan_id`` (prefix ``e-``) and a ``timestamp`` if absent.
+    Returns ``False`` on any error and never raises (spec D5). No ``fsync``, no
+    full-file rewrite.
+    """
+    try:
+        rec = dict(event)
+        rec.setdefault("scan_id", f"e-{uuid.uuid4().hex[:6]}")
+        rec.setdefault("timestamp", time.time())
+        line = json.dumps(rec, default=str) + "\n"
+        with open(_spool_path(), "a", encoding="utf-8") as f:
+            f.write(line)
+        return True
+    except Exception:
+        return False
+
+
+def spool_size(path: str | None = None) -> int:
+    """Byte size of the spool, or 0 if absent/unstattable. Never raises."""
+    try:
+        return os.path.getsize(path if path is not None else _spool_path())
+    except OSError:
+        return 0
+
+
+def drain_enforcement_events(path: str, after_offset: int) -> tuple[list[dict[str, Any]], int]:
+    """Read complete JSONL records strictly forward from *after_offset* in *path*.
+
+    Returns ``(events, new_offset)``. A trailing partial line (a torn mid-append
+    write) is NOT consumed: *new_offset* is the byte position after the last
+    COMPLETE record, so the partial line is re-read once finished. Never re-reads
+    a record before *after_offset*, so each event is surfaced exactly once (no
+    ``scan_id`` seen-set needed). A malformed (non-JSON / non-dict) line is skipped
+    but still advances the offset past it. **Fail-safe:** any stat/read error
+    returns ``([], after_offset)`` (keep last-good). Pure peek — commits no cursor
+    state; the caller owns the offset and commits after a successful push.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return [], after_offset
+    if size <= after_offset:
+        return [], after_offset
+    try:
+        with open(path, "rb") as f:
+            f.seek(after_offset)
+            data = f.read()
+    except OSError:
+        return [], after_offset
+    nl = data.rfind(b"\n")
+    if nl == -1:
+        return [], after_offset  # no complete record yet (only a partial line)
+    complete = data[: nl + 1]
+    new_offset = after_offset + len(complete)
+    events: list[dict[str, Any]] = []
+    for raw in complete.split(b"\n"):
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw.decode("utf-8"))
+        except Exception:
+            continue  # skip a malformed line; offset still advances past it
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events, new_offset
+
+
+def rotate_spool(path: str | None = None) -> bool:
+    """Atomically rename the live spool to ``<spool>.rot``. The dashboard is the sole rotator.
+
+    Returns ``False`` without renaming if a ``.rot`` already exists (the caller
+    must recover/clear that leftover first, so its undrained events are never
+    overwritten — spec edge F-2) or if the OS refuses (e.g. a Windows sharing
+    violation while the gateway holds a write handle). Never raises.
+    """
+    p = path if path is not None else _spool_path()
+    rot = p + _ROT_SUFFIX
+    try:
+        if os.path.exists(rot):
+            return False
+        if not os.path.exists(p):
+            return False
+        os.replace(p, rot)
+        return True
+    except OSError:
+        return False

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -9,6 +9,8 @@ treats the parameter as a required query param — every standalone POST/PUT
 TYPE_CHECKING-only names in module-level signatures are quoted instead.
 """
 
+import asyncio
+import contextlib
 import hashlib
 import hmac
 import json
@@ -34,6 +36,46 @@ _logger = logging.getLogger(__name__)
 
 _MAX_SCAN_TEXT_LEN = 100_000
 _VALID_DIRECTIONS = frozenset({"inbound", "outbound"})
+
+# PET-131: enforcement event_types that count as a block for the *blocked* tile and
+# the per-session reconciliation tally. `bypassed_disarmed` is a visible-but-not-
+# blocked heartbeat and is deliberately excluded.
+_BLOCK_EVENT_TYPES = frozenset({"block", "quarantine", "tier3"})
+# Bound on the per-session block tally (drop-oldest by session), mirroring the
+# config.max_terminated_tombstones discipline. Independent of the 500-entry ring.
+_MAX_TALLY_SESSIONS = 10_000
+# Poll cadence of the dashboard's background enforcement-spool tailer (standalone).
+_ENFORCEMENT_TAIL_INTERVAL_S = 1.0
+
+
+def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
+    """Build the unified `scan_history` summary for a drained enforcement event (D6).
+
+    One schema, two producers: `run_scan` writes playground summaries (no `source`,
+    read as "playground"); enforcement entries carry `source="enforcement"` plus
+    tool/event_type/tier/rule_id/severity/reason. A block-class event sets
+    `safe=False` so the existing `safe === false` tile loop counts it with no
+    tile-math change; a `bypassed_disarmed` event sets `safe=True` (visible row,
+    never counted as blocked).
+    """
+    event_type = ev.get("event_type")
+    is_block = event_type in _BLOCK_EVENT_TYPES
+    return {
+        "scan_id": ev.get("scan_id"),
+        "source": "enforcement",
+        "safe": not is_block,
+        "finding_count": 1 if is_block else 0,
+        "duration_ms": 0.0,
+        "direction": "tool_call",
+        "session_id": ev.get("session_id"),
+        "timestamp": ev.get("timestamp"),
+        "tool": ev.get("tool"),
+        "event_type": event_type,
+        "tier": ev.get("tier"),
+        "rule_id": ev.get("rule_id"),
+        "severity": ev.get("severity"),
+        "reason": ev.get("reason"),
+    }
 
 
 def _persist_config(validated_config: Any) -> bool:
@@ -108,8 +150,124 @@ class ConsoleHandlers:
         self.sse = SSEBroadcaster()
         self._start_time = time.monotonic()
 
+        # PET-131: cross-process enforcement-event drain state. Byte offsets into the
+        # spool / its rotated segment (restart-independent; not a producer seq). One
+        # asyncio.Lock serializes the whole peek->push->advance->broadcast(+rotate)
+        # unit so the background tailer and a concurrent get_scan_history are
+        # exactly-once. The per-session block tally is the reconciliation source of
+        # truth (D4) — independent of the 500-entry ring's eviction.
+        self._enforcement_offset = 0
+        self._rot_offset = 0
+        self._enforcement_lock = asyncio.Lock()
+        self._block_tally: dict[str, int] = {}
+
         pipeline.add_audit_listener(self._on_audit)
         pipeline.add_alert_listener(self._on_alert)
+
+    def block_tally_for(self, session_id: str) -> int:
+        """PET-131: per-session count of surfaced block-class enforcement events.
+
+        The D4 reconciliation source of truth; survives ring-buffer eviction within a
+        session. Resets on a dashboard restart (in-memory by design).
+        """
+        return self._block_tally.get(session_id, 0)
+
+    def _bump_block_tally(self, session_id: str) -> None:
+        tally = self._block_tally
+        if session_id in tally:
+            tally[session_id] += 1
+            return
+        tally[session_id] = 1
+        if len(tally) > _MAX_TALLY_SESSIONS:
+            # Drop-oldest by insertion order (dict is insertion-ordered).
+            del tally[next(iter(tally))]
+
+    async def _surface_enforcement_event(self, ev: dict[str, Any]) -> None:
+        """Fold one drained enforcement event into scan_history + the tally + SSE."""
+        summary = _enforcement_summary(ev)
+        self.scan_history.push(summary)
+        if ev.get("event_type") in _BLOCK_EVENT_TYPES:
+            sid = ev.get("session_id")
+            if isinstance(sid, str) and sid:
+                self._bump_block_tally(sid)
+        await self.sse.broadcast("scan_result", summary)
+
+    async def _drain_and_clear_rot(self, rot_path: str) -> None:
+        """Drain a rotated `.rot` segment forward from `self._rot_offset`, then unlink.
+
+        `_rot_offset` advances per recovered record and resets to 0 only after a
+        successful unlink — so if the unlink fails (a Windows handle held on `.rot`)
+        the next cycle does NOT re-push or re-tally the already-recovered records
+        (spec round-4 edge F-1). Never raises.
+        """
+        import os
+
+        from petasos.console import _events
+
+        try:
+            events, new_off = _events.drain_enforcement_events(rot_path, self._rot_offset)
+        except Exception:
+            events, new_off = [], self._rot_offset
+        for ev in events:
+            await self._surface_enforcement_event(ev)
+        self._rot_offset = new_off
+        try:
+            os.remove(rot_path)
+            self._rot_offset = 0
+        except OSError:
+            _logger.warning(
+                "PETASOS_ENFORCEMENT could not unlink %s; will retry next cycle", rot_path
+            )
+
+    async def _drain_enforcement_into_history(self) -> None:
+        """Drain the cross-process enforcement spool into scan_history + SSE (PET-131).
+
+        Exactly-once under one asyncio.Lock: the byte offset advances inside the same
+        critical section that pushes the ring and broadcasts, and any rotation runs
+        inside it too, so the background tailer and a concurrent get_scan_history can
+        never double-deliver or interleave a rotation. Forward-only reader -> no
+        scan_id seen-set. Read-side; never raises.
+        """
+        import os
+
+        from petasos.console import _events
+
+        async with self._enforcement_lock:
+            path = _events._spool_path()
+            rot = path + _events._ROT_SUFFIX
+            # (1) Recover an orphan .rot from a reader that crashed mid-rotation BEFORE
+            # touching the live spool, so its undrained events are never overwritten.
+            if os.path.exists(rot):
+                await self._drain_and_clear_rot(rot)
+            # Normal forward drain of the live spool.
+            try:
+                events, new_offset = _events.drain_enforcement_events(
+                    path, self._enforcement_offset
+                )
+            except Exception:
+                events, new_offset = [], self._enforcement_offset
+            for ev in events:
+                await self._surface_enforcement_event(ev)
+            self._enforcement_offset = new_offset
+            # (2/3) Bounding via reader-owned rotation, off the gateway hot path.
+            try:
+                if _events.spool_size(path) > _events.SPOOL_CAP_BYTES:
+                    if _events.rotate_spool(path):
+                        # The just-renamed .rot IS the former live spool; continue
+                        # from the committed live offset to capture in-flight appends,
+                        # then reset the live offset to 0 for the fresh spool.
+                        self._rot_offset = self._enforcement_offset
+                        await self._drain_and_clear_rot(rot)
+                        self._enforcement_offset = 0
+                    else:
+                        # Windows handle held, or a leftover .rot we could not clear:
+                        # soft cap. The spool grows on disk (no telemetry loss, no
+                        # double-count); the WARNING makes it observable; retry next cycle.
+                        _logger.warning(
+                            "PETASOS_ENFORCEMENT spool over cap; rotation skipped (will retry)"
+                        )
+            except Exception:
+                _logger.debug("enforcement spool bounding failed", exc_info=True)
 
     def _on_audit(self, event: Any) -> None:
         import asyncio
@@ -253,6 +411,11 @@ class ConsoleHandlers:
         }
 
     async def get_scan_history(self, limit: int = 100) -> dict[str, Any]:
+        # PET-131: drain-on-read is the floor that surfaces live enforcement on the
+        # gated-mode polling fallback (PET-83) and in the embedded Hermes plugin path
+        # (no FastAPI startup tailer there). The background tailer is the live-SSE
+        # latency optimization on top; both share the exactly-once drain.
+        await self._drain_enforcement_into_history()
         clamped = min(max(1, limit), 1000)
         return {"entries": list(reversed(self.scan_history.to_list(clamped)))}
 
@@ -380,8 +543,30 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
     static_dir = importlib.resources.files("petasos.console") / "static"
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
+    # PET-131: background enforcement-spool tailer (standalone live-SSE latency).
+    # Embedded Hermes-plugin mode mounts the bare router and never runs this
+    # lifecycle; there the drain-on-read in get_scan_history is the floor.
+    _enforcement_tailer: dict[str, Any] = {"task": None}
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        async def _tail() -> None:
+            while True:
+                try:
+                    await handlers._drain_enforcement_into_history()
+                except Exception:
+                    _logger.debug("enforcement tailer drain failed", exc_info=True)
+                await asyncio.sleep(_ENFORCEMENT_TAIL_INTERVAL_S)
+
+        _enforcement_tailer["task"] = asyncio.create_task(_tail())
+
     @app.on_event("shutdown")
     async def _shutdown() -> None:
+        task = _enforcement_tailer.get("task")
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
         await handlers.sse.shutdown()
 
     @app.get("/", response_class=HTMLResponse)

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -46,6 +46,12 @@ _BLOCK_EVENT_TYPES = frozenset({"block", "quarantine", "tier3"})
 _MAX_TALLY_SESSIONS = 10_000
 # Poll cadence of the dashboard's background enforcement-spool tailer (standalone).
 _ENFORCEMENT_TAIL_INTERVAL_S = 1.0
+# Cap on the surfaced enforcement `reason` length. The raw matched value lives in a
+# finding's `matched_text` (never surfaced); `reason` is the structured scanner/guard
+# message (e.g. "PII detected: PERSON"), already returned to the agent. We cap it so a
+# long decoded-payload message cannot bloat the ring buffer / SSE frame — matching the
+# 200-char block-message truncation in petasos/session/formatting.py.
+_MAX_REASON_LEN = 200
 
 
 def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
@@ -60,6 +66,9 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
     """
     event_type = ev.get("event_type")
     is_block = event_type in _BLOCK_EVENT_TYPES
+    reason = ev.get("reason")
+    if isinstance(reason, str) and len(reason) > _MAX_REASON_LEN:
+        reason = reason[:_MAX_REASON_LEN]
     return {
         "scan_id": ev.get("scan_id"),
         "source": "enforcement",
@@ -74,7 +83,7 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
         "tier": ev.get("tier"),
         "rule_id": ev.get("rule_id"),
         "severity": ev.get("severity"),
-        "reason": ev.get("reason"),
+        "reason": reason,
     }
 
 
@@ -158,6 +167,7 @@ class ConsoleHandlers:
         # truth (D4) — independent of the 500-entry ring's eviction.
         self._enforcement_offset = 0
         self._rot_offset = 0
+        self._enforcement_spool_path: str | None = None
         self._enforcement_lock = asyncio.Lock()
         self._block_tally: dict[str, int] = {}
 
@@ -234,6 +244,13 @@ class ConsoleHandlers:
 
         async with self._enforcement_lock:
             path = _events._spool_path()
+            # The resolved spool can move mid-session (a Hermes profile/config path
+            # switch). Stale byte offsets index a different (possibly smaller) file and
+            # would skip its events, so reset to 0 and read the new spool from the start.
+            if path != self._enforcement_spool_path:
+                self._enforcement_offset = 0
+                self._rot_offset = 0
+                self._enforcement_spool_path = path
             rot = path + _events._ROT_SUFFIX
             # (1) Recover an orphan .rot from a reader that crashed mid-rotation BEFORE
             # touching the live spool, so its undrained events are never overwritten.

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -639,30 +639,66 @@
       if (isNaN(dt.getTime())) return "—"; // guard against Invalid Date
       return pad2(dt.getHours()) + ":" + pad2(dt.getMinutes()) + ":" + pad2(dt.getSeconds());
     }
+    // PET-131: coerce any field to a printable cell — the no-data glyph "—" for
+    // null/empty, never the string "undefined" (a bypassed_disarmed row carries no
+    // tier/rule/severity). Mirrors the existing guarded cells; never throws.
+    function pcell(v, w) {
+      var el = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: w, display: "inline-block" } });
+      el.textContent = (v == null || v === "") ? "—" : String(v);
+      return el;
+    }
     var table = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "6px" } });
     for (var i = 0; i < hist.length; i++) {
       var e = hist[i];
       if (!e || typeof e !== "object") continue; // never-throw: skip a malformed entry (e.g. JSON null from a bad SSE frame) rather than aborting the synchronous re-render
+
+      // PET-131: enforcement rows (source==="enforcement") render distinguishably —
+      // an "enf" source pill, a blocked/bypassed/safe badge, and tool + event/tier in
+      // place of the playground direction/findings pair. Playground rows are
+      // byte-identical to before (no source pill). No em/en dash or double-hyphen in
+      // any label (house style); the only "—" is the no-data glyph.
+      var isEnforcement = (e.source === "enforcement");
+      var et = (e.event_type == null || e.event_type === "") ? "" : String(e.event_type);
+      var isBypass = isEnforcement && et === "bypassed_disarmed";
       var isBlocked = (e.safe === false); // strict ===false; truthy-but-not-false is not "blocked"
-      var badge = Pet.h("span", { className: "pill " + (isBlocked ? "err" : "ok"), style: { minWidth: "62px", justifyContent: "center" } }, isBlocked ? "blocked" : "safe");
 
-      var dirEl = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: "64px", display: "inline-block" } });
-      dirEl.textContent = (e.direction != null && e.direction !== "") ? String(e.direction) : "—";
+      var badgeText = isBypass ? "bypassed (disarmed)" : (isBlocked ? "blocked" : "safe");
+      var badgeClass = isBypass ? "warn" : (isBlocked ? "err" : "ok");
+      var badge = Pet.h("span", { className: "pill " + badgeClass, style: { justifyContent: "center" } }, badgeText);
 
-      var findEl = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: "78px", display: "inline-block" } });
-      findEl.textContent = (Number(e.finding_count) || 0) + " findings";
+      var rowEls = [];
+      if (isEnforcement) {
+        rowEls.push(Pet.h("span", { className: "pill blue", style: { minWidth: "40px", justifyContent: "center", fontSize: "10px" } }, "enf"));
+      }
+      rowEls.push(badge);
+
+      if (isEnforcement) {
+        var tierStr = (e.tier == null || e.tier === "") ? "" : String(e.tier);
+        var etTier = et + (tierStr && tierStr !== et ? (" " + tierStr) : "");
+        rowEls.push(pcell(e.tool, "120px"));
+        rowEls.push(pcell(etTier, "120px"));
+      } else {
+        rowEls.push(pcell(e.direction, "64px"));
+        var findEl = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: "78px", display: "inline-block" } });
+        findEl.textContent = (Number(e.finding_count) || 0) + " findings";
+        rowEls.push(findEl);
+      }
 
       var latEl = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: "56px", display: "inline-block" } });
       latEl.textContent = (Number(e.duration_ms) || 0).toFixed(1) + "ms"; // never e.duration_ms.toFixed — would throw on missing/non-numeric
+      rowEls.push(latEl);
 
       var sidStr = (e.session_id == null || e.session_id === "") ? "" : String(e.session_id);
       var sidEl = Pet.h("span", { className: "mono", title: sidStr, style: { fontSize: "11px", color: "var(--tx-faint)", maxWidth: "120px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "inline-block" } });
       sidEl.textContent = sidStr ? (sidStr.length > 12 ? sidStr.slice(0, 12) + "…" : sidStr) : "—";
+      rowEls.push(sidEl);
 
       var timeEl = Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", marginLeft: "auto", display: "inline-block" } });
       timeEl.textContent = fmtTime(e.timestamp);
+      rowEls.push(timeEl);
 
-      var row = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px" } }, badge, dirEl, findEl, latEl, sidEl, timeEl);
+      var row = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px" } });
+      for (var ri = 0; ri < rowEls.length; ri++) row.appendChild(rowEls[ri]);
       table.appendChild(row);
     }
     return table;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,13 @@ import os
 import pathlib
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
 import jwt as pyjwt
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _FIXTURES = pathlib.Path(__file__).parent / "fixtures"
 _PRIVATE_KEY = (_FIXTURES / "test_private.pem").read_bytes()
@@ -36,6 +40,32 @@ def _make_token(
     if extra_claims:
         payload.update(extra_claims)
     return pyjwt.encode(payload, key or _PRIVATE_KEY, algorithm=algorithm)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_enforcement_spool(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """PET-131: redirect the cross-process enforcement spool to a throwaway temp path
+    for every test.
+
+    The dashboard now drains this spool on ``get_scan_history`` and the gateway
+    ``_pre_tool_call`` block branches append to it, so without isolation a test could
+    read the real machine spool (``%LOCALAPPDATA%/hermes/petasos-enforcement.jsonl``)
+    or pollute it. Tests that inspect the spool read ``_events._spool_path()``, which
+    returns this per-test path. A no-op if the console module is unimportable.
+    """
+    try:
+        import petasos.console._events as _ev
+    except Exception:
+        yield
+        return
+    saved_override = _ev._SPOOL_PATH_OVERRIDE
+    saved_cap = _ev.SPOOL_CAP_BYTES
+    _ev._reset_events_state(str(tmp_path_factory.mktemp("enf_spool") / "enf.jsonl"))
+    try:
+        yield
+    finally:
+        _ev._SPOOL_PATH_OVERRIDE = saved_override
+        _ev.SPOOL_CAP_BYTES = saved_cap
 
 
 @pytest.fixture()

--- a/tests/js/enforcement-history.test.mjs
+++ b/tests/js/enforcement-history.test.mjs
@@ -1,0 +1,180 @@
+// Unit tests for Pet.scanHistoryRows enforcement rendering (petasos.js), PET-131.
+//
+// The Observability history must render live enforcement entries
+// (source==="enforcement") distinguishably from playground scans: an "enf" source
+// pill, a blocked / bypassed / safe badge, and tool + event/tier in place of the
+// playground direction/findings pair. A bypassed_disarmed row carries no
+// tier/rule/severity and must show the no-data glyph, never "undefined". Playground
+// rows render byte-identically to before. Never throws on a malformed/partial/
+// non-object entry (the scan_result SSE handler re-renders synchronously). New
+// operator-facing labels carry no banned dash (em / en / double-hyphen) per house
+// style — the only "—" is the no-data glyph for absent fields.
+//
+// Zero npm deps: Node's built-in test runner + a DOM shim + node:vm over the real
+// shipped petasos.js. Run with: node --test tests/js/enforcement-history.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── DOM shim ────────────────────────────────────────────────────────────────
+// scanHistoryRows uses `el.textContent = ...` on freshly-created spans, so the
+// shim ALLOWS textContent assignment (unlike the PET-103 scanner-health shim). The
+// textContent getter aggregates child text plus any directly-set text.
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    dataset: {},
+    _text: "",
+    setAttribute() {},
+    addEventListener() {},
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
+    },
+    set textContent(v) {
+      this._text = String(v);
+      this.childNodes = [];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+function findEl(node, pred) {
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (pred(child)) return child;
+      const found = findEl(child, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+const hasClass = (cls) => (el) => typeof el.className === "string" && el.className.split(/\s+/).includes(cls);
+function text(tree) {
+  return tree.textContent;
+}
+
+const ENF_BLOCK = {
+  source: "enforcement",
+  safe: false,
+  event_type: "quarantine",
+  tier: "tier2",
+  tool: "send_email",
+  rule_id: "petasos.injection.x",
+  severity: "HIGH",
+  session_id: "sess-1",
+  duration_ms: 5,
+  timestamp: 1700000000,
+  scan_id: "e-001",
+};
+const ENF_BYPASS = {
+  source: "enforcement",
+  safe: true,
+  event_type: "bypassed_disarmed",
+  tool: "send_email",
+  session_id: "sess-2",
+  timestamp: 1700000000,
+  scan_id: "e-002",
+  // tier / rule_id / severity deliberately absent
+};
+const PLAYGROUND = {
+  safe: false,
+  direction: "inbound",
+  finding_count: 2,
+  duration_ms: 3.5,
+  session_id: "sess-p",
+  timestamp: 1700000000,
+  scan_id: "s-aaa",
+};
+
+// ── tests ───────────────────────────────────────────────────────────────
+
+test("loader: petasos.js exports scanHistoryRows", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.scanHistoryRows, "function");
+});
+
+test("enforcement block row renders distinguishably (enf pill + blocked badge + tool)", () => {
+  const tree = Pet.scanHistoryRows([ENF_BLOCK]);
+  const enfPill = findEl(tree, hasClass("blue"));
+  assert.ok(enfPill, "expected an 'enf' source pill");
+  assert.equal(enfPill.textContent, "enf");
+
+  const blockedBadge = findEl(tree, (el) => hasClass("err")(el) && el.textContent === "blocked");
+  assert.ok(blockedBadge, "expected a 'blocked' (pill err) badge");
+
+  const t = text(tree);
+  assert.ok(t.includes("send_email"), "tool name rendered");
+  assert.ok(t.includes("quarantine"), "event_type rendered");
+});
+
+test("bypassed_disarmed row: warn badge, no tier/rule/severity rendered as 'undefined'", () => {
+  const tree = Pet.scanHistoryRows([ENF_BYPASS]);
+  const badge = findEl(tree, (el) => hasClass("warn")(el) && el.textContent === "bypassed (disarmed)");
+  assert.ok(badge, "expected a 'bypassed (disarmed)' (pill warn) badge");
+  // It must NOT count as blocked (no 'err' badge present).
+  assert.equal(findEl(tree, (el) => hasClass("err")(el)), null, "bypass must not be a blocked/err badge");
+  // Absent fields show the no-data glyph, never the string 'undefined'.
+  assert.ok(!/undefined/.test(text(tree)), "no 'undefined' for absent tier/rule/severity");
+});
+
+test("playground row renders unchanged (no enf pill; findings count present)", () => {
+  const tree = Pet.scanHistoryRows([PLAYGROUND]);
+  assert.equal(findEl(tree, hasClass("blue")), null, "playground row has no 'enf' source pill");
+  const blockedBadge = findEl(tree, (el) => hasClass("err")(el) && el.textContent === "blocked");
+  assert.ok(blockedBadge, "playground blocked badge preserved");
+  assert.ok(text(tree).includes("2 findings"), "playground findings count preserved");
+});
+
+test("never throws on malformed / partial / non-object entries", () => {
+  assert.doesNotThrow(() => Pet.scanHistoryRows([{ source: "enforcement" }])); // no tool/event/safe
+  assert.doesNotThrow(() => Pet.scanHistoryRows([null, 42, "x"])); // non-object entries skipped
+  // A non-object entry alongside a valid enforcement entry: the valid one still renders.
+  const tree = Pet.scanHistoryRows([null, ENF_BLOCK]);
+  assert.ok(text(tree).includes("send_email"));
+});
+
+test("enforcement labels carry no banned dash (em / en / double-hyphen)", () => {
+  // Fully-populated rows so no field falls back to the no-data glyph '—'; what
+  // remains is pure label text, which must be dash-free per house style.
+  const tree = Pet.scanHistoryRows([ENF_BLOCK, { ...ENF_BYPASS, tier: "n/a", rule_id: "n/a", severity: "n/a" }]);
+  const t = text(tree);
+  assert.ok(!t.includes("—"), "no em dash in labels");
+  assert.ok(!t.includes("–"), "no en dash in labels");
+  assert.ok(!t.includes("--"), "no double-hyphen in labels");
+});

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -1,0 +1,561 @@
+"""PET-131: cross-process enforcement-event surfacing on the Observability tab.
+
+The gateway (``reference_plugin._pre_tool_call``) emits a structured enforcement
+event onto a file spool beside each block/quarantine/tier3/disarmed-bypass
+decision; the dashboard (``ConsoleHandlers``) drains the spool into its
+``scan_history`` ring buffer + ``scan_result`` SSE stream so live enforcement
+reaches the operator. Each test pins a vector that silently failed before PET-131.
+
+Backend-free: no Presidio / ML pipeline. The guard is stubbed and the spool is
+redirected to a temp file via ``_events._reset_events_state``.
+
+Regression for PET-131: enforcement that blocks without surfacing is a trust
+failure (the operator is flown blind while ~45% of tool calls are blocked).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import petasos.console._events as ev  # noqa: E402
+from petasos import GuardResult, PetasosConfig, Pipeline, ScanFinding, Severity  # noqa: E402
+from petasos.console.server import ConsoleHandlers  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+if TYPE_CHECKING:
+    import types
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+_EGRESS = frozenset({"send_email", "http_request", "clipboard_write"})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / harness
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def spool() -> str:
+    """The per-test enforcement-spool path.
+
+    The autouse ``_isolate_enforcement_spool`` conftest fixture already redirected
+    the spool to a throwaway temp path (and restores the override + cap on teardown);
+    this returns that path for tests that read/write/assert on the spool directly.
+    """
+    return ev._spool_path()
+
+
+@pytest.fixture()
+def handlers() -> ConsoleHandlers:
+    pipeline = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    return ConsoleHandlers(pipeline)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet131", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _guard_result(
+    *,
+    findings: tuple[ScanFinding, ...] = (),
+    tier: str = "none",
+    allowed: bool = True,
+    reason: str = "allowed",
+    param_scan_unsafe: bool = False,
+    param_scan_degraded: bool = False,
+) -> GuardResult:
+    return GuardResult(
+        allowed=allowed,
+        reason=reason,
+        findings=findings,
+        tier=tier,
+        param_scan_unsafe=param_scan_unsafe,
+        param_scan_degraded=param_scan_degraded,
+    )
+
+
+def _finding(finding_type: str, severity: Severity = Severity.HIGH) -> ScanFinding:
+    return ScanFinding(
+        rule_id=f"petasos.{finding_type}.x",
+        finding_type=finding_type,
+        severity=severity,
+        confidence=0.9,
+        message=f"{finding_type} finding",
+        scanner_name="minimal" if finding_type != "pii" else "presidio",
+    )
+
+
+def _setup_plugin(ref: Any, monkeypatch: pytest.MonkeyPatch, *, armed: bool = True) -> None:
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: armed)
+    monkeypatch.setattr(ref, "_egress_sink_tools", _EGRESS)
+    monkeypatch.setattr(ref, "_guard", type("G", (), {"evaluate": lambda self, *a, **k: None})())
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+
+
+def _read_spool(path: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if s:
+                    out.append(json.loads(s))
+    except FileNotFoundError:
+        pass
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Break 1: every gateway decision emits a structured enforcement event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("kind", "tool", "guard", "expect"),
+    [
+        (
+            "tier3",
+            "send_email",
+            _guard_result(tier="tier3"),
+            {"event_type": "tier3", "tier": "tier3"},
+        ),
+        (
+            "block",
+            "send_email",
+            _guard_result(allowed=False, reason="blocked by escalation", tier="tier2"),
+            {"event_type": "block", "tier": "tier2"},
+        ),
+        (
+            "degraded",
+            "send_email",
+            _guard_result(param_scan_degraded=True),
+            {"event_type": "quarantine"},
+        ),
+        (
+            "non_pii_high",
+            "send_email",
+            _guard_result(
+                findings=(_finding("injection", Severity.HIGH),), param_scan_unsafe=True
+            ),
+            {"event_type": "quarantine", "severity": "HIGH", "rule_id": "petasos.injection.x"},
+        ),
+        (
+            "pii_egress",
+            "send_email",
+            _guard_result(findings=(_finding("pii", Severity.CRITICAL),), param_scan_unsafe=True),
+            {"event_type": "quarantine", "severity": "CRITICAL"},
+        ),
+    ],
+)
+def test_block_emits_enforcement_event(
+    spool: str,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    tool: str,
+    guard: GuardResult,
+    expect: dict[str, Any],
+) -> None:
+    # The headline regression (Break 1): a _pre_tool_call that blocks emits exactly
+    # one enforcement event carrying session + tool + the attribution in scope.
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: guard)
+
+    out = ref._pre_tool_call(tool, {"text": "x"}, task_id="sess-A")
+    assert out is not None and out["action"] == "block", f"{kind} should block"
+
+    events = _read_spool(spool)
+    assert len(events) == 1, f"{kind}: expected exactly one enforcement event"
+    e = events[0]
+    assert e["session_id"] == "sess-A"
+    assert e["tool"] == tool
+    assert e["direction"] == "tool_call"
+    assert e["scan_id"].startswith("e-")
+    for key, val in expect.items():
+        assert e[key] == val, f"{kind}: {key}"
+
+
+def test_allowed_call_emits_no_event(spool: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A clean pass-through (armed, allowed, no findings) writes nothing to the spool.
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: _guard_result())
+    assert ref._pre_tool_call("send_email", {"text": "x"}, task_id="s") is None
+    assert _read_spool(spool) == []
+
+
+# ---------------------------------------------------------------------------
+# Break 2: drained events land on the scanHistory surface, not auditLog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforcement_event_reaches_observability_buffer(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    ev.emit_enforcement_event(
+        {"session_id": "s1", "tool": "send_email", "event_type": "quarantine", "severity": "HIGH"}
+    )
+    await handlers._drain_enforcement_into_history()
+
+    rows = handlers.scan_history.to_list()
+    assert len(rows) == 1
+    row = rows[0]
+    # Lands on the scanHistory surface the tiles read; tagged enforcement; counts
+    # as blocked (safe is False -> the *blocked* tile increments via `safe===false`).
+    assert row["source"] == "enforcement"
+    assert row["safe"] is False
+    assert row["tool"] == "send_email"
+    assert row["direction"] == "tool_call"
+
+
+# ---------------------------------------------------------------------------
+# Break 3: surfaced across the process / pipeline-instance boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dashboard_observes_gateway_enforcement(spool: str) -> None:
+    # The dashboard self-initialized its own host_id="dashboard" pipeline — a separate
+    # instance from any gateway pipeline. The event still surfaces because the channel
+    # is transport-level (the spool), not pipeline-instance-scoped.
+    dash = ConsoleHandlers(
+        Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(), host_id="dashboard")
+    )
+    ev.emit_enforcement_event({"session_id": "s1", "tool": "http_request", "event_type": "block"})
+    await dash._drain_enforcement_into_history()
+    assert any(r.get("source") == "enforcement" for r in dash.scan_history.to_list())
+
+
+# ---------------------------------------------------------------------------
+# D4: reconciliation — block tally == N == block-class log-line count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_block_count_reconciles_with_log(
+    spool: str,
+    handlers: ConsoleHandlers,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch)
+    gr = _guard_result(findings=(_finding("injection", Severity.HIGH),), param_scan_unsafe=True)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: gr)
+
+    n = 5
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        for _ in range(n):
+            ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-R")
+
+    await handlers._drain_enforcement_into_history()
+
+    log_blocks = sum(
+        1
+        for rec in caplog.records
+        if any(
+            p in rec.getMessage() for p in ("PETASOS_QUARANTINE", "PETASOS_BLOCK", "PETASOS_TIER3")
+        )
+        and "sess-R" in rec.getMessage()
+    )
+    assert log_blocks == n
+    assert handlers.block_tally_for("sess-R") == n
+    assert len(_read_spool(spool)) == n
+
+
+@pytest.mark.asyncio
+async def test_block_count_survives_ring_eviction(spool: str, handlers: ConsoleHandlers) -> None:
+    # The per-session tally is independent of the 500-entry ring's eviction — the
+    # case that distinguishes the running tally from a buffer-scoped count (D4).
+    n = 560
+    for _ in range(n):
+        ev.emit_enforcement_event(
+            {"session_id": "sess-long", "tool": "send_email", "event_type": "quarantine"}
+        )
+    await handlers._drain_enforcement_into_history()
+
+    assert len(handlers.scan_history.to_list()) == 500  # ring evicted to its cap
+    assert handlers.block_tally_for("sess-long") == n  # tally survived the rollover
+
+
+# ---------------------------------------------------------------------------
+# Independence from armed state (PET-130 tie-in) + across profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observability_correct_when_disarmed(
+    spool: str, handlers: ConsoleHandlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch, armed=False)
+    ref._reset_disarm_log()
+
+    # A burst of disarmed pass-throughs in one 30s window emits exactly ONE
+    # distinguishable bypassed_disarmed event (1:1 with the PETASOS_DISARMED log line).
+    for _ in range(4):
+        assert ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-D") is None
+
+    events = _read_spool(spool)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "bypassed_disarmed"
+    assert events[0]["armed"] is False
+
+    await handlers._drain_enforcement_into_history()
+    rows = handlers.scan_history.to_list()
+    assert len(rows) == 1
+    assert rows[0]["safe"] is True  # a bypass is visible but NOT counted as blocked
+    assert handlers.block_tally_for("sess-D") == 0  # the bypass does not move the tally
+
+
+@pytest.mark.asyncio
+async def test_observability_correct_across_profiles(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # No profile-scoped filtering on the event path: enforcement from a non-default
+    # profile's session surfaces identically and tallies independently.
+    for sess in ("default-sess", "gibson-sess"):
+        ev.emit_enforcement_event(
+            {"session_id": sess, "tool": "send_email", "event_type": "quarantine"}
+        )
+    await handlers._drain_enforcement_into_history()
+    assert handlers.block_tally_for("default-sess") == 1
+    assert handlers.block_tally_for("gibson-sess") == 1
+    assert len(handlers.scan_history.to_list()) == 2
+
+
+# ---------------------------------------------------------------------------
+# D5: fail-open telemetry floor
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_emission_never_blocks_toolcall(
+    spool: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch)
+    gr = _guard_result(findings=(_finding("injection", Severity.HIGH),), param_scan_unsafe=True)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: gr)
+
+    # A raising sink must not change the verdict nor throw out of _pre_tool_call.
+    def _boom(event: dict[str, Any]) -> bool:
+        raise RuntimeError("spool on fire")
+
+    monkeypatch.setattr(ev, "emit_enforcement_event", _boom)
+    out = ref._pre_tool_call("send_email", {"text": "x"}, task_id="s")
+    assert out is not None and out["action"] == "block"
+
+    # A slow sink must also leave the verdict and the call path intact.
+    import time as _time
+
+    def _slow(event: dict[str, Any]) -> bool:
+        _time.sleep(0.02)
+        return False
+
+    monkeypatch.setattr(ev, "emit_enforcement_event", _slow)
+    out2 = ref._pre_tool_call("send_email", {"text": "x"}, task_id="s")
+    assert out2 is not None and out2["action"] == "block"
+
+
+# ---------------------------------------------------------------------------
+# Spool primitive: bounding, rotation, restart, paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforcement_spool_bounded(spool: str, handlers: ConsoleHandlers) -> None:
+    # A tiny cap forces reader-owned rotation; every event still surfaces exactly once
+    # and the live spool is bounded (rotated away), not grown without bound.
+    ev.SPOOL_CAP_BYTES = 1
+    n = 10
+    ids = []
+    for i in range(n):
+        ev.emit_enforcement_event(
+            {"scan_id": f"e-{i:04d}", "session_id": "s", "tool": "t", "event_type": "quarantine"}
+        )
+        ids.append(f"e-{i:04d}")
+    await handlers._drain_enforcement_into_history()
+
+    surfaced = [r["scan_id"] for r in handlers.scan_history.to_list()]
+    assert sorted(surfaced) == sorted(ids)  # all n, none lost, none duplicated
+    assert ev.spool_size(spool) == 0  # rotated + cleared -> live spool bounded
+
+
+@pytest.mark.asyncio
+async def test_enforcement_survives_gateway_seq_reset(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # The reader cursors on a byte offset, not a producer seq. A gateway restart
+    # (its per-process counter resetting) cannot make the dashboard drop new events:
+    # appends simply continue and the byte offset advances past them.
+    for i in range(3):
+        ev.emit_enforcement_event(
+            {"scan_id": f"e-a{i}", "session_id": "s", "tool": "t", "event_type": "block"}
+        )
+    await handlers._drain_enforcement_into_history()
+    assert len(handlers.scan_history.to_list()) == 3
+
+    # "Gateway restart": a fresh producer keeps appending to the same spool.
+    for i in range(3):
+        ev.emit_enforcement_event(
+            {"scan_id": f"e-b{i}", "session_id": "s", "tool": "t", "event_type": "block"}
+        )
+    await handlers._drain_enforcement_into_history()
+    ids = {r["scan_id"] for r in handlers.scan_history.to_list()}
+    assert ids == {"e-a0", "e-a1", "e-a2", "e-b0", "e-b1", "e-b2"}
+
+
+@pytest.mark.asyncio
+async def test_reader_rotation_captures_inflight_and_no_doublecount(
+    spool: str, handlers: ConsoleHandlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A line the gateway appends in the window between the reader's last read and the
+    # rename is captured by the .rot drain (forward from the committed offset), not
+    # lost; nothing is double-pushed and the tally is unchanged by the rotation.
+    ev.SPOOL_CAP_BYTES = 1
+    ev.emit_enforcement_event(
+        {"scan_id": "e-A", "session_id": "s", "tool": "t", "event_type": "block"}
+    )
+
+    orig_rotate = ev.rotate_spool
+
+    def _rotate_with_inflight(path: str | None = None) -> bool:
+        # The gateway appends B after the reader's last read but before the rename.
+        ev.emit_enforcement_event(
+            {"scan_id": "e-B", "session_id": "s", "tool": "t", "event_type": "block"}
+        )
+        return orig_rotate(path)
+
+    monkeypatch.setattr(ev, "rotate_spool", _rotate_with_inflight)
+    await handlers._drain_enforcement_into_history()
+
+    ids = [r["scan_id"] for r in handlers.scan_history.to_list()]
+    assert sorted(ids) == ["e-A", "e-B"]  # in-flight B captured, A not re-pushed
+    assert handlers.block_tally_for("s") == 2  # exactly two, no rotation double-count
+
+
+@pytest.mark.asyncio
+async def test_orphan_rot_recovered_not_overwritten(spool: str, handlers: ConsoleHandlers) -> None:
+    # A .rot left by a reader that crashed mid-rotation is recovered (drained +
+    # unlinked) before any new rotation, so its events are never overwritten/lost.
+    rot = spool + ev._ROT_SUFFIX
+    with open(rot, "w", encoding="utf-8") as f:
+        f.write(
+            json.dumps({"scan_id": "e-X", "session_id": "s", "tool": "t", "event_type": "block"})
+            + "\n"
+        )
+        f.write(
+            json.dumps({"scan_id": "e-Y", "session_id": "s", "tool": "t", "event_type": "block"})
+            + "\n"
+        )
+    ev.emit_enforcement_event(
+        {"scan_id": "e-Z", "session_id": "s", "tool": "t", "event_type": "block"}
+    )
+
+    await handlers._drain_enforcement_into_history()
+    ids = {r["scan_id"] for r in handlers.scan_history.to_list()}
+    assert ids == {"e-X", "e-Y", "e-Z"}
+    assert not os.path.exists(rot)  # orphan recovered + cleared
+
+
+@pytest.mark.asyncio
+async def test_drain_exactly_once_under_concurrency(spool: str, handlers: ConsoleHandlers) -> None:
+    # The background tailer and a concurrent get_scan_history drain against one spool
+    # each yield every scan_id exactly once (one asyncio.Lock; forward offset). Includes
+    # an over-cap spool so the concurrent path exercises rotation under the lock.
+    ev.SPOOL_CAP_BYTES = 1
+    for i in range(8):
+        ev.emit_enforcement_event(
+            {"scan_id": f"e-{i}", "session_id": "s", "tool": "t", "event_type": "block"}
+        )
+
+    await asyncio.gather(
+        handlers._drain_enforcement_into_history(),
+        handlers._drain_enforcement_into_history(),
+        handlers.get_scan_history(),
+    )
+    ids = [r["scan_id"] for r in handlers.scan_history.to_list()]
+    assert sorted(ids) == [f"e-{i}" for i in range(8)]  # each exactly once
+    assert handlers.block_tally_for("s") == 8
+
+
+@pytest.mark.asyncio
+async def test_enforcement_visible_on_polling_fallback(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # Drain-on-read: get_scan_history surfaces enforcement with no live SSE and no
+    # background tailer running (the gated-mode polling fallback floor, PET-83).
+    ev.emit_enforcement_event(
+        {"session_id": "s", "tool": "send_email", "event_type": "quarantine"}
+    )
+    res = await handlers.get_scan_history()
+    assert any(e.get("source") == "enforcement" for e in res["entries"])
+
+
+@pytest.mark.asyncio
+async def test_live_enforcement_row_survives_a_poll(spool: str, handlers: ConsoleHandlers) -> None:
+    # A row delivered "live" (drain) is still present after a subsequent poll, because
+    # the server ring is the single source of truth and get_scan_history serves it.
+    ev.emit_enforcement_event(
+        {"scan_id": "e-live", "session_id": "s", "tool": "t", "event_type": "block"}
+    )
+    await handlers._drain_enforcement_into_history()
+    res = await handlers.get_scan_history()
+    assert any(e.get("scan_id") == "e-live" for e in res["entries"])
+
+
+@pytest.mark.asyncio
+async def test_enforcement_visible_via_embedded_plugin_route(
+    spool: str, handlers: ConsoleHandlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The embedded Hermes plugin route delegates to the same drained get_scan_history,
+    # so the D-WIN gated-Windows floor holds with no FastAPI startup tailer.
+    import petasos.console.hermes.plugin_api as papi
+
+    monkeypatch.setattr(papi, "_require_handlers", lambda: handlers)
+    ev.emit_enforcement_event({"session_id": "s", "tool": "send_email", "event_type": "block"})
+    res = await papi.get_scan_history(100)
+    assert any(e.get("source") == "enforcement" for e in res["entries"])
+
+
+def test_spool_path_identical_under_dangling_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Gateway-emit and dashboard-drain resolve to the SAME spool file even under a
+    # dangling active_profile (root-tier fallback), because both compute the path from
+    # the one resolve_hermes_config_path() recomputed per call.
+    from petasos.console._paths import HermesConfigResolution
+
+    ev._reset_events_state(None)  # use the real resolver path for this test
+    root_cfg = tmp_path / "config.yaml"
+    res = HermesConfigResolution(path=root_cfg, tier="root", warning="active_profile dangling")
+    monkeypatch.setattr(ev, "resolve_hermes_config_path", lambda: res)
+
+    p1 = ev._spool_path()  # "gateway"
+    p2 = ev._spool_path()  # "dashboard"
+    assert p1 == p2 == os.path.join(str(tmp_path), ev._SPOOL_FILENAME)

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -559,3 +559,68 @@ def test_spool_path_identical_under_dangling_profile(
     p1 = ev._spool_path()  # "gateway"
     p2 = ev._spool_path()  # "dashboard"
     assert p1 == p2 == os.path.join(str(tmp_path), ev._SPOOL_FILENAME)
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit follow-ups (PR #117)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_spool_path_change_resets_offset(handlers: ConsoleHandlers, tmp_path: Path) -> None:
+    # A Hermes profile/config path switch points the drain at a different (smaller)
+    # spool. The stale byte offset must reset to 0 so the new spool's events are not
+    # skipped (CodeRabbit PR #117).
+    p1 = str(tmp_path / "a.jsonl")
+    ev._reset_events_state(p1)
+    ev.emit_enforcement_event(
+        {"scan_id": "e-1", "session_id": "s", "tool": "t", "event_type": "block"}
+    )
+    await handlers._drain_enforcement_into_history()
+    assert {r["scan_id"] for r in handlers.scan_history.to_list()} == {"e-1"}
+
+    p2 = str(tmp_path / "b.jsonl")  # a fresh, smaller spool at a new path
+    ev._reset_events_state(p2)
+    ev.emit_enforcement_event(
+        {"scan_id": "e-2", "session_id": "s", "tool": "t", "event_type": "block"}
+    )
+    await handlers._drain_enforcement_into_history()
+    # Without the offset reset, the stale (larger) offset would skip e-2.
+    assert "e-2" in {r["scan_id"] for r in handlers.scan_history.to_list()}
+
+
+@pytest.mark.asyncio
+async def test_long_reason_is_capped(spool: str, handlers: ConsoleHandlers) -> None:
+    # A long scanner/guard message must not bloat the ring buffer / SSE frame
+    # (CodeRabbit PR #117). The raw matched value is never in `reason` to begin with.
+    ev.emit_enforcement_event(
+        {"session_id": "s", "tool": "t", "event_type": "quarantine", "reason": "x" * 500}
+    )
+    await handlers._drain_enforcement_into_history()
+    assert len(handlers.scan_history.to_list()[0]["reason"]) == 200
+
+
+def test_fallback_init_window_block_emits_event(
+    spool: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A cold-start (init-window) block via _fallback_pre_tool_call is still a gateway
+    # block and must surface to the operator (CodeRabbit PR #117).
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+    monkeypatch.setattr(ref, "_ensure_initialized", lambda: False)  # init in progress
+    monkeypatch.setattr(
+        ref, "_get_fallback_scanner", lambda: type("S", (), {"scan": lambda self, *a, **k: None})()
+    )
+    scan_result = type("R", (), {"findings": (_finding("injection", Severity.CRITICAL),)})()
+    monkeypatch.setattr(ref, "_run_async", lambda coro: scan_result)
+
+    out = ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-F")
+    assert out is not None and out["action"] == "block"
+    events = _read_spool(spool)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "quarantine"
+    assert events[0]["session_id"] == "sess-F"
+    assert events[0]["tool"] == "send_email"
+    assert events[0]["rule_id"] == "petasos.injection.x"


### PR DESCRIPTION
## Summary
- The Hermes gateway blocked tool calls but only logged a `PETASOS_QUARANTINE`-class warning and returned a block dict; nothing reached the Observability tab. During the PET-130 gibson session Petasos blocked ~45% of tool calls while the dashboard showed zero — the operator was flown blind. This adds a **transport-level enforcement-event channel** so live blocks surface.
- The gateway emits a structured event beside each block/quarantine/tier3/disarmed-bypass decision; the dashboard drains it into the **same** `scan_history` ring buffer + `scan_result` SSE stream the four tiles and history panel already read (not the dead `auditLog` arm).
- The channel is a **file spool** (the only cross-process primitive in the codebase — gateway and dashboard are separate processes), so it is independent of which pipeline instance the dashboard bound. This dissolves the process/instance boundary rather than patching the `_shared_pipeline` vs `host_id="dashboard"` fork.

## Layered defense
The event sits beside the existing log line (one emit per log line → log and surface share one source of truth). The drain is exactly-once under a single `asyncio.Lock`; a per-session block tally reconciles with the log and **survives ring-buffer eviction** (the brief's running-total requirement). Telemetry is **fail-open**: emission never gates, delays, or breaks a tool call (raising *and* slow sinks tested). The reader is forward-only on a **byte offset** (restart-independent — a gateway restart cannot drop post-restart events); bounding is reader-owned rotation (atomic rename + drain-forward, no in-place tail rewrite) with orphan-`.rot` crash recovery. Visible on both the live-SSE path and the gated-mode `/api/scan-history` polling fallback (PET-83), in standalone and embedded Hermes-plugin modes.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_events.py` | New — cross-process enforcement spool (fail-open writer, forward-only byte-offset reader, reader-owned rotation + orphan recovery); `_armed.py`/`_reload.py` sibling |
| `docs/deployment/reference_plugin/__init__.py` | Emits a self-guarded fail-open enforcement event at each `_pre_tool_call` decision branch; `_log_disarmed_bypass` returns bool so the bypass event shares its rate-limit clock |
| `petasos/console/server.py` | `ConsoleHandlers` asyncio-locked exactly-once drain (background tailer + drain-on-read), unified `scan_history` summary with a `source` discriminator, per-session reconciliation tally |
| `petasos/console/static/petasos.js` | `scanHistoryRows` renders enforcement rows distinguishably (enf pill, blocked/bypassed/safe badge, tool + event/tier); playground rows unchanged; never-throw; no banned dash |
| `tests/conftest.py` | Autouse fixture isolating the cross-process spool to a per-test temp path |
| `tests/test_enforcement_events.py` | New — 22 backend regressions (breaks 1/2/3, reconciliation + ring-eviction survival, disarmed, fail-open, rotation/restart/concurrency, polling-fallback, embedded route) |
| `tests/js/enforcement-history.test.mjs` | New — 6 frontend rendering regressions |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/test_enforcement_events.py tests/test_console_server.py tests/test_console_handlers.py tests/test_reference_plugin_egress.py --deselect ...validation::test_default_ignorable_rejected --deselect ...handlers::test_get_about` — 107/107 pass (full output: docs/specs/TODO/PET-131.test-output.txt)
- [x] `node --test tests/js/enforcement-history.test.mjs` — 6/6 pass
- [x] Full suite: 1753 passed, 41 skipped, 2 deselected, 1 xfailed
- [x] `ruff check .`, `ruff format --check .`, `mypy --strict .` — clean
- [x] The two deselects are pre-existing master failures unrelated to this change (`test_default_ignorable_rejected` Unicode-13-vs-14; `test_get_about` asserts the stale `0.1.0` version, package is now 0.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cross-process enforcement-event spool that publishes structured enforcement outcomes (including block, tier-3, bypassed/disarmed, and quarantine) to the dashboard.
  * Console now drains enforcement events into scan history with exactly-once reconciliation, rotation-safe recovery, and per-session block tallying; history polling also performs a drain fallback.
  * Updated scan-history UI to render enforcement entries with distinct pills/badges and consistent “no data” cell formatting.
* **Tests**
  * Added backend regression tests for spool emission/draining/rotation and fail-open telemetry behavior, plus new JS rendering tests and an enforcement-spool isolation fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->