### PR TITLE
fix(pet-132): re-establishable boot-pin on a trusted profile change

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -220,6 +220,41 @@ short-circuit `_pre_tool_call` before any scan runs, so a disarmed pipeline neve
 reaches tier evaluation or rule matching. Do not mistake the floor for
 self-disarm protection.
 
+### Profile changes require a restart (the boot profile is pinned)
+
+Petasos pins its config resolution **once, at plugin registration**, from the
+operator-trusted boot environment (PET-130). Every armed-bit read and every live
+config reload resolves through that boot pin, so a per-profile gateway process
+enforces its own profile correctly for its whole lifetime. This is the supported
+model on Hermes 0.16.x, where each gateway is a per-profile process with its own
+`HERMES_HOME`.
+
+The pin is captured at boot and is **not** re-derived on a profile change. If a
+running gateway process is ever retargeted to a different profile **in place**
+(a live profile swap with no process restart), Petasos keeps enforcing the
+**boot** profile's policy: a disarm, a tier change, or any `petasos:` edit written
+to the *new* profile is not picked up. For a security control that is the wrong
+default, so the contract is explicit:
+
+- [ ] **A security-relevant profile change requires a gateway/process restart.**
+      Restart the gateway after switching the active profile; do not rely on a
+      live swap to move enforcement. Confirm the new binding from the log line
+      `PETASOS_ARMED_RESOLUTION tier=<t> path=<p>` (it names the `config.yaml` the
+      running process is pinned to). If it still names the old profile, the
+      process did not re-bind: restart it.
+
+PET-132 ships the Petasos half of the eventual no-restart path: an
+operator-trusted re-bind worker that re-pins the resolution, resets the
+armed/reload caches, and hot-applies the new profile's config. It is **dormant**
+until Hermes fires a trusted profile-change signal that names the new profile
+home out-of-band from anything the guarded agent can write (the re-bind never
+re-reads the agent-writable `active_profile` pointer, preserving the section 6
+boundary). Until that Hermes-side signal exists, the restart contract above is
+the only supported way to change a security-bearing gateway's profile. When the
+re-bind does fire, the pipeline/guard config is process-wide, so it applies to
+every session the process hosts; in-flight sessions see the new shared config at
+their next tool call (the swap does not drain them first).
+
 ---
 
 *Companion docs: [hermes-desktop.md](hermes-desktop.md) (step-by-step Hermes

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -22,6 +22,7 @@ import os
 import threading
 import time
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from petasos._types import Severity  # PET-112: dep-light (enum + dataclasses, no ML imports)
@@ -83,6 +84,43 @@ _DISARM_LOG_EVERY_S = 30.0
 _reload_log_lock = threading.Lock()
 _last_attribution_log = 0.0
 _last_reload_fail_log = 0.0
+
+# PET-132: live profile-swap re-bind. PET-130 pins _session_resolution once at boot;
+# these make the pin RE-establishable on an operator-trusted profile change without a
+# process restart. _rebind_to_profile re-captures the resolution from the TRUSTED profile
+# home (never the agent-writable active_profile pointer, PET-125 / Decision 2), resets the
+# (mtime,size)-keyed armed/reload caches (Decision 5), refreshes _config, and hot-applies
+# the pipeline config via PET-126's _apply_reconfigure (Decision 4). The whole worker runs
+# under _rebind_lock so concurrent re-binds commit in re-pin order (Decision 7). The two
+# process-global flags keep a re-runnable register() (the forced-rediscovery route) from
+# double-registering hooks or spawning a second init thread (Decision 3). _last_rebind_log
+# is a DEDICATED clock — never the disarm/reload clocks — so a routine reload failure
+# cannot suppress a one-shot operator-triggered re-bind line (Decision 6).
+_rebind_lock = threading.Lock()
+_hooks_registered = False
+_init_thread_started = False
+_rebind_log_lock = threading.Lock()
+_last_rebind_log = 0.0
+
+
+def _reset_hooks_registered() -> None:
+    """Test seam — clear the one-shot hook-registration flag (Decision 3)."""
+    global _hooks_registered
+    _hooks_registered = False
+
+
+def _reset_init_thread_started() -> None:
+    """Test seam — clear the one-shot init-thread-spawn flag (Decision 3)."""
+    global _init_thread_started
+    _init_thread_started = False
+
+
+def _reset_rebind_log() -> None:
+    """Test seam — reset the dedicated re-bind rate-limit clock (Decision 6)."""
+    global _last_rebind_log
+    with _rebind_log_lock:
+        _last_rebind_log = 0.0
+
 
 # PET-107: sub-agent lineage (Option A). The registry is constructed in
 # _deferred_init (it shares the tracker's clock + lock discipline), but the
@@ -807,6 +845,195 @@ def _maybe_reconfigure() -> None:
     _log_reconfigure_applied()
 
 
+# ---------------------------------------------------------------------------
+# PET-132: trusted profile-swap re-bind (re-establish the boot-pin on a profile change)
+# ---------------------------------------------------------------------------
+
+
+def _validated_profile_home(profile_home: Any) -> tuple[Path | None, str]:
+    """Validate a trusted profile-change payload (Decision 2/6 fail-secure floor).
+
+    Returns ``(home, "")`` on success or ``(None, reason)`` on rejection. The payload
+    must be a non-empty, ABSOLUTE path that resolves to an existing directory. The
+    absolute check runs BEFORE ``resolve()`` so a relative path can never be anchored to
+    the process CWD — closing the CWD vector the brief's D-WIN names (an agent that can
+    chdir cannot make a relative home resolve into a tree it controls). ``resolve(strict=
+    False)`` normalizes a well-formed absolute path (``..`` segments) without requiring
+    every component to pre-exist; the ``is_dir()`` check is the existence gate.
+    """
+    if not profile_home:
+        return None, "empty profile_home"
+    if not isinstance(profile_home, (str, os.PathLike)):
+        return None, f"non-path profile_home type={type(profile_home).__name__}"
+    candidate = Path(profile_home)
+    # Absolute BEFORE resolve(): resolve() would anchor a relative path to CWD and mask
+    # the rejection. On Windows is_absolute() requires a drive or UNC root, so a bare or
+    # mixed-separator relative path is rejected here (tested on win32).
+    if not candidate.is_absolute():
+        return None, f"non-absolute profile_home {str(profile_home)!r}"
+    try:
+        home = candidate.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None, f"unresolvable profile_home {str(profile_home)!r}"
+    if not home.is_dir():
+        return None, f"profile_home is not an existing directory: {home}"
+    return home, ""
+
+
+def _log_rebind_skipped(reason: str) -> None:
+    """Rate-limited WARNING: a malformed/untrusted profile-change payload was rejected;
+    the boot binding, caches, and live config are left unchanged (fail-secure, Decision
+    6). Uses the dedicated ``_last_rebind_log`` clock so a routine reload failure cannot
+    suppress this operator-triggered attribution line."""
+    global _last_rebind_log
+    now = time.monotonic()
+    with _rebind_log_lock:
+        if now - _last_rebind_log < _DISARM_LOG_EVERY_S:
+            return
+        _last_rebind_log = now
+    logger.warning("PETASOS_REBIND_SKIPPED reason=%s", reason)
+
+
+def _log_rebind_config_stale(res: HermesConfigResolution, detail: str | BaseException) -> None:
+    """Rate-limited WARNING: a valid re-pin landed but the heavier pipeline config did
+    not apply (no ``petasos:`` section, build failure, or apply failure). The binding has
+    already moved, so the armed bit honors the new profile immediately; the pipeline keeps
+    last-good via ``_apply_reconfigure``'s two-phase guarantee. Loud + attributable so the
+    transient armed/pipeline divergence (Decision 6) is never silent. Accepts a string
+    reason or an exception so the None-path, build-failure, and apply-failure call sites
+    all type-check (correctness round-3 F-1). Dedicated clock."""
+    global _last_rebind_log
+    now = time.monotonic()
+    with _rebind_log_lock:
+        if now - _last_rebind_log < _DISARM_LOG_EVERY_S:
+            return
+        _last_rebind_log = now
+    logger.warning("PETASOS_REBIND_CONFIG_STALE path=%s: %s", res.path, detail)
+
+
+def _dispatch_reconfigure(cfg: PetasosConfig, on_success, on_error) -> None:
+    """Schedule ``_apply_reconfigure(cfg)`` on ``_async_loop`` WITHOUT blocking the caller
+    (Decision 4). PET-126's ``_maybe_reconfigure`` blocks up to 15s on ``future.result()``;
+    that is fine on the tool-call hot path but not on an operator-interactive profile-change
+    callback that may run while ``_async_loop`` is busy with an ML scan. Reuses
+    ``_ensure_async_loop()`` + ``run_coroutine_threadsafe`` (the guts of ``_run_async``,
+    minus the blocking ``.result()``) so loop access stays single-sourced. The completion
+    callback runs ``on_success`` when the apply committed or ``on_error`` if it raised —
+    both on the loop thread, after ``_rebind_lock`` has been released (Decision 7)."""
+    _ensure_async_loop()
+    future = asyncio.run_coroutine_threadsafe(_apply_reconfigure(cfg), _async_loop)
+
+    def _done(fut: Any) -> None:
+        try:
+            fut.result()
+        except Exception as exc:
+            on_error(exc)
+        else:
+            on_success()
+
+    future.add_done_callback(_done)
+
+
+def _apply_live(res: HermesConfigResolution) -> None:
+    """Hot-apply the new profile via the same peek/commit sequence as
+    ``_maybe_reconfigure`` (Decision 4/5). The reload cache was reset by the worker, so a
+    non-empty ``petasos:`` section at the new profile reads as a change; a missing/empty/
+    malformed section yields ``None`` -> keep last-good policy by design (the armed bit is
+    independently re-stat'd and honored, fail-secure ``True``). Either way the outcome is
+    attributable, never silent."""
+    from petasos.console._reload import commit_seen, read_changed_section
+
+    changed = read_changed_section(res)
+    if changed is None:
+        _log_rebind_config_stale(
+            res, "no petasos: section at new profile; keeping last-good policy"
+        )
+        return
+    section, key = changed
+    try:
+        cfg = _build_config_from_section(section)
+    except Exception as exc:
+        _log_rebind_config_stale(res, exc)
+        return
+
+    def _on_apply_error(exc: BaseException) -> None:
+        # On apply failure also reset the reload cache so a stale committed key from a
+        # superseded re-bind cannot suppress the next re-read (Decision 5 / Decision 7).
+        from petasos.console._reload import _reset_reload_cache
+
+        _reset_reload_cache()
+        _log_rebind_config_stale(res, exc)
+
+    _dispatch_reconfigure(
+        cfg,
+        on_success=lambda: commit_seen(key, res),  # settle the reload cache on the new profile
+        on_error=_on_apply_error,
+    )
+
+
+def _rebind_to_resolution(res: HermesConfigResolution) -> None:
+    """Serialized re-pin + cache reset + ``_config`` refresh + branch decision + dispatch
+    (Decisions 3/5/7). ``_deferred_init`` holds ``_init_lock`` across its whole build and
+    flips ``_initialized`` only at the end while still holding it, so while we hold
+    ``_init_lock`` the build is never mid-flight: ``_initialized`` is either already-True
+    (init done) or will-read-our-``_config`` (init not yet started). Deciding the branch
+    under the SAME ``_init_lock`` acquisition makes case selection race-free, closing the
+    init-window TOCTOU. Lock order is strictly ``_rebind_lock`` then ``_init_lock``
+    (acyclic; ``_deferred_init`` takes only ``_init_lock``)."""
+    global _session_resolution, _config
+    from petasos.console._armed import _reset_armed_cache
+    from petasos.console._reload import _reset_reload_cache
+
+    with _rebind_lock:
+        _session_resolution = res  # re-pin; the armed bit follows immediately
+        _reset_armed_cache()  # Decision 5: drop W's (mtime,size)-keyed bit
+        _reset_reload_cache()  # Decision 5: force the new profile to read as a change
+        logger.info("PETASOS_ARMED_RESOLUTION tier=%s path=%s", res.tier, res.path)
+
+        # Refresh _config AND decide the branch under the SAME _init_lock acquisition.
+        with _init_lock:
+            _config = _load_config(res)
+            live = _initialized and _pipeline is not None and _guard is not None
+            failed = (not live) and _init_error is not None
+
+        if live:
+            _apply_live(res)  # peek/build/dispatch the new profile onto the live pipeline
+        elif failed:
+            logger.warning(
+                "PETASOS_REBIND_NOPIPELINE path=%s: init failed earlier; "
+                "binding moved, no pipeline to reconfigure",
+                res.path,
+            )
+        else:
+            # Init window: _deferred_init has not yet read _config and will build from the
+            # resolution we just stored. No apply here (no pipeline yet). Honest wording:
+            # _deferred_init swallows a malformed section to PetasosConfig() defaults with
+            # only its own generic validation log, so the binding move is attributable here
+            # but the config outcome is NOT guaranteed to be the new profile's.
+            logger.info(
+                "PETASOS_REBIND_PENDING_INIT path=%s: scanner init in flight; new "
+                "profile staged, applied at init only if it validates (else defaults)",
+                res.path,
+            )
+
+
+def _rebind_to_profile(profile_home: Any) -> None:
+    """Internal re-bind worker entry. Validates the trusted payload (fail-secure: a bad
+    payload keeps the current binding, Decision 6), constructs the resolution DIRECTLY
+    from the trusted home (Decision 2: never ``resolve_hermes_config_path`` /
+    ``read_active_profile``), and delegates to the serialized worker."""
+    home, reason = _validated_profile_home(profile_home)
+    if home is None:
+        _log_rebind_skipped(reason)  # binding + caches + config unchanged
+        return
+    from petasos.console._paths import HermesConfigResolution
+
+    # tier="profile" is a valid Tier literal; omitting warning defaults it to None, which
+    # satisfies the dataclass invariant "warning non-None only when tier=='root'".
+    res = HermesConfigResolution(path=home / "config.yaml", tier="profile")
+    _rebind_to_resolution(res)
+
+
 def _pre_tool_call(
     tool_name: str, args: dict, task_id: str = "", **kwargs
 ) -> dict[str, str] | None:
@@ -972,6 +1199,18 @@ def _on_session_start(**kwargs) -> None:
     logger.info("PETASOS_SESSION_START — Petasos content security active")
 
 
+def _on_profile_change(profile_name: str = "", profile_home: str = "", **kwargs: Any) -> None:
+    """PET-132: trusted Hermes profile-change signal. Hermes fires this only from the
+    operator-trusted swap path with the new profile's home; Petasos does not re-derive the
+    identity (Decision 2). ``profile_name`` is cosmetic and logged via ``%r`` (repr escapes
+    any newline/control char) so a crafted name cannot inject a forged
+    ``PETASOS_ARMED_RESOLUTION`` line; the load-bearing identity is the path, logged
+    separately by the worker (Decision 6). Registered defensively via _try_register_hook,
+    so a host without the event simply never calls it (dormant, safe)."""
+    logger.info("PETASOS_PROFILE_CHANGE name=%r", profile_name or "<unnamed>")
+    _rebind_to_profile(profile_home)
+
+
 def _subagent_start(parent_session_id: str = "", child_session_id: str = "", **kwargs) -> None:
     """Host-asserted lineage edge: child spawned by parent (PET-107 D2).
 
@@ -1021,13 +1260,22 @@ def _try_register_hook(ctx, name: str, handler) -> bool:
 
 def register(ctx) -> None:
     global _config, _subagent_hooks_available, _session_resolution
+    global _hooks_registered, _init_thread_started
+
+    # PET-132: a re-runnable register() is the forced-rediscovery re-bind route (Decision
+    # 1 fallback / Decision 3). The FIRST register() of an uninitialized process spawns
+    # _deferred_init; a SECOND one (Hermes re-ran discovery under the new profile env)
+    # must re-bind the live pipeline instead of double-registering hooks or spawning a
+    # duplicate init thread. Latch the boot-vs-rebind decision BEFORE the flags move.
+    first_boot = not _init_thread_started and not _initialized and not _init_error
 
     # PET-130: capture the session-bound resolution FIRST — before any hook is
     # registered or the init thread starts — so the first _pre_tool_call cannot
     # observe a None binding and fall back to an ambient resolve. Pre-clear to None
     # so a re-register whose capture fails cannot leave a stale prior binding. The
     # binding source is the operator-trusted boot environment, never in-session
-    # state (PET-125 / Decision 2).
+    # state (PET-125 / Decision 2). On the forced-rediscovery route Hermes has set the
+    # env to the new profile, so this re-captures the new profile here too.
     _session_resolution = None
     try:
         from petasos.console._paths import resolve_hermes_config_path
@@ -1039,8 +1287,10 @@ def register(ctx) -> None:
             "failed (%s); falling back to per-call resolve",
             exc,
         )
-    if _session_resolution is not None:
+    if first_boot and _session_resolution is not None:
         # D2: greppable, names the tier + absolute path the armed/reload reads pin to.
+        # On a re-register the worker (below) re-emits this line after re-pinning, so it
+        # is logged exactly once per register() either way.
         logger.info(
             "PETASOS_ARMED_RESOLUTION tier=%s path=%s",
             _session_resolution.tier,
@@ -1053,33 +1303,58 @@ def register(ctx) -> None:
         logger.error("Failed to load petasos config: %s", exc)
         _config = {}
 
-    ctx.register_hook("pre_tool_call", _pre_tool_call)
-    ctx.register_hook("post_tool_call", _post_tool_call)
-    ctx.register_hook("on_session_start", _on_session_start)
+    # PET-132: register every hook exactly once per process (Decision 3). The already-
+    # registered closures read the module globals (_session_resolution, _config,
+    # _pipeline, _guard) dynamically, so a re-register's new binding is observed without
+    # re-registration; a second register() onto a fresh ctx intentionally skips it.
+    if not _hooks_registered:
+        ctx.register_hook("pre_tool_call", _pre_tool_call)
+        ctx.register_hook("post_tool_call", _post_tool_call)
+        ctx.register_hook("on_session_start", _on_session_start)
 
-    # PET-107: sub-agent lineage hooks (Option A). Registered defensively — both
-    # must be accepted, else A degrades fully to C (an edge store that never sees
-    # subagent_stop would leak edges to the TTL/on_terminate backstop only).
-    start_ok = _try_register_hook(ctx, "subagent_start", _subagent_start)
-    stop_ok = _try_register_hook(ctx, "subagent_stop", _subagent_stop)
-    _subagent_hooks_available = start_ok and stop_ok
-    if not _subagent_hooks_available:
-        rejected = [
-            name
-            for name, ok in (("subagent_start", start_ok), ("subagent_stop", stop_ok))
-            if not ok
-        ]
-        logger.warning(
-            "Petasos sub-agent lineage (A) inactive — hook(s) unavailable: %s. "
-            "Delegation fan-out gate (C) remains active.",
-            ", ".join(rejected),
+        # PET-107: sub-agent lineage hooks (Option A). Registered defensively — both
+        # must be accepted, else A degrades fully to C (an edge store that never sees
+        # subagent_stop would leak edges to the TTL/on_terminate backstop only).
+        start_ok = _try_register_hook(ctx, "subagent_start", _subagent_start)
+        stop_ok = _try_register_hook(ctx, "subagent_stop", _subagent_stop)
+        _subagent_hooks_available = start_ok and stop_ok
+        if not _subagent_hooks_available:
+            rejected = [
+                name
+                for name, ok in (("subagent_start", start_ok), ("subagent_stop", stop_ok))
+                if not ok
+            ]
+            logger.warning(
+                "Petasos sub-agent lineage (A) inactive — hook(s) unavailable: %s. "
+                "Delegation fan-out gate (C) remains active.",
+                ", ".join(rejected),
+            )
+
+        # PET-132: the trusted profile-change re-bind hook. Registered defensively so a
+        # host without on_profile_change degrades to "restart required" (Decision 8)
+        # rather than crashing; on every host today it is simply never fired (dormant).
+        _try_register_hook(ctx, "on_profile_change", _on_profile_change)
+
+        _hooks_registered = True
+
+    if first_boot:
+        _init_thread_started = True
+        init_thread = threading.Thread(
+            target=_deferred_init,
+            daemon=True,
+            name="petasos-init",
         )
-
-    init_thread = threading.Thread(
-        target=_deferred_init,
-        daemon=True,
-        name="petasos-init",
-    )
-    init_thread.start()
-
-    logger.info("Petasos plugin registered — hooks active, scanner init in background")
+        init_thread.start()
+        logger.info("Petasos plugin registered — hooks active, scanner init in background")
+    elif _session_resolution is not None:
+        # Forced-rediscovery re-register of an already-started process: re-bind the live
+        # pipeline to the freshly-captured resolution (re-pin, reset the (mtime,size)-keyed
+        # caches, re-emit ARMED_RESOLUTION, hot-apply / stage per init state). The init
+        # thread is NOT re-spawned (Decision 3).
+        _rebind_to_resolution(_session_resolution)
+        logger.info("Petasos plugin re-registered — re-bound to the current profile resolution")
+    else:
+        logger.warning(
+            "Petasos re-register: boot capture failed and no prior binding to re-bind; "
+            "enforcement reflects the last good binding until restart"
+        )

--- a/tests/test_profile_rebind.py
+++ b/tests/test_profile_rebind.py
@@ -551,17 +551,23 @@ def test_concurrent_rebinds_converge(tmp_path: Path, monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
 
     barrier = threading.Barrier(2)
+    errors: list[Exception] = []
 
     def _fire(home: Path) -> None:
-        barrier.wait()
-        ref._on_profile_change(profile_home=str(home))
+        try:
+            barrier.wait(timeout=2.0)
+            ref._on_profile_change(profile_home=str(home))
+        except Exception as exc:  # noqa: BLE001 — record, assert empty later
+            errors.append(exc)
 
     t1 = threading.Thread(target=_fire, args=(x_home,))
     t2 = threading.Thread(target=_fire, args=(y_home,))
     t1.start()
     t2.start()
-    t1.join()
-    t2.join()
+    t1.join(timeout=2.0)
+    t2.join(timeout=2.0)
+    assert not t1.is_alive() and not t2.is_alive(), "rebind workers did not finish"
+    assert errors == [], f"worker errors: {errors!r}"
 
     expected = {
         (x_home / "config.yaml").resolve(strict=False): "closed",

--- a/tests/test_profile_rebind.py
+++ b/tests/test_profile_rebind.py
@@ -1,0 +1,623 @@
+"""PET-132: trusted live profile-swap re-bind (reference_plugin).
+
+PET-130 pins the gateway's config resolution (``_session_resolution``) once at
+``register()`` from the operator-trusted boot environment. PET-132 makes the pin
+RE-establishable on a trusted profile change without a process restart: a
+``_on_profile_change`` hook (and a re-runnable ``register()``) re-captures the
+resolution from the trusted profile home, resets the ``(mtime,size)``-keyed
+armed/reload caches, refreshes ``_config``, and hot-applies the new profile's
+pipeline config via PET-126's ``_apply_reconfigure`` — all without ever re-reading
+the agent-writable ``active_profile`` pointer (PET-125).
+
+Harness mirrors ``test_console_reload.py``: a fresh plugin module per test (isolated
+module globals) imported via ``importlib``, trusted ``profile_home`` tmp dirs built
+with a ``config.yaml``, a ``_FakeCtx`` capturing ``register_hook`` calls, and an
+autouse fixture that resets the SHARED singleton caches the importlib re-import does
+not touch (``_armed`` / ``_reload``). Live-pipeline assertions run the dispatched
+apply synchronously (the repo's ``_run_async -> asyncio.run`` idiom) so the
+non-deterministic loop dispatch does not flake the test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import petasos.console._armed as armed_mod
+import petasos.console._reload as reload_mod
+from petasos.config import PetasosConfig
+from petasos.normalize import canonicalize_tool_name
+from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import MinimalScanner
+from petasos.session.frequency import FrequencyTracker
+from petasos.session.guard import ToolCallGuard
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterator
+
+    from petasos.console._paths import Tier
+
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet132", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_config(path: Path, petasos_section: dict[str, Any] | None) -> None:
+    import yaml
+
+    data: dict[str, Any] = {"model": {"provider": "test"}}
+    if petasos_section is not None:
+        data["petasos"] = petasos_section
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+
+
+def _profile_home(tmp_path: Path, name: str, section: dict[str, Any] | None) -> Path:
+    """Build an absolute profile home ``<tmp>/profiles/<name>`` with a ``config.yaml``."""
+    home = tmp_path / "profiles" / name
+    _write_config(home / "config.yaml", section)
+    return home
+
+
+def _make_resolution(path: Path, tier: Tier = "profile") -> Any:
+    from petasos.console._paths import HermesConfigResolution
+
+    return HermesConfigResolution(path=path, tier=tier)
+
+
+def _same_config(actual: Path, home: Path) -> bool:
+    """True if ``actual`` names ``<home>/config.yaml``, robust to per-platform path
+    normalization (the hook path resolve()s the home; the register/HERMES_HOME path does
+    not)."""
+    return actual.resolve(strict=False) == (home / "config.yaml").resolve(strict=False)
+
+
+def _install_sync_dispatch(ref: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the dispatched ``_apply_reconfigure`` synchronously (fresh loop) so live-path
+    assertions are deterministic — the repo's established ``_run_async -> asyncio.run``
+    idiom (``test_console_reload.py``). Exercises the real ``_apply_live`` /
+    ``_apply_reconfigure``; only the loop-dispatch mechanism is stubbed."""
+
+    def _sync(cfg: Any, on_success: Any, on_error: Any) -> None:
+        try:
+            asyncio.run(ref._apply_reconfigure(cfg))
+        except Exception as exc:
+            on_error(exc)
+        else:
+            on_success()
+
+    monkeypatch.setattr(ref, "_dispatch_reconfigure", _sync)
+
+
+def _wire_live(
+    ref: types.ModuleType, monkeypatch: pytest.MonkeyPatch, section: dict[str, Any]
+) -> tuple[Any, Any]:
+    """Build a real live pipeline + guard from ``section`` and mark the module
+    initialized, so the re-bind worker takes its live-apply branch deterministically."""
+    cfg = ref._build_config_from_section(section)
+    pipe = Pipeline(scanners=[MinimalScanner()], config=cfg)
+    tracker = FrequencyTracker(cfg)
+    guard = ToolCallGuard(pipe, tracker, cfg, lineage=None)
+    monkeypatch.setattr(ref, "_pipeline", pipe)
+    monkeypatch.setattr(ref, "_guard", guard)
+    monkeypatch.setattr(ref, "_lineage_registry", None)
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(
+        ref,
+        "_egress_sink_tools",
+        frozenset(c for c in (canonicalize_tool_name(t) for t in cfg.egress_sink_tools) if c),
+    )
+    _install_sync_dispatch(ref, monkeypatch)
+    return pipe, guard
+
+
+class _FakeCtx:
+    """Minimal Hermes plugin ctx; captures registered hook names and can reject some."""
+
+    def __init__(self, reject: set[str] | None = None) -> None:
+        self.registered: list[str] = []
+        self._reject = reject or set()
+
+    def register_hook(self, name: str, handler: object) -> None:
+        if name in self._reject:
+            raise ValueError(f"unknown hook: {name!r}")
+        self.registered.append(name)
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # The (mtime_ns, size)-keyed singleton caches live in the SHARED _armed / _reload
+    # modules, which importlib does not re-import per test — reset so a fresh tmp file
+    # can't be served a coincidentally-matching stale key.
+    armed_mod._reset_armed_cache()
+    reload_mod._reset_reload_cache()
+    for var in ("PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY", "PETASOS_LICENSE_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    yield
+    armed_mod._reset_armed_cache()
+    reload_mod._reset_reload_cache()
+
+
+# ── headline + cache coherence ────────────────────────────────────────────────
+
+
+def test_rebind_honors_new_profile_disarm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132: boot-bound to W (enabled:true); a trusted re-bind to X
+    # (enabled:false) is honored within one call — _is_armed() False, binding names X,
+    # and the next _pre_tool_call passes through.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    x_home = _profile_home(tmp_path, "x", {"enabled": False})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+    assert ref._is_armed() is True  # booted armed on W
+
+    ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    assert _same_config(ref._session_resolution.path, x_home)
+    assert ref._is_armed() is False
+    assert ref._pre_tool_call("shell", {"cmd": "x"}, task_id="s1") is None  # pass-through
+
+
+def test_rebind_survives_mtime_size_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-132 (Decision 5): after a W->X re-pin, a stale armed bit cached
+    # under a (mtime_ns, size) key that COLLIDES with X's key would, without the cache
+    # reset, serve W's value. Simulate that exact collision and assert the re-bind's
+    # _reset_armed_cache() makes X's real disarm win over the colliding key.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    x_home = _profile_home(tmp_path, "x", {"enabled": False})
+    x_res = _make_resolution(x_home / "config.yaml")
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    st = (x_home / "config.yaml").stat()
+    x_key = (st.st_mtime_ns, st.st_size)
+    # Seed the armed cache as if W's armed bit were cached under X's exact key (collision).
+    armed_mod._ARMED_CACHE = (x_key, True, time.monotonic())
+    # Control: with the stale entry present, a read at X's key HITS and returns True.
+    assert armed_mod.read_armed(x_res) is True
+
+    ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    # The re-bind reset the cache, so X is re-stat'd and its disarm wins over the collision.
+    assert ref._is_armed() is False
+
+
+def test_rebind_reapplies_full_pipeline_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-132 (Decision 4/5): a live re-bind re-applies the new profile's
+    # FULL pipeline config (fail_mode + egress set) via _apply_reconfigure, not just the
+    # armed bit; and the on-success commit_seen settles the reload cache so no redundant
+    # re-apply is queued on the next call.
+    ref = _import_reference_plugin()
+    w_section = {"enabled": True, "fail_mode": "degraded", "egress_sink_tools": ["w_tool"]}
+    pipe, _guard = _wire_live(ref, monkeypatch, w_section)
+    w_home = _profile_home(tmp_path, "w", {"enabled": True, "fail_mode": "degraded"})
+    x_home = _profile_home(
+        tmp_path, "x", {"enabled": True, "fail_mode": "closed", "egress_sink_tools": ["x_tool"]}
+    )
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+    assert pipe.config.fail_mode == "degraded"
+    assert ref._is_egress_sink("w_tool") is True
+    assert ref._is_egress_sink("x_tool") is False
+
+    ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    assert _same_config(ref._session_resolution.path, x_home)
+    assert pipe.config.fail_mode == "closed"  # X's pipeline policy is live
+    assert ref._is_egress_sink("x_tool") is True  # X's egress set is live
+    assert ref._is_egress_sink("w_tool") is False  # W's is gone
+    # commit_seen settled the reload cache on X -> the next reconfigure check is a no-op.
+    assert reload_mod.read_changed_section(ref._session_resolution) is None
+
+
+# ── the PET-125 boundary survives the swap ──────────────────────────────────────
+
+
+def test_rebind_is_operator_trusted_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132 / PET-125: the re-bind identity comes ONLY from the trusted
+    # payload. An in-session agent rewriting active_profile / HERMES_HOME must not move the
+    # binding, and the worker must never consult resolve_hermes_config_path or
+    # read_active_profile. A sentinel on both fails the test if the re-bind path hits them.
+    import petasos.console._paths as paths_mod
+
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    x_home = _profile_home(tmp_path, "x", {"enabled": False})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise AssertionError("re-bind re-derived identity from agent-writable state (PET-125)")
+
+    monkeypatch.setattr(paths_mod, "resolve_hermes_config_path", _boom)
+    monkeypatch.setattr(paths_mod, "read_active_profile", _boom)
+    # An agent points HERMES_HOME at a profile it controls; the re-bind must ignore it.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "attacker_controlled"))
+
+    ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    assert _same_config(ref._session_resolution.path, x_home)  # trusted payload, not env
+    assert ref._is_armed() is False  # X's disarm, not the attacker's HERMES_HOME
+
+
+def test_rebind_rejects_unsafe_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 2/6): empty, relative, file-not-dir, and
+    # non-existent profile_home each leave the boot binding intact, stay armed, and emit
+    # PETASOS_REBIND_SKIPPED. _session_resolution is never left None.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    boot = _make_resolution(w_home / "config.yaml")
+    monkeypatch.setattr(ref, "_session_resolution", boot)
+
+    a_file = tmp_path / "a_file"
+    a_file.write_text("x", encoding="utf-8")
+    bad_inputs: list[Any] = [
+        "",  # empty
+        "relative/profile",  # relative (non-absolute on every platform)
+        str(a_file),  # absolute but a file, not a directory
+        str(tmp_path / "does_not_exist"),  # absolute but missing
+    ]
+    if sys.platform == "win32":
+        # A bare backslash-separated relative path is non-absolute on Windows (no drive /
+        # UNC root); gated to win32 so it tests Windows separator policy on Windows rather
+        # than passing for the wrong reason on POSIX.
+        bad_inputs.append("profiles\\gibson")
+
+    for bad in bad_inputs:
+        ref._reset_rebind_log()  # each rejection must be independently attributable
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+            ref._on_profile_change(profile_name="x", profile_home=bad)
+        assert ref._session_resolution is boot  # binding object unchanged
+        assert ref._is_armed() is True  # stays armed on W
+        skipped = [r for r in caplog.records if "PETASOS_REBIND_SKIPPED" in r.getMessage()]
+        assert len(skipped) == 1, f"no skip log for {bad!r}"
+
+
+def test_rebind_to_absolute_windows_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132 (brief D-WIN positive path): a well-formed ABSOLUTE profile
+    # home (the real Hermes payload shape) is accepted and moves the binding — proving
+    # _validated_profile_home does not over-reject absolute homes.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    x_home = _profile_home(tmp_path, "gibson", {"enabled": False})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+    assert x_home.is_absolute()  # tmp_path is absolute on every platform
+
+    ref._on_profile_change(profile_name="gibson", profile_home=str(x_home))
+
+    assert _same_config(ref._session_resolution.path, x_home)
+    assert ref._is_armed() is False
+
+
+def test_rebind_to_sectionless_profile_keeps_lastgood(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 5 / _apply_live None path): re-bind to an X whose
+    # config.yaml has NO petasos: section -> the binding moves and _is_armed() reflects X
+    # (fail-secure True), the live pipeline keeps W's last-good policy, and a
+    # PETASOS_REBIND_CONFIG_STALE line is emitted (never silent).
+    ref = _import_reference_plugin()
+    pipe, _guard = _wire_live(ref, monkeypatch, {"enabled": True, "fail_mode": "closed"})
+    w_home = _profile_home(tmp_path, "w", {"enabled": True, "fail_mode": "closed"})
+    x_home = _profile_home(tmp_path, "x", None)  # config.yaml with no petasos: section
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+    ref._reset_rebind_log()
+
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    assert _same_config(ref._session_resolution.path, x_home)  # binding moved
+    assert ref._is_armed() is True  # X has no petasos: section -> read_armed fail-secure True
+    assert pipe.config.fail_mode == "closed"  # W's last-good pipeline policy kept
+    stale = [r for r in caplog.records if "PETASOS_REBIND_CONFIG_STALE" in r.getMessage()]
+    assert len(stale) == 1
+
+
+# ── init-window correctness ─────────────────────────────────────────────────────
+
+
+def test_rebind_during_init_window_builds_new_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 3 case 2, both interleavings): the in-_init_lock
+    # branch decision is race-free.
+    # (a) Worker wins the race (init not yet started): the re-bind stages X into _config
+    #     under _init_lock; _deferred_init then builds the pipeline from X, no second
+    #     petasos-init thread spawned by the hook path.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True, "fail_mode": "degraded"})
+    x_home = _profile_home(tmp_path, "x", {"enabled": True, "fail_mode": "closed"})
+    monkeypatch.setattr(ref, "_config", {"enabled": True, "fail_mode": "degraded"})
+    monkeypatch.setattr(ref, "_initialized", False)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_pipeline", None)
+    monkeypatch.setattr(ref, "_guard", None)
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+    pending = [r for r in caplog.records if "PETASOS_REBIND_PENDING_INIT" in r.getMessage()]
+    assert len(pending) == 1  # init-window branch taken
+    assert _same_config(ref._session_resolution.path, x_home)
+    assert ref._config.get("fail_mode") == "closed"  # X staged for _deferred_init
+    assert ref._init_thread_started is False  # the hook path spawns no init thread
+
+    ref._deferred_init()  # now let init build from the staged profile
+    assert ref._initialized is True
+    assert ref._pipeline is not None
+    assert ref._pipeline.config.fail_mode == "closed"  # built from X, not W
+
+    # (b) Init completes first, THEN the re-bind fires: the worker observes _initialized
+    #     True and takes the live apply, so the pipeline reflects the new profile.
+    ref2 = _import_reference_plugin()
+    pipe2, _g2 = _wire_live(ref2, monkeypatch, {"enabled": True, "fail_mode": "degraded"})
+    w2_home = _profile_home(tmp_path, "w2", {"enabled": True, "fail_mode": "degraded"})
+    y_home = _profile_home(tmp_path, "y", {"enabled": True, "fail_mode": "open"})
+    monkeypatch.setattr(ref2, "_session_resolution", _make_resolution(w2_home / "config.yaml"))
+
+    ref2._on_profile_change(profile_name="y", profile_home=str(y_home))
+    assert _same_config(ref2._session_resolution.path, y_home)
+    assert pipe2.config.fail_mode == "open"  # live apply built from Y
+
+
+def test_rebind_initwindow_malformed_profile_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Deferred symmetry / attributability): a re-bind during the
+    # init window to an X whose petasos: section is non-empty but fails PetasosConfig
+    # validation stages X; _deferred_init then falls back to PetasosConfig() defaults. The
+    # PENDING_INIT line is honest about the validate-or-defaults fork (this impl did not
+    # adopt the optional pre-validate; that option would emit CONFIG_STALE instead).
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    # redaction_mode is constrained; an invalid value fails _build_config_from_section.
+    x_home = _profile_home(tmp_path, "x", {"enabled": True, "redaction_mode": "bogus"})
+    monkeypatch.setattr(ref, "_config", {"enabled": True})
+    monkeypatch.setattr(ref, "_initialized", False)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_pipeline", None)
+    monkeypatch.setattr(ref, "_guard", None)
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+        pending = [r for r in caplog.records if "PETASOS_REBIND_PENDING_INIT" in r.getMessage()]
+        assert len(pending) == 1
+        ref._deferred_init()
+
+    assert ref._initialized is True
+    assert ref._pipeline is not None
+    # malformed X -> _deferred_init fell back to PetasosConfig() defaults (fail-secure).
+    assert ref._pipeline.config.redaction_mode == PetasosConfig().redaction_mode
+
+
+def test_session_start_does_not_rebind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132: _on_session_start carries no profile and must never move the
+    # binding or re-resolve config (locks out the naive fix).
+    import petasos.console._paths as paths_mod
+
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    boot = _make_resolution(w_home / "config.yaml")
+    monkeypatch.setattr(ref, "_session_resolution", boot)
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise AssertionError("on_session_start must not re-resolve config")
+
+    monkeypatch.setattr(paths_mod, "resolve_hermes_config_path", _boom)
+
+    ref._on_session_start(session_id="s1", model="m", platform="p")
+
+    assert ref._session_resolution is boot  # binding unchanged
+
+
+# ── re-runnable register() (forced-rediscovery route) ───────────────────────────
+
+
+def test_register_idempotent_rebind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132 (Decision 3): two register() calls under different profile
+    # homes leave exactly one set of hooks, spawn the init thread once, end on the second
+    # profile's config, and leak no prior-profile state.
+    ref = _import_reference_plugin()
+
+    spawns: list[str] = []
+
+    class _NoStartThread:
+        # Records construction and never runs the target, so init stays deterministic and
+        # fast and the spawn count is observable (Decision 3: spawned exactly once).
+        def __init__(
+            self, *a: Any, target: Any = None, name: str = "", daemon: bool = False, **k: Any
+        ) -> None:
+            spawns.append(name)
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(ref.threading, "Thread", _NoStartThread)
+
+    w_home = _profile_home(tmp_path, "w", {"enabled": True, "fail_mode": "degraded"})
+    x_home = _profile_home(tmp_path, "x", {"enabled": True, "fail_mode": "closed"})
+    ctx = _FakeCtx()
+
+    monkeypatch.setenv("HERMES_HOME", str(w_home))
+    ref.register(ctx)
+    monkeypatch.setenv("HERMES_HOME", str(x_home))
+    ref.register(ctx)  # forced-rediscovery re-register under the new profile env
+
+    for hook in ("pre_tool_call", "post_tool_call", "on_session_start", "on_profile_change"):
+        assert ctx.registered.count(hook) == 1  # no duplicate hooks
+    assert ref._init_thread_started is True
+    assert spawns.count("petasos-init") == 1  # init thread spawned exactly once
+    assert _same_config(ref._session_resolution.path, x_home)  # ended on X, no leaked W
+    assert ref._config.get("fail_mode") == "closed"
+
+
+# ── observability + attributability ─────────────────────────────────────────────
+
+
+def test_rebind_reemits_armed_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 6): a successful re-bind re-emits
+    # PETASOS_ARMED_RESOLUTION tier= path= naming the new profile (mirrors the PET-130
+    # boot line) so the active binding stays greppable after a swap.
+    ref = _import_reference_plugin()
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    x_home = _profile_home(tmp_path, "x", {"enabled": True})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    res_lines = [
+        r.getMessage() for r in caplog.records if "PETASOS_ARMED_RESOLUTION" in r.getMessage()
+    ]
+    assert len(res_lines) == 1
+    assert "tier=profile" in res_lines[0]
+    assert str((x_home / "config.yaml").resolve(strict=False)) in res_lines[0]
+
+
+def test_rebind_log_not_suppressed_by_reload_clock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 6): the re-bind logs use a DEDICATED clock, so a
+    # routine PET-126 reload failure cannot suppress a one-shot re-bind attribution line
+    # within the same rate-limit window.
+    ref = _import_reference_plugin()
+    _pipe, _guard = _wire_live(ref, monkeypatch, {"enabled": True, "fail_mode": "degraded"})
+    ref._reset_reload_logs()
+    ref._reset_rebind_log()
+
+    w_home = _profile_home(tmp_path, "w", {"redaction_mode": "bogus"})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        # 1) Routine reload failure on the boot binding (malformed section -> build fails).
+        ref._maybe_reconfigure()
+        # 2) A re-bind whose new profile is also malformed -> PETASOS_REBIND_CONFIG_STALE,
+        #    within the same window. Different clock -> not suppressed.
+        x_home = _profile_home(tmp_path, "x", {"redaction_mode": "also_bogus"})
+        ref._on_profile_change(profile_name="x", profile_home=str(x_home))
+
+    reload_fail = [r for r in caplog.records if "PETASOS_RELOAD_FAILED" in r.getMessage()]
+    rebind_stale = [r for r in caplog.records if "PETASOS_REBIND_CONFIG_STALE" in r.getMessage()]
+    assert len(reload_fail) == 1
+    assert len(rebind_stale) == 1
+
+
+# ── concurrency ─────────────────────────────────────────────────────────────────
+
+
+def test_concurrent_rebinds_converge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-132 (Decision 7): two re-binds (X then Y) from two threads end
+    # with _session_resolution and the live pipeline config in agreement (the last re-pin
+    # under _rebind_lock wins for both); and a trailing re-bind whose apply FAILS resets
+    # the reload cache (on_error) so a stale committed key cannot suppress the next read.
+    ref = _import_reference_plugin()
+    pipe, _guard = _wire_live(ref, monkeypatch, {"enabled": True, "fail_mode": "degraded"})
+    w_home = _profile_home(tmp_path, "w", {"enabled": True, "fail_mode": "degraded"})
+    x_home = _profile_home(tmp_path, "x", {"enabled": True, "fail_mode": "closed"})
+    y_home = _profile_home(tmp_path, "y", {"enabled": True, "fail_mode": "open"})
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+
+    barrier = threading.Barrier(2)
+
+    def _fire(home: Path) -> None:
+        barrier.wait()
+        ref._on_profile_change(profile_home=str(home))
+
+    t1 = threading.Thread(target=_fire, args=(x_home,))
+    t2 = threading.Thread(target=_fire, args=(y_home,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    expected = {
+        (x_home / "config.yaml").resolve(strict=False): "closed",
+        (y_home / "config.yaml").resolve(strict=False): "open",
+    }
+    final = ref._session_resolution.path.resolve(strict=False)
+    assert pipe.config.fail_mode == expected[final]  # binding and config agree
+
+    # Sub-case: a trailing re-bind whose apply FAILS must reset the reload cache (on_error),
+    # so a stale committed key from a superseded re-bind cannot suppress the next re-read.
+    reset_calls = {"n": 0}
+    real_reset = reload_mod._reset_reload_cache
+
+    def _counting_reset() -> None:
+        reset_calls["n"] += 1
+        real_reset()
+
+    def _raise_apply(_cfg: Any) -> Any:
+        raise RuntimeError("forced apply failure")
+
+    monkeypatch.setattr(reload_mod, "_reset_reload_cache", _counting_reset)
+    monkeypatch.setattr(ref, "_apply_reconfigure", _raise_apply)
+    z_home = _profile_home(tmp_path, "z", {"enabled": True, "fail_mode": "closed"})
+
+    ref._on_profile_change(profile_home=str(z_home))
+
+    assert _same_config(ref._session_resolution.path, z_home)  # binding still moved
+    # worker-top reset + on_error reset: the failed apply must additionally reset the cache.
+    assert reset_calls["n"] >= 2
+    assert reload_mod._RELOAD_CACHE is None  # not left committed to a superseded profile
+
+
+# ── the documented interim contract (no Hermes signal yet) ──────────────────────
+
+
+def test_no_trusted_signal_means_restart_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-132 (Decision 8): a host whose register_hook rejects
+    # on_profile_change degrades cleanly — _try_register_hook returns False, a warning is
+    # logged, the boot binding is intact and armed, and register() does not crash.
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # neutralize bg thread
+    w_home = _profile_home(tmp_path, "w", {"enabled": True})
+    monkeypatch.setenv("HERMES_HOME", str(w_home))
+    ctx = _FakeCtx(reject={"on_profile_change"})
+
+    with caplog.at_level(logging.WARNING, logger="petasos.plugin"):
+        ref.register(ctx)  # must not raise
+
+    assert "on_profile_change" not in ctx.registered
+    assert "pre_tool_call" in ctx.registered  # core hooks unaffected
+    assert ref._session_resolution is not None
+    assert _same_config(ref._session_resolution.path, w_home)  # boot binding intact
+    assert ref._is_armed() is True
+    rejected = [
+        r for r in caplog.records if "register_hook(on_profile_change) rejected" in r.getMessage()
+    ]
+    assert len(rejected) == 1


### PR DESCRIPTION
## Summary
- Makes PET-130's boot-pinned config resolution **re-establishable** on an operator-trusted profile change, so a future in-process profile swap can't leave Petasos silently enforcing the boot profile's policy (armed bit, rules, tiers, egress) after the operator switched.
- The Petasos half ships now and is **dormant** until a trusted Hermes signal fires it; until then the supported contract for a security-relevant profile change is a gateway/process restart, now documented.
- The re-bind identity comes only from the trusted payload, never from re-reading the agent-writable `active_profile` pointer (preserves the PET-125 boundary across the swap).

## Layered defense
1. **Re-bind worker** (`_rebind_to_profile`): validate trusted payload (non-empty, absolute, existing dir — closes the CWD vector) → construct the resolution directly from the trusted home → re-pin `_session_resolution` → reset the `(mtime,size)`-keyed armed/reload caches (the core correctness fix) → refresh `_config` and decide live / init-window / failed-init under **one** `_init_lock` acquisition (race-free) → live path hot-applies via PET-126's `_apply_reconfigure` on a **non-blocking** dispatch, serialized under `_rebind_lock`.
2. **Armed bit vs pipeline policy**: re-pin + cache reset makes a disarm in the new profile take effect immediately (independent of the heavier pipeline apply); an apply failure keeps last-good policy and is loud + attributable on a **dedicated** rate-limit clock (`PETASOS_REBIND_CONFIG_STALE`), never suppressed by the reload/disarm clocks.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/__init__.py` | Adds `_rebind_to_profile` / `_rebind_to_resolution` / `_apply_live` / `_dispatch_reconfigure` / `_on_profile_change` / `_validated_profile_home` + re-bind log helpers + idempotency flags & reset seams; makes `register()` idempotent and re-bind-safe |
| `tests/test_profile_rebind.py` | New — 15 regression vectors covering disarm, cache collision, full re-apply, PET-125 trust, unsafe-home rejection, Windows absolute home, sectionless keep-last-good, init-window interleavings, idempotent register, ARMED_RESOLUTION re-emit, dedicated-clock non-suppression, concurrent convergence + on-error reset, no-signal restart contract |
| `docs/deployment/hardening.md` | Documents the interim "restart required" contract and the agent-unreachable re-bind property (§6) |

## Test plan
- [x] Focused gate (spec § Test command): `python -m pytest tests/test_profile_rebind.py tests/test_console_armed.py tests/test_console_reload.py tests/test_plugin_init_logging.py tests/test_subagent_plugin_wiring.py tests/test_reference_plugin_egress.py tests/test_plugin_api_paths.py -q` → **149 passed** (15 new)
- [x] Full suite (two documented deselects): `python -m pytest -q --deselect ...test_default_ignorable_rejected --deselect ...test_get_about` → **1790 passed, 41 skipped, 2 deselected, 1 xfailed**
- [x] `ruff check .` clean · `ruff format --check .` clean
- [x] `mypy --strict .` (Hermes venv) → **no issues in 129 source files**
- [x] Re-bind runs off the tool-call hot path (non-blocking dispatch; per-call armed/reload cost unchanged)

Out of scope (per spec): the Hermes-side trigger (forced re-discovery / firing `on_profile_change`) is a separate Hermes work item; this PR ships the dormant-but-tested Petasos re-bind + the documented restart contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that profile/config resolution is pinned at plugin initialization from the operator-trusted environment, and that security-relevant profile changes require a restart.
  * Documented how to verify the pinned profile via the `PETASOS_ARMED_RESOLUTION` log line, plus how trusted live swaps behave.

* **New Features**
  * Added operator-trusted live “profile-swap” re-binding, with validation, hot re-apply when the pipeline is running, and immediate armed/disarmed behavior updates.

* **Tests**
  * Added end-to-end automated coverage for re-binding, cache reset correctness, safety/ignore of untrusted inputs, and concurrency/race handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->