### PR TITLE
fix(pet-134): per-namespace source-taint egress fence

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -255,6 +255,40 @@ re-bind does fire, the pipeline/guard config is process-wide, so it applies to
 every session the process hosts; in-flight sessions see the new shared config at
 their next tool call (the swap does not drain them first).
 
+### The source-taint egress fence is verbatim, defense-in-depth (PET-134)
+
+`source_taint_namespaces` adds a content-agnostic egress fence: once a tool in a
+declared source namespace (for example a banking or health connector) returns
+content, that **exact** text is blocked from leaving again through any
+`egress_sink_tools` tool, even when it carries no PII pattern. It closes the
+structural hole the PII matcher cannot reach: a non-PII balance, amount, or
+merchant relayed off-box. It is **off by default** (empty
+`source_taint_namespaces`); the Configuration guide covers the two operator levers
+(`source_taint_namespaces` and `taint_min_span_length`).
+
+Understand its boundary before relying on it:
+
+- **It is a verbatim, source-to-off-box guarantee, not a dataflow tracer.** The
+  fence matches a normalized exact substring of what the source returned. A copy
+  the model paraphrases, summarizes, base64-encodes, or otherwise transforms
+  before the egress call is **not** caught. Treat it as defense-in-depth against a
+  direct relay, not a complete exfiltration control.
+- **It does not intercept the model call.** There is no `pre_llm_call` hook, so
+  tainted content can still reach the language model. Closing the inference-time
+  leak is a configuration concern (run a local model so the content never leaves
+  the box), not something this fence does.
+- **It is not a replacement for local inference or network isolation.** It rides
+  on the same tool-call boundary as the rest of the guard. An agent with an
+  unsanctioned network path (a shell, or an HTTP tool that is not listed in
+  `egress_sink_tools`) is outside its reach. Pair it with the deployment posture
+  in this section, do not substitute it for that posture.
+- **The enabling field must survive the model switcher (see Vector A / PET-115).**
+  The fence is off whenever `source_taint_namespaces` is empty, and the Hermes
+  Desktop model switcher wipes the `petasos:` config section, which empties the
+  field and silently disarms the fence: the same per-field config-wipe footgun
+  every `petasos:` setting shares. Confirm the field is still present after a model
+  switch before trusting the fence.
+
 ---
 
 *Companion docs: [hermes-desktop.md](hermes-desktop.md) (step-by-step Hermes

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -259,8 +259,11 @@ their next tool call (the swap does not drain them first).
 
 `source_taint_namespaces` adds a content-agnostic egress fence: once a tool in a
 declared source namespace (for example a banking or health connector) returns
-content, that **exact** text is blocked from leaving again through any
-`egress_sink_tools` tool, even when it carries no PII pattern. It closes the
+content, a **normalized substring** of that text is blocked from leaving again
+through any `egress_sink_tools` tool, even when it carries no PII pattern. The
+match folds case, zero-width, and homoglyph variants, so a trivially obfuscated
+copy is still caught; a paraphrase or re-encoding is not (see the verbatim bullet
+below). It closes the
 structural hole the PII matcher cannot reach: a non-PII balance, amount, or
 merchant relayed off-box. It is **off by default** (empty
 `source_taint_namespaces`); the Configuration guide covers the two operator levers

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -224,6 +224,36 @@ def _is_egress_sink(tool_name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# PET-134: per-namespace source-taint egress fence
+# ---------------------------------------------------------------------------
+
+# The taint store (per-session bounded span set) and the canonicalized source-namespace
+# prefix set, built in _deferred_init from config beside _egress_sink_tools and rebuilt in
+# _apply_reconfigure. Written once under _init_lock before _initialized flips; read lock-free
+# in the post-init hot path (_pre_tool_call / _post_tool_call). Both default to the
+# feature-off sentinels (None store, empty set) so the fence is a no-op until an operator
+# declares a source namespace. _taint_store is typed loosely (Any) to keep this deployment
+# artifact import-light — the concrete type is petasos.session.taint.SessionTaintStore.
+_taint_store: Any = None
+_source_taint_namespaces: frozenset[str] = frozenset()
+
+
+def _match_source_namespace(tool_name: str) -> str | None:
+    """Return the declared source-namespace prefix the producing ``tool_name`` falls under,
+    or ``None``. Canonicalizes the tool name through the SAME primitive as the sinks
+    (PET-118: closes the variant bypass on the source side) and PREFIX-matches it (a source
+    namespace labels a FAMILY of tools, unlike the exact membership a sink uses). The
+    LONGEST matching prefix wins, so overlapping declarations (``mcp_`` and ``mcp_bank_``)
+    resolve deterministically to the most specific provenance (D-NS)."""
+    canon_tool = canonicalize_tool_name(tool_name)
+    return max(
+        (p for p in _source_taint_namespaces if canon_tool.startswith(p)),
+        key=len,
+        default=None,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Async bridge — dedicated event loop in a background thread
 # ---------------------------------------------------------------------------
 
@@ -485,7 +515,7 @@ def _deferred_init() -> None:
                     "PETASOS_LICENSE_KEY not set — all features available (license is optional)"
                 )
 
-            from petasos import FrequencyTracker, LineageRegistry
+            from petasos import FrequencyTracker, LineageRegistry, SessionTaintStore
 
             global _lineage_registry
             if _subagent_hooks_available:
@@ -532,6 +562,25 @@ def _deferred_init() -> None:
                 logger.warning(
                     "egress_sink_tools is empty (or all names canonicalized away) — "
                     "PII will not be blocked on any egress tool"
+                )
+
+            # PET-134: build the source-taint set + store under the SAME happens-before as
+            # _egress_sink_tools (written before _initialized flips; read lock-free in the
+            # hot path). The `global` is MANDATORY — without it the assignments bind
+            # function-locals and leave the module set frozen empty / the store None forever,
+            # silently disabling the fence (the exact footgun the egress comment warns of).
+            # _source_taint_namespaces uses the identical canonicalize-drop-empty-warn idiom;
+            # the prefixes are canonicalized so a variant-named source tool still matches
+            # (PET-118 on the source side).
+            global _taint_store, _source_taint_namespaces
+            _source_taint_namespaces = frozenset(
+                c for c in (canonicalize_tool_name(t) for t in config.source_taint_namespaces) if c
+            )
+            _taint_store = SessionTaintStore(config)
+            if config.source_taint_namespaces and not _source_taint_namespaces:
+                logger.warning(
+                    "source_taint_namespaces is set but all names canonicalized away — "
+                    "the source-taint egress fence will match no producing tool"
                 )
 
             scanner_names = [s.name for s in scanners]
@@ -802,10 +851,20 @@ async def _apply_reconfigure(cfg: PetasosConfig) -> None:
     _guard.apply_config(cfg)
     if _lineage_registry is not None:
         _lineage_registry.apply_config(cfg)
-    global _egress_sink_tools
+    global _egress_sink_tools, _source_taint_namespaces
     _egress_sink_tools = frozenset(
         c for c in (canonicalize_tool_name(t) for t in cfg.egress_sink_tools) if c
     )
+    # PET-134: rebuild the source-namespace set and apply the live FP floor beside the
+    # egress rebuild (the gateway owns this state; the pipeline cannot reach it). The
+    # `global` is mandatory for the rebind (the store itself is mutated in place, not
+    # reassigned). apply_config only rebinds an already-validated scalar under the store
+    # lock, so it cannot raise on this phase-1-validated cfg (commit-phase no-raise).
+    _source_taint_namespaces = frozenset(
+        c for c in (canonicalize_tool_name(t) for t in cfg.source_taint_namespaces) if c
+    )
+    if _taint_store is not None:
+        _taint_store.apply_config(cfg)
 
 
 def _maybe_reconfigure() -> None:
@@ -1114,6 +1173,33 @@ def _pre_tool_call(
     non_pii_blocking = [f for f in blocking if f.finding_type != "pii"]
     pii_blocking = [f for f in blocking if f.finding_type == "pii"]
 
+    # 0. PET-134 source-taint egress fence: the FIRST block check, additive to and
+    #    independent of the PII-egress block below. Content a tool in a declared source
+    #    namespace returned may not leave, verbatim, via an egress sink, regardless of
+    #    whether it also matches PII. All three short-circuits collapse to a fast empty-set
+    #    check on the default, so the feature-off / untainted path is byte-identical to the
+    #    pre-PET-134 behavior. Direction-orthogonal: tainted_source is a pure substring
+    #    test that never consults Direction and never calls the pipeline scan. The
+    #    model-facing message carries no source/sink detail (PET-77); the provenance
+    #    namespace and sink go only to the operator log line + enforcement event (D-OBSERV).
+    if egress and _source_taint_namespaces and _taint_store is not None:
+        tainted_ns = _taint_store.tainted_source(session_id, args)
+        if tainted_ns is not None:
+            reason = f"source-taint egress: {tainted_ns} -> {tool_name}"
+            logger.warning(
+                "PETASOS_QUARANTINE tool=%s session=%s — %s", tool_name, session_id, reason
+            )
+            _emit_enforcement_event(
+                session_id=session_id,
+                tool=tool_name,
+                event_type="quarantine",
+                reason=reason,
+            )
+            return {
+                "action": "block",
+                "message": format_content_block("taint_egress", tool_name, ()),
+            }
+
     # 1. Scan degraded/unreliable -> block ALL dangerous tools (fail-mode; cannot trust the
     #    scan). Independent of finding type, so a degraded scanner co-occurring with a PII
     #    finding still blocks (D-DEGRADED, closes the degraded+PII hole).
@@ -1193,6 +1279,27 @@ def _post_tool_call(
     if not _is_armed():  # PET-111: skip the completion log while disarmed
         return
     logger.debug("PETASOS_TOOL_COMPLETE tool=%s duration_ms=%d", tool_name, duration_ms)
+
+    # PET-134: capture tainted spans from a declared source namespace. Fast-path off on the
+    # empty default (zero added cost, preserves the no-op posture, brief D-PERF). Guarded
+    # end-to-end so capture can never break a completing tool call.
+    if not _source_taint_namespaces or _taint_store is None:
+        return
+    try:
+        source_ns = _match_source_namespace(tool_name)
+        if source_ns is None:
+            return
+        # D1b: skip capture when no stable correlator was supplied. That input shape
+        # (no task_id and no _agent) drives _derive_session_id into a fresh anon-<uuid>
+        # per call that a later _pre_tool_call check can never match, so storing under it
+        # is a guaranteed fail-open plus orphan-session growth. The discriminator is the
+        # INPUTS, not the derived-id string: a durable task_id that legitimately begins
+        # with "anon-" stays correlatable and is captured.
+        if not task_id and kwargs.get("_agent") is None:
+            return
+        _taint_store.capture(_derive_session_id(task_id, kwargs), result, source_ns)
+    except Exception as exc:
+        logger.debug("Petasos taint capture failed: %s; skipping", exc)
 
 
 def _on_session_start(**kwargs) -> None:

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -26,9 +26,9 @@ The editor shows 11 sections, in this render order:
 10. Alerting
 11. Session Management
 
-Together these cover 59 editable fields.
+Together these cover 61 editable fields.
 
-<!-- petasos-doc-assert: config_field_count=59 -->
+<!-- petasos-doc-assert: config_field_count=61 -->
 
 Each field below is named exactly as it appears in config files and the editor.
 Where a field has a safe range or a fixed set of choices, it is given.
@@ -114,6 +114,19 @@ system or the shell.*
   data is blocked only when an agent tries to send it through one of these;
   writing to local files or the terminal is never blocked for personal data. Set
   these to your host's actual outbound tool names.
+- `source_taint_namespaces`: tool namespaces (by name prefix, such as a banking or
+  health connector) whose returned content must not leave again through an egress
+  sink. Once a tool in one of these groups returns data, that exact text is blocked
+  from any `egress_sink_tools` tool above, even when it is not flagged as personal
+  data, which catches a plain account balance or amount the PII scanner would miss.
+  Empty (the default) turns the fence off. Matching is exact-text only, so a
+  paraphrased or re-encoded copy is not caught.
+- `taint_min_span_length`: the shortest piece of restricted-source content the fence
+  will remember (minimum 1; default 12 characters). Short, common values (a price
+  like $5.00, a year like 2026) fall below this and are ignored, so they cannot
+  block every later message that happens to contain them. Raise it if benign
+  messages get blocked for sharing a common phrase; lower it to catch shorter
+  sensitive values at the cost of more false alarms.
 
 ## 5. Scanning
 
@@ -304,4 +317,4 @@ so do not conclude this page is incomplete if you cannot find it:
 <!-- Drift-guard index: the full set of editor-surfaced field names documented
      above. Kept in sync with petasos.console._config_meta._FIELD_META by
      tests/test_docs_usage_consistency.py. -->
-<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,detect_rtl_override,fold_leet,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones -->
+<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,detect_rtl_override,fold_leet,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones,source_taint_namespaces,taint_min_span_length -->

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -28,6 +28,7 @@ from petasos.session.guard import GuardResult, ToolCallGuard
 from petasos.session.license import LicenseClaims, LicenseState, LicenseValidator, validate_license
 from petasos.session.lineage import LineageRegistry
 from petasos.session.profiles import ProfileResolver, ResolvedProfile, TierThresholds
+from petasos.session.taint import SessionTaintStore
 
 __all__ = [
     "Alert",
@@ -59,6 +60,7 @@ __all__ = [
     "ScanFinding",
     "ScanResult",
     "Scanner",
+    "SessionTaintStore",
     "Severity",
     "TierThresholds",
     "ToolCallGuard",

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -174,6 +174,21 @@ class PetasosConfig:
         "send_webhook",
         "clipboard_write",
     )
+    # PET-134: source namespaces whose returned content taints (a content-agnostic
+    # provenance fence layered over the PII-egress block). Stored RAW as
+    # single-underscore wire prefixes (e.g. "mcp_bank_"); canonicalized by the plugin
+    # through the SAME canonicalize_tool_name primitive the egress sinks use (PET-118),
+    # then PREFIX-matched against a producing tool's canonical name (D-NS). Empty (the
+    # default) disables the fence entirely, exactly as an empty egress_sink_tools
+    # disables egress PII blocking. Validated identically to egress_sink_tools (bare-str
+    # reject, list->tuple coerce, per-entry non-empty, empty allowed). No
+    # banking-specific names ship — this is a reusable Petasos primitive.
+    source_taint_namespaces: tuple[str, ...] = ()
+    # PET-134: the false-positive floor — a tainted span shorter than this (measured on
+    # the NORMALIZED span) is never stored, so low-entropy values ("$5.00", "2026")
+    # cannot poison every later argument. Operator-tunable (FP is the single biggest
+    # usability risk) without a code change; positive-int, mirrors lineage_max_edges.
+    taint_min_span_length: int = 12
 
     def __post_init__(self) -> None:
         for fname in _BOOL_FIELDS:
@@ -433,6 +448,42 @@ class PetasosConfig:
                 raise ValueError(
                     f"egress_sink_tools entries must be non-empty strings, got {tool_name!r}"
                 )
+        # source_taint_namespaces (PET-134): RAW namespace prefixes, canonicalized +
+        # prefix-matched by the plugin. Validated with the egress_sink_tools template —
+        # bare-str reject (tuple("mcp_bank_") would char-explode and silently empty the
+        # set), list→tuple coerce, per-entry non-empty — and an EMPTY tuple is the default
+        # (= fence off; the plugin warns when a non-empty config canonicalizes away).
+        if isinstance(self.source_taint_namespaces, str):
+            raise ValueError(
+                "source_taint_namespaces must be an iterable of namespace prefixes, "
+                f"not a string, got {self.source_taint_namespaces!r}"
+            )
+        if not isinstance(self.source_taint_namespaces, tuple):
+            try:
+                object.__setattr__(
+                    self, "source_taint_namespaces", tuple(self.source_taint_namespaces)
+                )
+            except TypeError as exc:
+                raise ValueError(
+                    f"source_taint_namespaces must be an iterable of non-empty strings, "
+                    f"got {self.source_taint_namespaces!r}"
+                ) from exc
+        for ns in self.source_taint_namespaces:
+            if not isinstance(ns, str) or not ns:
+                raise ValueError(
+                    f"source_taint_namespaces entries must be non-empty strings, got {ns!r}"
+                )
+        # taint_min_span_length (PET-134): the FP floor — positive int, mirroring
+        # lineage_max_edges (bool excluded; True/False is not a valid length).
+        if (
+            not isinstance(self.taint_min_span_length, int)
+            or isinstance(self.taint_min_span_length, bool)
+            or self.taint_min_span_length <= 0
+        ):
+            raise ValueError(
+                f"taint_min_span_length must be a positive integer, "
+                f"got {self.taint_min_span_length!r}"
+            )
         if self.frequency_weights is not None:
             for k, v in self.frequency_weights.items():
                 if not isinstance(k, str) or not k:
@@ -616,6 +667,12 @@ class PetasosConfig:
             filtered["delegate_tool_names"] = tuple(filtered["delegate_tool_names"])
         if "egress_sink_tools" in filtered and isinstance(filtered["egress_sink_tools"], list):
             filtered["egress_sink_tools"] = tuple(filtered["egress_sink_tools"])
+        # PET-134: list→tuple in lockstep with egress_sink_tools so a to_dict/from_dict
+        # round-trip preserves the tuple type (the dataclass is frozen + tuple-typed).
+        if "source_taint_namespaces" in filtered and isinstance(
+            filtered["source_taint_namespaces"], list
+        ):
+            filtered["source_taint_namespaces"] = tuple(filtered["source_taint_namespaces"])
         # PET-109: coerce only when a list — preserve None so the None round-trip holds.
         if "presidio_entities" in filtered and isinstance(filtered["presidio_entities"], list):
             filtered["presidio_entities"] = tuple(filtered["presidio_entities"])

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -638,6 +638,35 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         ),
         "section": "tool_guard",
     },
+    "source_taint_namespaces": {
+        "description": (
+            "Tool namespaces whose returned content may not be sent back out through an"
+            " egress sink."
+        ),
+        "help_plain": (
+            "Marks tool groups (by name prefix, such as a banking or health connector) whose"
+            " results are sensitive. Once a tool in one of these groups returns data, that exact"
+            " text is blocked from leaving through any egress sink above (email, web request,"
+            " messaging), even when it is not recognized as personal data. This catches a plain"
+            " account balance or amount the personal-data scanner would miss. Leave empty (the"
+            " default) to turn the fence off; matching is exact-text only, so paraphrased or"
+            " re-encoded copies are not caught."
+        ),
+        "section": "tool_guard",
+    },
+    "taint_min_span_length": {
+        "description": "Shortest piece of restricted-source content the egress fence will track.",
+        "help_plain": (
+            "The minimum length, in characters, a piece of restricted-source content must reach"
+            " before the egress fence remembers it. Short, common values (a price like $5.00, a"
+            " year like 2026) fall below this and are ignored, so they cannot block every later"
+            " message that happens to contain them. Raise it if benign messages get blocked for"
+            " sharing a common phrase; lower it to catch shorter sensitive values at the cost of"
+            " more false alarms. Only applies to the restricted-source fence above."
+        ),
+        "section": "tool_guard",
+        "constraints": {"min": 1},
+    },
 }
 
 _EXCLUDED_FIELDS = frozenset({"session_secret"})

--- a/petasos/session/formatting.py
+++ b/petasos/session/formatting.py
@@ -25,13 +25,19 @@ _MAX_MESSAGE_LEN = 200
 # guard has returned allowed=True (or operate outside GuardResult), so they cannot reuse
 # format_block_message. format_content_block is keyed on the block decision the shim
 # already made (one of these paths) plus the findings that drove it.
-ContentBlockPath = Literal["init", "degraded", "non_pii_param", "pii_egress"]
+ContentBlockPath = Literal["init", "degraded", "non_pii_param", "pii_egress", "taint_egress"]
 
 _CONTENT_REASON: dict[str, str] = {
     "init": "Blocked by the initialization-time security scan.",
     "degraded": "Parameter scan unavailable (scanner degraded); blocked by fail-mode policy.",
     "non_pii_param": "Unsafe content detected in the tool parameters.",
     "pii_egress": "Sensitive data (PII) was about to leave via this tool; the call was stopped.",
+    # PET-134: the model-facing taint message carries NO source/sink detail (PET-77:
+    # internal provenance reasons never reach the model; that detail goes only to the
+    # operator log + enforcement event).
+    "taint_egress": (
+        "Content from a restricted source was about to leave via this tool; the call was stopped."
+    ),
 }
 
 

--- a/petasos/session/taint.py
+++ b/petasos/session/taint.py
@@ -1,0 +1,200 @@
+"""Per-namespace source-taint egress store (PET-134).
+
+A bounded, thread-safe, per-session set of normalized content spans that a tool
+in an operator-declared **source namespace** returned. The reference plugin
+captures spans at ``post_tool_call`` (``capture``) and, at ``pre_tool_call``,
+asks whether an outbound argument to an ``egress_sink_tools`` tool **contains**
+any live tainted span (``tainted_source``). A match blocks the relay regardless
+of whether the content matches a PII pattern — the structural hole the PII
+matcher cannot close (a non-PII bank balance / amount / merchant relayed
+off-box).
+
+The store delivers the brief's guarantee (no cross-session leak; memory bounded)
+without a session-end hook (the reference plugin registers none): isolation by
+``session_id`` key, a per-session span cap (evict-oldest), and a global session
+LRU cap (evict the least-recently-active session whole). Total memory is
+hard-bounded at ``_TAINT_MAX_SESSIONS * _TAINT_MAX_SPANS_PER_SESSION *
+_MAX_TAINT_SPAN_LEN``.
+
+Mirrors ``LineageRegistry``'s bounded-store + ``apply_config`` discipline
+(PET-126): the false-positive floor (``taint_min_span_length``) is cached at
+construction and re-read live under the same lock ``apply_config`` rebinds it
+through, so a live reconfigure is the happens-before for the next floor read.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections import OrderedDict
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any
+
+from petasos.normalize import normalize
+
+if TYPE_CHECKING:
+    from petasos.config import PetasosConfig
+
+# Internal DoS-safety ceilings (NOT config — they mirror _events.py's SPOOL_CAP_BYTES:
+# a safety bound with no operational tuning need). The operator surface is kept to the
+# two levers that are actually turned (which namespaces, and the FP floor).
+_TAINT_MAX_SPANS_PER_SESSION = 256  # per-session span cap, evict-oldest
+_TAINT_MAX_SESSIONS = 1024  # global session LRU cap, evict least-recently-active
+_MAX_TAINT_SPAN_LEN = 4096  # never store a leaf longer than this (raw codepoints)
+_MAX_SCAN_TEXT = 100_000  # cap text fed to normalize() (matches the plugin fallback cap)
+_MAX_SCAN_LEAVES = 2048  # cap leaves walked per capture (bounds the dict/list path)
+
+
+def _iter_leaf_strings(obj: object) -> Iterator[str]:
+    """Yield the leaf string candidates of an arbitrary JSON-ish value.
+
+    Recurses ``Mapping`` values and ``list``/``tuple`` items. ``str`` leaves are
+    yielded as-is; non-string scalar leaves (``int`` / ``float`` / ``bool``) are
+    stringified via ``json.dumps(v, default=str)`` — the JSON-wire form a relayed
+    value carries (``json.dumps(True)`` -> ``"true"``, not ``str(True)``'s
+    ``"True"``) — so capture and check see one canonical leaf shape. ``None`` is
+    skipped. ``default=str`` matches the house never-raise idiom (``_events.py``
+    / the plugin's ``json.dumps(..., default=str)``).
+    """
+    if obj is None:
+        return
+    if isinstance(obj, str):
+        yield obj
+        return
+    if isinstance(obj, Mapping):
+        for value in obj.values():
+            yield from _iter_leaf_strings(value)
+        return
+    if isinstance(obj, (list, tuple)):
+        for item in obj:
+            yield from _iter_leaf_strings(item)
+        return
+    # Non-string scalar (int/float/bool) or any other leaf: stringify to the
+    # JSON-wire form. Never raise — fall back to str() on an unserializable leaf.
+    try:
+        yield json.dumps(obj, default=str)
+    except (TypeError, ValueError):
+        yield str(obj)
+
+
+def _result_leaf_strings(result: object) -> Iterator[str]:
+    """Leaf candidates from a tool ``result``, without a lossy round-trip.
+
+    A ``dict`` / ``list`` (a host that passes a structured object) is walked
+    directly — never ``str()``-flattened to one unmatchable Python-repr blob. A
+    ``str`` is ``json.loads``-parsed (capped at ``_MAX_SCAN_TEXT``) and walked on
+    success; on ``JSONDecodeError`` (including a valid-JSON result truncated
+    mid-structure by the cap) the capped text is one leaf. Any other type
+    (``None``, a bare scalar) routes through ``_iter_leaf_strings``. Never raises.
+    """
+    if isinstance(result, str):
+        capped = result[:_MAX_SCAN_TEXT]
+        try:
+            parsed = json.loads(capped)
+        except (ValueError, TypeError):
+            # JSONDecodeError is a ValueError subclass. Treat the capped text as
+            # one leaf (an over-_MAX_TAINT_SPAN_LEN leaf is then dropped by capture).
+            yield capped
+            return
+        yield from _iter_leaf_strings(parsed)
+        return
+    yield from _iter_leaf_strings(result)
+
+
+class SessionTaintStore:
+    """Thread-safe per-session store of normalized tainted spans -> source namespace."""
+
+    def __init__(self, config: PetasosConfig) -> None:
+        self._min_span_len = config.taint_min_span_length
+        self._lock = threading.Lock()
+        # session_id -> ordered { normalized span -> source namespace it came from }.
+        # The outer OrderedDict is the global session LRU; the inner one is the
+        # per-session insertion-ordered span set (front = oldest).
+        self._store: OrderedDict[str, OrderedDict[str, str]] = OrderedDict()
+
+    def apply_config(self, new_config: PetasosConfig) -> None:
+        """PET-126: rebind the cached FP floor in place under the store lock.
+
+        Only rebinds an already-validated scalar (no fallible work), so it cannot
+        raise on a phase-1-validated ``cfg`` — preserving ``_apply_reconfigure``'s
+        commit-phase no-raise invariant, the same contract
+        ``LineageRegistry.apply_config`` honors. The change applies to **future
+        captures only**: already-stored spans are not re-filtered and
+        already-rejected spans are not retroactively admitted. The rebind runs
+        under the lock ``capture`` reads the floor through, the happens-before for
+        the next floor read.
+        """
+        with self._lock:
+            self._min_span_len = new_config.taint_min_span_length
+
+    def capture(self, session_id: str, result: object, source_ns: str) -> None:
+        """Taint each floor-clearing leaf of ``result`` for ``session_id``.
+
+        Granularity is per JSON-leaf value (never the whole blob). The leaf walk
+        is capped at ``_MAX_SCAN_LEAVES``; an over-cap leaf is a documented
+        capture-miss, not a crash. **Collision: first-source-wins** — an already
+        present span keeps its original namespace and insertion position. Never
+        raises (the caller wraps this too, but the store is the floor).
+        """
+        with self._lock:
+            min_span_len = self._min_span_len  # read under the lock (apply_config HB)
+            spans = self._store.get(session_id)
+            if spans is None:
+                spans = OrderedDict()
+                self._store[session_id] = spans  # new session -> MRU (inserted at end)
+            else:
+                self._store.move_to_end(session_id)  # touched -> MRU
+
+            for index, leaf in enumerate(_result_leaf_strings(result)):
+                if index >= _MAX_SCAN_LEAVES:
+                    break  # bound per-call work (documented capture-miss past the cap)
+                if len(leaf) > _MAX_TAINT_SPAN_LEN:
+                    continue  # drop over-max leaf rather than store a giant span
+                span = self._normalize(leaf)
+                if len(span) < min_span_len:
+                    continue  # FP floor, measured on the NORMALIZED span
+                if span in spans:
+                    continue  # first-source-wins: keep original ns + insertion order
+                spans[span] = source_ns
+                if len(spans) > _TAINT_MAX_SPANS_PER_SESSION:
+                    spans.popitem(last=False)  # evict oldest span
+
+            while len(self._store) > _TAINT_MAX_SESSIONS:
+                self._store.popitem(last=False)  # evict least-recently-active session whole
+
+    def tainted_source(self, session_id: str, args: dict[str, Any]) -> str | None:
+        """Return the source namespace of the first live span an ``args`` leaf carries.
+
+        Walks ``args`` leaves the same way capture walks a result (shared
+        extraction, identical leaf shapes), normalizes each, and returns the
+        source namespace of the **first** tainted span (by insertion order, stable
+        under first-source-wins) that is a normalized substring of any argument
+        leaf — else ``None`` (the no-match / allow result). Marks the session
+        most-recently-used so an actively-checked session is never LRU-evicted out
+        from under itself.
+        """
+        with self._lock:
+            spans = self._store.get(session_id)
+            if not spans:
+                return None
+            self._store.move_to_end(session_id)  # active -> MRU
+            candidates = [self._normalize(leaf) for leaf in _iter_leaf_strings(args)]
+            for span, source_ns in spans.items():
+                for candidate in candidates:
+                    if span in candidate:
+                        return source_ns
+        return None
+
+    def clear_session(self, session_id: str) -> None:
+        """Drop a session's spans. Idempotent. Wired for a future host that gains
+        an ``on_session_end`` signal; nothing calls it today (per-session keying +
+        the LRU cap already bound memory without it)."""
+        with self._lock:
+            self._store.pop(session_id, None)
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        """Canonical form for both capture and check: the pipeline's normalizer
+        (NFKC + zero-width strip + homoglyph fold) then casefold, capped at
+        ``_MAX_SCAN_TEXT`` so an oversized argument leaf cannot blow the budget."""
+        return normalize(text[:_MAX_SCAN_TEXT]).normalized.casefold()

--- a/petasos/session/taint.py
+++ b/petasos/session/taint.py
@@ -24,6 +24,7 @@ through, so a live reconfigure is the happens-before for the next floor read.
 
 from __future__ import annotations
 
+import itertools
 import json
 import threading
 from collections import OrderedDict
@@ -43,9 +44,11 @@ _TAINT_MAX_SESSIONS = 1024  # global session LRU cap, evict least-recently-activ
 _MAX_TAINT_SPAN_LEN = 4096  # never store a leaf longer than this (raw codepoints)
 _MAX_SCAN_TEXT = 100_000  # cap text fed to normalize() (matches the plugin fallback cap)
 _MAX_SCAN_LEAVES = 2048  # cap leaves walked per capture (bounds the dict/list path)
+_MAX_TAINT_DEPTH = 64  # cap leaf-walk recursion depth (a hostile deeply-nested payload
+# past this is a documented walk-miss, never a RecursionError)
 
 
-def _iter_leaf_strings(obj: object) -> Iterator[str]:
+def _iter_leaf_strings(obj: object, _depth: int = 0) -> Iterator[str]:
     """Yield the leaf string candidates of an arbitrary JSON-ish value.
 
     Recurses ``Mapping`` values and ``list``/``tuple`` items. ``str`` leaves are
@@ -55,7 +58,14 @@ def _iter_leaf_strings(obj: object) -> Iterator[str]:
     ``"True"``) — so capture and check see one canonical leaf shape. ``None`` is
     skipped. ``default=str`` matches the house never-raise idiom (``_events.py``
     / the plugin's ``json.dumps(..., default=str)``).
+
+    Recursion is bounded by ``_MAX_TAINT_DEPTH``: a hostile deeply-nested payload
+    (in a tool result or in outbound args) is a documented walk-miss past the cap,
+    never a ``RecursionError`` — preserving the never-raise invariant on both the
+    post-call capture and the pre-call enforcement path.
     """
+    if _depth > _MAX_TAINT_DEPTH:
+        return
     if obj is None:
         return
     if isinstance(obj, str):
@@ -63,11 +73,11 @@ def _iter_leaf_strings(obj: object) -> Iterator[str]:
         return
     if isinstance(obj, Mapping):
         for value in obj.values():
-            yield from _iter_leaf_strings(value)
+            yield from _iter_leaf_strings(value, _depth + 1)
         return
     if isinstance(obj, (list, tuple)):
         for item in obj:
-            yield from _iter_leaf_strings(item)
+            yield from _iter_leaf_strings(item, _depth + 1)
         return
     # Non-string scalar (int/float/bool) or any other leaf: stringify to the
     # JSON-wire form. Never raise — fall back to str() on an unserializable leaf.
@@ -91,9 +101,11 @@ def _result_leaf_strings(result: object) -> Iterator[str]:
         capped = result[:_MAX_SCAN_TEXT]
         try:
             parsed = json.loads(capped)
-        except (ValueError, TypeError):
-            # JSONDecodeError is a ValueError subclass. Treat the capped text as
-            # one leaf (an over-_MAX_TAINT_SPAN_LEN leaf is then dropped by capture).
+        except (ValueError, TypeError, RecursionError):
+            # JSONDecodeError (ValueError) for malformed/truncated input; RecursionError
+            # for a hostile deeply-nested JSON string (json's own recursion guard). Either
+            # way, treat the capped text as one leaf (then dropped if over
+            # _MAX_TAINT_SPAN_LEN) rather than propagating — the never-raise invariant.
             yield capped
             return
         yield from _iter_leaf_strings(parsed)
@@ -172,13 +184,21 @@ class SessionTaintStore:
         leaf — else ``None`` (the no-match / allow result). Marks the session
         most-recently-used so an actively-checked session is never LRU-evicted out
         from under itself.
+
+        The candidate leaves are normalized **outside** the lock and bounded by
+        ``_MAX_SCAN_LEAVES``: normalization touches no shared state, so a hostile
+        wide/deep ``args`` payload cannot amplify lock-hold on the pre-call
+        enforcement path (the lock guards only the span comparison).
         """
+        candidates = [
+            self._normalize(leaf)
+            for leaf in itertools.islice(_iter_leaf_strings(args), _MAX_SCAN_LEAVES)
+        ]
         with self._lock:
             spans = self._store.get(session_id)
             if not spans:
                 return None
             self._store.move_to_end(session_id)  # active -> MRU
-            candidates = [self._normalize(leaf) for leaf in _iter_leaf_strings(args)]
             for span, source_ns in spans.items():
                 for candidate in candidates:
                     if span in candidate:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,3 +270,59 @@ class TestDecodeEncodedPayloads:
         meta = _FIELD_META["decode_encoded_payloads"]
         assert meta["help_plain"].strip() != meta["description"].strip()
         assert meta["section"] == "normalization"
+
+
+class TestSourceTaintConfig:
+    # PET-134: source_taint_namespaces + taint_min_span_length.
+
+    def test_defaults_off(self) -> None:
+        cfg = PetasosConfig()
+        assert cfg.source_taint_namespaces == ()  # empty == fence off
+        assert cfg.taint_min_span_length == 12
+
+    def test_source_taint_config_roundtrip_and_frozen(self) -> None:
+        # source_taint_namespaces round-trips (list -> tuple), rejects a bare string, allows
+        # empty (= disabled), is immutable post-construction; taint_min_span_length rejects < 1.
+        # constructor coerces a list arg to a tuple in __post_init__.
+        cfg = PetasosConfig(source_taint_namespaces=["mcp_bank_"])  # type: ignore[arg-type]
+        assert cfg.source_taint_namespaces == ("mcp_bank_",)
+
+        d = cfg.to_dict()
+        assert isinstance(d["source_taint_namespaces"], list)  # to_dict emits a list
+        assert PetasosConfig.from_dict(d).source_taint_namespaces == ("mcp_bank_",)
+        # from_dict coerces a list payload back to a tuple.
+        assert PetasosConfig.from_dict(
+            {"source_taint_namespaces": ["mcp_bank_", "mcp_health_"]}
+        ).source_taint_namespaces == ("mcp_bank_", "mcp_health_")
+
+        # empty allowed (= disabled) and round-trips.
+        assert PetasosConfig(source_taint_namespaces=()).source_taint_namespaces == ()
+        assert (
+            PetasosConfig.from_dict(
+                PetasosConfig(source_taint_namespaces=()).to_dict()
+            ).source_taint_namespaces
+            == ()
+        )
+
+        # bare string rejected (would char-explode into a per-character set).
+        with pytest.raises(ValueError, match="source_taint_namespaces"):
+            PetasosConfig(source_taint_namespaces="mcp_bank_")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="source_taint_namespaces"):
+            PetasosConfig.from_dict({"source_taint_namespaces": "mcp_bank_"})
+        # per-entry non-empty.
+        with pytest.raises(ValueError, match="source_taint_namespaces"):
+            PetasosConfig(source_taint_namespaces=("",))
+
+        # taint_min_span_length: positive-int only.
+        with pytest.raises(ValueError, match="taint_min_span_length"):
+            PetasosConfig(taint_min_span_length=0)
+        with pytest.raises(ValueError, match="taint_min_span_length"):
+            PetasosConfig(taint_min_span_length=-5)
+        with pytest.raises(ValueError, match="taint_min_span_length"):
+            PetasosConfig(
+                taint_min_span_length=True
+            )  # bool is an int subtype; rejected at runtime
+
+        # frozen / immutable post-construction (frozen-export invariant).
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.source_taint_namespaces = ("x",)  # type: ignore[misc]

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -28,6 +28,7 @@ from petasos import (
     PipelineResult,
     ScanFinding,
     ScanResult,
+    SessionTaintStore,
     Severity,
     ToolCallGuard,
 )
@@ -697,3 +698,216 @@ def test_disarm_emits_rate_limited_warning(
     msg = warnings[0].getMessage()
     assert "PETASOS_DISARMED" in msg
     assert "shell" in msg
+
+
+# ---------------------------------------------------------------------------
+# PET-134: per-namespace source-taint egress fence (plugin-level integration)
+# ---------------------------------------------------------------------------
+
+_BANK_NS = ("mcp_bank_",)
+# A non-PII span: matches no PII pattern, so only the taint fence can block it.
+_TAINTED = "$4,000 at Whole Foods on groceries"
+
+
+def _make_taint_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    namespaces: tuple[str, ...] = _BANK_NS,
+    min_span_length: int = 12,
+    egress: frozenset[str] = _EGRESS,
+    guard_result: GuardResult | None = None,
+) -> types.ModuleType:
+    """Freshly imported, post-init, armed plugin with the taint fence wired: a real
+    SessionTaintStore plus the canonicalized source-namespace set. The guard is stubbed
+    (its evaluate result is supplied) so the fence is exercised in isolation."""
+    ref = _import_reference_plugin()
+    cfg = PetasosConfig(source_taint_namespaces=namespaces, taint_min_span_length=min_span_length)
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+    monkeypatch.setattr(ref, "_egress_sink_tools", egress)
+    monkeypatch.setattr(
+        ref,
+        "_source_taint_namespaces",
+        frozenset(c for c in (canonicalize_tool_name(t) for t in namespaces) if c),
+    )
+    monkeypatch.setattr(ref, "_taint_store", SessionTaintStore(cfg))
+    gr = guard_result if guard_result is not None else _guard_result()
+    stub_guard = type("G", (), {"evaluate": lambda self, *a, **k: None})()
+    monkeypatch.setattr(ref, "_guard", stub_guard)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: gr)
+    return ref
+
+
+def test_tainted_nonpii_blocked_to_egress_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The headline regression: a non-PII string captured from a declared source namespace,
+    # then relayed to an egress sink, is blocked though it matches no PII pattern. The
+    # enforcement-event reason names the matched SOURCE namespace (D-OBSERV).
+    ref = _make_taint_plugin(monkeypatch)
+    events: list[dict[str, Any]] = []
+    monkeypatch.setattr(ref, "_emit_enforcement_event", lambda **kw: events.append(kw))
+
+    ref._post_tool_call("mcp_bank_list_accounts", {}, result=_TAINTED, task_id="s1")
+    out = ref._pre_tool_call("send_email", {"body": f"FYI: {_TAINTED}"}, task_id="s1")
+
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+    # PET-77: the model-facing message carries no source/sink provenance detail.
+    assert "mcp_bank_" not in out["message"]
+    quarantines = [e for e in events if e.get("event_type") == "quarantine"]
+    assert quarantines, "expected a quarantine enforcement event"
+    assert quarantines[-1]["reason"] == "source-taint egress: mcp_bank_ -> send_email"
+
+
+def test_tainted_content_to_internal_tool_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The same tainted content to an internal tool is NOT blocked (internal-exempt parity:
+    # the fence is egress-scoped, like the PII-egress block).
+    ref = _make_taint_plugin(monkeypatch)
+    ref._post_tool_call("mcp_bank_list_accounts", {}, result=_TAINTED, task_id="s1")
+    for tool in ("write_file", "terminal"):
+        assert ref._pre_tool_call(tool, {"content": _TAINTED}, task_id="s1") is None, tool
+
+
+def test_untainted_content_to_egress_sink_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Content never captured from a tainted source flows to an egress sink unchanged: the
+    # no-match path is byte-identical to today (no over-block).
+    ref = _make_taint_plugin(monkeypatch)
+    assert ref._pre_tool_call("send_email", {"body": _TAINTED}, task_id="s1") is None
+
+
+def test_taint_capture_only_from_declared_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A result from a non-declared namespace does not taint; relaying it is allowed.
+    ref = _make_taint_plugin(monkeypatch)
+    ref._post_tool_call("mcp_weather_forecast", {}, result=_TAINTED, task_id="s1")
+    assert ref._pre_tool_call("send_email", {"body": _TAINTED}, task_id="s1") is None
+
+
+def test_taint_namespace_canonicalized_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A cased / CamelCase / _tool variant of a tool in the declared namespace still taints
+    # (reuses canonicalize_tool_name; closes the PET-118-class bypass on the source side).
+    ref = _make_taint_plugin(monkeypatch)
+    value = "canonical-taint-check-value"
+    for producer in (
+        "MCP_BANK_List_Accounts",
+        "mcp_bank_ListAccounts",
+        "mcp_bank_get_balance_tool",
+    ):
+        cfg = PetasosConfig(source_taint_namespaces=_BANK_NS, taint_min_span_length=12)
+        monkeypatch.setattr(ref, "_taint_store", SessionTaintStore(cfg))  # isolate each producer
+        ref._post_tool_call(producer, {}, result=value, task_id="s1")
+        out = ref._pre_tool_call("send_email", {"body": f"relay {value}"}, task_id="s1")
+        assert out is not None and out["action"] == "block", producer
+
+
+def test_taint_block_is_additive_to_pii(monkeypatch: pytest.MonkeyPatch) -> None:
+    # (a) a tainted arg that ALSO matches PII is blocked by the taint fence (ordered first).
+    gr_pii = _guard_result(findings=(_pii(Severity.CRITICAL),), param_scan_unsafe=True)
+    ref = _make_taint_plugin(monkeypatch, guard_result=gr_pii)
+    ref._post_tool_call(
+        "mcp_bank_list_accounts", {}, result="taxpayer-balance-record-xyz", task_id="s1"
+    )
+    out = ref._pre_tool_call(
+        "send_email", {"body": "relay taxpayer-balance-record-xyz"}, task_id="s1"
+    )
+    assert out is not None and out["action"] == "block"
+    assert "restricted source" in out["message"]  # the taint_egress message, not pii_egress
+
+    # (b) an untainted PII arg still takes the unchanged pii_egress path (distinct message).
+    ref2 = _make_taint_plugin(monkeypatch, guard_result=gr_pii)
+    out2 = ref2._pre_tool_call("send_email", {"body": "no taint here"}, task_id="s2")
+    assert out2 is not None and out2["action"] == "block"
+    assert "PII" in out2["message"] and "restricted source" not in out2["message"]
+
+
+def test_taint_fence_direction_orthogonal(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The fence fires identically with and without a direction kwarg (D4 orthogonality:
+    # it never consults Direction).
+    ref = _make_taint_plugin(monkeypatch)
+    value = "direction-orthogonal-value-99"
+    ref._post_tool_call("mcp_bank_list_accounts", {}, result=value, task_id="s1")
+    out_no_dir = ref._pre_tool_call("send_email", {"body": f"relay {value}"}, task_id="s1")
+    out_with_dir = ref._pre_tool_call(
+        "send_email", {"body": f"relay {value}"}, task_id="s1", direction="outbound"
+    )
+    assert out_no_dir is not None and out_with_dir is not None
+    assert out_no_dir["message"] == out_with_dir["message"]
+
+
+def test_taint_feature_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With source_taint_namespaces=() the capture and check paths are inert; _pre_tool_call
+    # behavior equals the pre-PET-134 baseline.
+    ref = _make_taint_plugin(monkeypatch, namespaces=())
+    ref._post_tool_call("mcp_bank_list_accounts", {}, result=_TAINTED, task_id="s1")
+    assert ref._pre_tool_call("send_email", {"body": _TAINTED}, task_id="s1") is None
+
+
+def test_taint_capture_check_same_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # (a) post then pre through the SAME (task_id, kwargs) -> blocked (the keying invariant, D1b).
+    ref = _make_taint_plugin(monkeypatch)
+    ref._post_tool_call(
+        "mcp_bank_list_accounts", {}, result="same-session-keying-value", task_id="t-42"
+    )
+    out = ref._pre_tool_call(
+        "send_email", {"body": "relay same-session-keying-value"}, task_id="t-42"
+    )
+    assert out is not None and out["action"] == "block"
+
+    # (b) an uncorrelatable call (no task_id, no _agent) captures nothing and never blocks
+    # (the fail-open guard: capture under a fresh anon-<uuid> could never be matched).
+    ref2 = _make_taint_plugin(monkeypatch)
+    ref2._post_tool_call(
+        "mcp_bank_list_accounts", {}, result="anon-uncorrelatable-value", task_id=""
+    )
+    assert (
+        ref2._pre_tool_call("send_email", {"body": "relay anon-uncorrelatable-value"}, task_id="")
+        is None
+    )
+
+
+def test_taint_namespace_set_reconfigure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Adding a namespace live via _apply_reconfigure makes a subsequent relay blocked;
+    # removing all namespaces live makes it allowed (the `global`-declaration / live-rebuild
+    # guard, F-6). Proves the module set is rebuilt, not frozen at boot.
+    ref = _make_taint_plugin(monkeypatch, namespaces=())  # start with the fence off
+
+    class _Collab:
+        # Serves both _guard.evaluate (relay) and the _apply_reconfigure phase calls.
+        def evaluate(self, *a: Any, **k: Any) -> None:
+            return None
+
+        def validate_config(self, cfg: PetasosConfig) -> None:
+            return None
+
+        def apply_config(self, cfg: PetasosConfig) -> None:
+            return None
+
+        def reconfigure(self, cfg: PetasosConfig) -> None:
+            return None
+
+    collab = _Collab()
+    monkeypatch.setattr(ref, "_guard", collab)
+    monkeypatch.setattr(ref, "_pipeline", collab)
+    monkeypatch.setattr(ref, "_lineage_registry", None)
+
+    value = "reconfigure-taint-value-7"
+
+    def _relay() -> Any:  # ref._pre_tool_call is dynamically typed (module attr) -> Any
+        ref._post_tool_call("mcp_bank_list_accounts", {}, result=value, task_id="s1")
+        return ref._pre_tool_call("send_email", {"body": f"relay {value}"}, task_id="s1")
+
+    # initially off -> allowed
+    assert _relay() is None
+
+    # add the namespace live (default egress_sink_tools include send_email)
+    cfg_on = PetasosConfig(source_taint_namespaces=_BANK_NS, taint_min_span_length=12)
+    asyncio.run(ref._apply_reconfigure(cfg_on))
+    assert ref._source_taint_namespaces == frozenset({"mcp_bank_"})
+    out = _relay()
+    assert out is not None and out["action"] == "block"
+
+    # remove all namespaces live -> allowed again
+    cfg_off = PetasosConfig(source_taint_namespaces=(), taint_min_span_length=12)
+    asyncio.run(ref._apply_reconfigure(cfg_off))
+    assert ref._source_taint_namespaces == frozenset()
+    assert _relay() is None

--- a/tests/test_session_taint.py
+++ b/tests/test_session_taint.py
@@ -1,0 +1,266 @@
+"""Unit tests for SessionTaintStore (PET-134).
+
+Backend-free: the store depends only on ``petasos.normalize`` + ``PetasosConfig``
+(no ML extras), so this file runs in the default ``ci.yml`` lane. Covers the FP
+floor (measured on the normalized span), per-session isolation, the two memory
+bounds (per-session span cap + global session LRU), JSON-leaf granularity,
+first-source-wins collision, the verbatim-only matching residual, and the
+non-retroactive ``apply_config`` semantics.
+
+Invisible / look-alike characters are written as explicit ``\\u`` escapes so the
+test intent is legible and the source survives reformatting.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+from petasos import PetasosConfig
+from petasos.session.taint import (
+    _MAX_SCAN_LEAVES,
+    _MAX_SCAN_TEXT,
+    _MAX_TAINT_SPAN_LEN,
+    _TAINT_MAX_SESSIONS,
+    _TAINT_MAX_SPANS_PER_SESSION,
+    SessionTaintStore,
+    _iter_leaf_strings,
+)
+
+_ZWSP = "​"  # ZERO WIDTH SPACE (category Cf, stripped by normalize)
+_CYRILLIC_O = "о"  # Cyrillic small letter o (folds to ASCII 'o')
+
+
+def _store(min_span_length: int = 12) -> SessionTaintStore:
+    return SessionTaintStore(PetasosConfig(taint_min_span_length=min_span_length))
+
+
+# ---------------------------------------------------------------------------
+# FP floor
+# ---------------------------------------------------------------------------
+
+
+def test_taint_minlength_floor_no_false_positive() -> None:
+    # A span below taint_min_span_length is never stored, so a low-entropy value
+    # cannot poison an unrelated later argument.
+    store = _store()
+    store.capture("s1", "$5.00", "ns")  # 5 chars, below floor
+    store.capture("s1", "2026", "ns")  # parses to int 2026 -> "2026", below floor
+    assert store.tainted_source("s1", {"body": "I paid $5.00 back in 2026"}) is None
+
+
+def test_taint_floor_measured_on_normalized_codepoints() -> None:
+    # F-3: the floor is a codepoint count on the NORMALIZED span, not the raw input.
+    store = _store(12)
+    # 11 sharp-s (U+00DF, raw 11, below the floor) casefolds to 22 's' (>= floor): STORED,
+    # because the floor is measured after normalization. A raw-length floor would drop it.
+    sharp_s = "ß" * 11
+    store.capture("s1", sharp_s, "ns")
+    assert store.tainted_source("s1", {"v": sharp_s}) == "ns"
+    # Converse: a value whose RAW length clears the floor but whose NORMALIZED length falls
+    # below it (zero-width stripping shrinks it) is dropped.
+    raw = "abcdefghij" + _ZWSP + "k"  # raw 12; normalized 11 < 12
+    store.capture("s2", raw, "ns")
+    assert store.tainted_source("s2", {"v": "abcdefghijk"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-session isolation + memory bounds
+# ---------------------------------------------------------------------------
+
+
+def test_taint_per_session_isolation() -> None:
+    # A span captured under session A never matches a check for session B (keyed
+    # isolation delivers the brief's "cleared on session end" guarantee since no
+    # session-end hook exists, D1a).
+    store = _store()
+    store.capture("A", "sensitive-balance-12345", "ns")
+    assert store.tainted_source("A", {"v": "sensitive-balance-12345"}) == "ns"
+    assert store.tainted_source("B", {"v": "sensitive-balance-12345"}) is None
+
+
+def test_taint_set_bounded_per_session() -> None:
+    # Over the per-session span cap, the oldest spans are evicted (memory bound).
+    store = _store()
+    total = _TAINT_MAX_SPANS_PER_SESSION + 50
+    for i in range(total):
+        store.capture("s1", f"sensitive-span-value-{i:05d}", "ns")
+    newest = f"sensitive-span-value-{total - 1:05d}"
+    oldest = "sensitive-span-value-00000"
+    assert store.tainted_source("s1", {"v": newest}) == "ns"
+    assert store.tainted_source("s1", {"v": oldest}) is None  # evicted
+
+
+def test_taint_set_bounded_sessions_lru() -> None:
+    # Over the global session cap, the least-recently-active session's whole set is
+    # evicted (the no-session-end backstop; total memory hard-bounded).
+    store = _store()
+    span = "shared-sensitive-value-xyz"
+    store.capture("first", span, "ns")
+    for i in range(_TAINT_MAX_SESSIONS + 5):
+        store.capture(f"sess-{i}", f"other-sensitive-value-{i:05d}", "ns")
+    # 'first' is the least-recently-active key and was evicted whole.
+    assert store.tainted_source("first", {"v": span}) is None
+    recent_i = _TAINT_MAX_SESSIONS + 4
+    recent = f"sess-{recent_i}"
+    assert store.tainted_source(recent, {"v": f"other-sensitive-value-{recent_i:05d}"}) == "ns"
+
+
+# ---------------------------------------------------------------------------
+# JSON-leaf granularity + leaf shape
+# ---------------------------------------------------------------------------
+
+
+def test_taint_json_leaf_granularity() -> None:
+    store = _store(12)
+    # (a) A JSON-object string taints per leaf. A floor-clearing numeric leaf is
+    # json.dumps-stringified and captured; a short bare number is below the floor and
+    # dropped like a short string (F-9 / F-1: the headline amount is fenced via a longer
+    # descriptive field, not as a bare number).
+    result = json.dumps(
+        {
+            "ref": 20260617400012,  # 14-digit int -> "20260617400012" (>= floor)
+            "amount": 4000.0,  # -> "4000.0" (6 chars, dropped)
+            "memo": "Whole Foods groceries run",  # >= floor string leaf
+        }
+    )
+    store.capture("s1", result, "ns")
+    assert store.tainted_source("s1", {"v": "ref 20260617400012 posted"}) == "ns"
+    assert store.tainted_source("s1", {"v": "the amount was 4000.0 even"}) is None
+    assert store.tainted_source("s1", {"v": "see Whole Foods groceries run today"}) == "ns"
+
+    # (b) A bool leaf is extracted as its JSON-wire form ("true"/"false"), not Python's
+    # str() ("True"/"False") -- the shared canonical shape for capture and check.
+    assert list(_iter_leaf_strings({"a": True, "b": False})) == ["true", "false"]
+
+    # (c) A dict result (NOT a JSON string) is walked per leaf, never str()-flattened to one
+    # Python-repr blob; the bare leaf value is fenced (F-2).
+    store.capture("s3", {"outer": {"inner": "deep-sensitive-token-9988"}}, "ns")
+    assert store.tainted_source("s3", {"v": "relay deep-sensitive-token-9988 now"}) == "ns"
+    assert store.tainted_source("s3", {"v": "{'outer': {'inner':"}) is None  # repr is not a span
+
+    # (d) Unescaped-value symmetry: a quoted JSON leaf still matches an unescaped relay
+    # (both sides are the post-parse value, so JSON quote-escaping never breaks the match).
+    store.capture("s4", json.dumps({"note": 'say "hello world" to all'}), "ns")
+    assert store.tainted_source("s4", {"v": 'say "hello world" to all'}) == "ns"
+
+
+def test_taint_capture_non_str_and_oversize() -> None:
+    store = _store(12)
+    # (a) non-str / None result: no raise, nothing harmful stored; a long bare scalar is
+    # eligible (stringified), a short one is dropped.
+    store.capture("s1", None, "ns")
+    store.capture("s1", 4000.0, "ns")  # -> "4000.0" (6 chars, dropped)
+    store.capture("s1", 12345678901234, "ns")  # -> "12345678901234" (14 chars, stored)
+    assert store.tainted_source("s1", {"v": "ref 12345678901234 x"}) == "ns"
+
+    # (b) a valid-JSON result larger than _MAX_SCAN_TEXT degrades to a capture-miss (the cut
+    # truncates mid-structure -> one over-max leaf -> dropped; no crash).
+    big = json.dumps({"k": "S" + "a" * (_MAX_SCAN_TEXT + 5000)})
+    store.capture("s2", big, "ns")
+    assert store.tainted_source("s2", {"v": "a" * 200}) is None
+
+    # (c) an oversized STRUCTURED result with > _MAX_SCAN_LEAVES leaves: bounded walk. The
+    # last leaf within the walk cap is captured; a leaf past the cap is a documented miss.
+    last_walked = _MAX_SCAN_LEAVES - 1
+    past_cap = _MAX_SCAN_LEAVES + 150
+    huge = {f"k{i}": f"sensitive-leaf-value-{i:06d}" for i in range(_MAX_SCAN_LEAVES + 200)}
+    store.capture("s3", huge, "ns")
+    assert store.tainted_source("s3", {"v": f"sensitive-leaf-value-{last_walked:06d}"}) == "ns"
+    assert store.tainted_source("s3", {"v": f"sensitive-leaf-value-{past_cap:06d}"}) is None
+
+    # (d) an over-_MAX_TAINT_SPAN_LEN leaf is dropped, not stored whole.
+    store.capture("s4", "z" * (_MAX_TAINT_SPAN_LEN + 10), "ns")
+    assert store.tainted_source("s4", {"v": "z" * (_MAX_TAINT_SPAN_LEN + 10)}) is None
+
+
+# ---------------------------------------------------------------------------
+# Collision, common-phrase residual, normalization parity
+# ---------------------------------------------------------------------------
+
+
+def test_taint_span_multi_namespace_collision() -> None:
+    # First-source-wins: the same span captured from two namespaces reports a STABLE
+    # namespace so the operator block reason is deterministic (F-1).
+    store = _store()
+    span_text = "shared-collision-value-001"
+    store.capture("s1", span_text, "mcp_bank_")
+    store.capture("s1", span_text, "mcp_health_")  # same span, later source -> ignored
+    assert store.tainted_source("s1", {"v": span_text}) == "mcp_bank_"
+
+
+def test_taint_common_phrase_blocks() -> None:
+    # F-4 (accepted residual, pinned as intended): a 12+ char common phrase over the floor
+    # DOES block a later arg containing it -- the length floor is not an entropy floor.
+    store = _store()
+    store.capture("s1", "Amazon Web Services", "ns")  # 19 chars, a common phrase
+    assert store.tainted_source("s1", {"v": "invoice from Amazon Web Services"}) == "ns"
+
+
+def test_taint_normalized_match() -> None:
+    # A homoglyph / cased / zero-width variant of a captured span in the outbound arg still
+    # matches (normalization parity); a base64 re-encoding does NOT (D-EVASION verbatim-only).
+    store = _store()
+    store.capture("s1", "Sensitive Account Holder", "ns")
+    homoglyph = "sensitive acc" + _CYRILLIC_O + "unt holder"  # Cyrillic 'o' + lowercased
+    assert store.tainted_source("s1", {"v": homoglyph}) == "ns"
+    zero_width = "Sensitive" + _ZWSP + " Account Holder"
+    assert store.tainted_source("s1", {"v": zero_width}) == "ns"
+    b64 = base64.b64encode(b"Sensitive Account Holder").decode()
+    assert store.tainted_source("s1", {"v": b64}) is None
+
+
+# ---------------------------------------------------------------------------
+# apply_config (PET-126 parity): live floor change, non-retroactive
+# ---------------------------------------------------------------------------
+
+
+def test_taint_apply_config_updates_floor() -> None:
+    store = _store(20)
+    store.capture("s1", "fifteen-chars12", "ns")  # 15 chars < 20 -> dropped
+    assert store.tainted_source("s1", {"v": "fifteen-chars12"}) is None
+    store.apply_config(PetasosConfig(taint_min_span_length=10))  # lower the floor live
+    store.capture("s1", "fifteen-chars99", "ns")  # 15 chars >= 10 -> stored
+    assert store.tainted_source("s1", {"v": "fifteen-chars99"}) == "ns"
+
+
+def test_taint_apply_config_floor_not_retroactive() -> None:
+    # F-5: a live floor change applies to FUTURE captures only.
+    store = _store(10)
+    store.capture("s1", "twelve-chars1", "ns")  # 13 chars >= 10 -> stored
+    store.apply_config(PetasosConfig(taint_min_span_length=50))  # raise the floor
+    assert store.tainted_source("s1", {"v": "twelve-chars1"}) == "ns"  # not retroactively removed
+
+    store2 = _store(50)
+    store2.capture("s2", "short-twelve", "ns")  # 12 chars < 50 -> never stored
+    store2.apply_config(PetasosConfig(taint_min_span_length=5))  # lower the floor
+    assert store2.tainted_source("s2", {"v": "short-twelve"}) is None  # not retroactively admitted
+
+
+# ---------------------------------------------------------------------------
+# Performance (bounded-work checks, loose to avoid CI flake)
+# ---------------------------------------------------------------------------
+
+
+def test_taint_block_off_hot_path_cost() -> None:
+    store = _store()
+    for i in range(_TAINT_MAX_SPANS_PER_SESSION):
+        store.capture("s1", f"sensitive-span-value-{i:05d}", "ns")
+
+    # (a) check side: tainted_source against a full per-session span set stays well within
+    # the syntactic-only budget.
+    args = {"a": "no tainted content here at all, just benign text", "b": 12345}
+    start = time.perf_counter()
+    for _ in range(50):
+        store.tainted_source("s1", args)
+    check_avg = (time.perf_counter() - start) / 50
+    assert check_avg < 0.05, f"tainted_source too slow: {check_avg * 1000:.2f}ms"
+
+    # (b) capture side: normalizing + JSON-walking a representative tainted result is bounded.
+    payload = json.dumps({"rows": [f"row-value-{i}-xxxxxxxx" for i in range(50)]})
+    start = time.perf_counter()
+    for _ in range(50):
+        store.capture("s2", payload, "ns")
+    capture_avg = (time.perf_counter() - start) / 50
+    assert capture_avg < 0.05, f"capture too slow: {capture_avg * 1000:.2f}ms"

--- a/tests/test_session_taint.py
+++ b/tests/test_session_taint.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 import base64
 import json
 import time
+from typing import Any
 
 from petasos import PetasosConfig
 from petasos.session.taint import (
     _MAX_SCAN_LEAVES,
     _MAX_SCAN_TEXT,
+    _MAX_TAINT_DEPTH,
     _MAX_TAINT_SPAN_LEN,
     _TAINT_MAX_SESSIONS,
     _TAINT_MAX_SPANS_PER_SESSION,
@@ -248,19 +250,41 @@ def test_taint_block_off_hot_path_cost() -> None:
     for i in range(_TAINT_MAX_SPANS_PER_SESSION):
         store.capture("s1", f"sensitive-span-value-{i:05d}", "ns")
 
-    # (a) check side: tainted_source against a full per-session span set stays well within
-    # the syntactic-only budget.
+    # (a) check side: tainted_source IS the pre-call enforcement hot path (syntactic-only
+    # budget < 5ms), and it is a few-microsecond op (normalize a couple of arg leaves, then
+    # substring-scan a full span set), so a 5ms ceiling holds ~1000x headroom and tightly
+    # catches a gross regression (e.g. an accidental O(n^2) blow-up).
     args = {"a": "no tainted content here at all, just benign text", "b": 12345}
     start = time.perf_counter()
     for _ in range(50):
         store.tainted_source("s1", args)
     check_avg = (time.perf_counter() - start) / 50
-    assert check_avg < 0.05, f"tainted_source too slow: {check_avg * 1000:.2f}ms"
+    assert check_avg < 0.005, f"tainted_source too slow: {check_avg * 1000:.2f}ms"
 
-    # (b) capture side: normalizing + JSON-walking a representative tainted result is bounded.
+    # (b) capture side: a deliberately loose bound. capture runs on _post_tool_call (after
+    # the tool ran), NOT on the < 5ms pre-call enforcement path, and it NFKC-normalizes
+    # every leaf, which on a contended CI runner approaches single-digit ms. Per spec
+    # § Performance this stays a flake-resistant bounded-work check, not a 5ms budget assert
+    # (a real latency budget needs a benchmark harness, not an averaged wall-clock assert).
     payload = json.dumps({"rows": [f"row-value-{i}-xxxxxxxx" for i in range(50)]})
     start = time.perf_counter()
     for _ in range(50):
         store.capture("s2", payload, "ns")
     capture_avg = (time.perf_counter() - start) / 50
     assert capture_avg < 0.05, f"capture too slow: {capture_avg * 1000:.2f}ms"
+
+
+def test_taint_deeply_nested_no_recursion_error() -> None:
+    # Finding 2 regression: a hostile deeply-nested payload must not raise RecursionError
+    # on EITHER path (bounded leaf walk); content past _MAX_TAINT_DEPTH is a documented
+    # walk-miss, not a crash.
+    store = _store(12)
+    deep: Any = "sensitive-deep-leaf-value-xyz"
+    for _ in range(_MAX_TAINT_DEPTH + 50):
+        deep = [deep]
+    store.capture("s1", deep, "ns")  # structured-walk recursion: must not raise
+    # the buried leaf sits past the depth cap, so it is never reached (no match, no crash).
+    assert store.tainted_source("s1", {"v": deep}) is None
+    # a deeply-nested JSON STRING result exercises json.loads's own recursion guard.
+    json_bomb = "[" * 50000 + "]" * 50000
+    store.capture("s2", json_bomb, "ns")  # must not raise


### PR DESCRIPTION
## Summary
- Adds a content-agnostic, provenance-typed egress fence to the reference plugin: content a tool in an operator-declared **source namespace** returned may not appear, verbatim, as an argument to any `egress_sink_tools` tool, regardless of PII match. Closes the structural hole the PII matcher cannot (a non-PII balance / amount / merchant relayed off-box).
- **Off by default** (empty `source_taint_namespaces`), **additive** to the existing PII-egress block, and reuses the existing egress sink set. A reusable Petasos primitive: no banking-specific names ship.
- New `SessionTaintStore` (per-session, bounded, thread-safe span set) mirrors `LineageRegistry`; memory is hard-bounded by a per-session span cap plus a global session LRU (the plugin registers no session-end hook).

## Layered defense
The fence is the **first** egress block check (block 0), ahead of degraded / non-PII / PII-egress:
- **Untainted / feature-off** path is byte-identical to today: three short-circuits (`egress`, non-empty `_source_taint_namespaces`, `_taint_store is not None`) collapse to an empty-set check.
- **Tainted argument** is blocked whether or not it also matches PII (additive). Matching is normalized exact-substring with a false-positive length floor (`taint_min_span_length`, default 12), measured on the normalized span. Capture happens at `_post_tool_call`; it skips uncorrelatable `anon-` ids to close a silent fail-open.
- The model-facing message carries **no** source/sink detail (PET-77); the provenance namespace and sink go only to the operator log line + `quarantine` enforcement event (`source-taint egress: <ns> -> <sink>`).

## Files changed

| File | Change |
|------|--------|
| `petasos/session/taint.py` | New: `SessionTaintStore` (capture / tainted_source / apply_config / clear_session) + JSON-leaf extraction helpers |
| `petasos/config.py` | Adds `source_taint_namespaces` + `taint_min_span_length` with validation and `from_dict` coercion |
| `petasos/__init__.py` | Re-exports `SessionTaintStore` |
| `petasos/session/formatting.py` | Adds the `taint_egress` content-block path (no source/sink detail) |
| `docs/deployment/reference_plugin/__init__.py` | Wires capture, the additive fence, and gateway globals (built in `_deferred_init`, rebuilt in `_apply_reconfigure`) |
| `petasos/console/_config_meta.py` | `_FIELD_META` entries (section `tool_guard`) for the two new fields |
| `docs/usage/configuration.md` | Three PET-128 drift-guard markers updated (count 59→61, CSV, prose rows) |
| `docs/deployment/hardening.md` | §6 operator note: verbatim source→off-box, defense-in-depth |
| `tests/test_session_taint.py` | New: store unit tests (floor, isolation, bounds, leaf granularity, collision, apply_config, perf) |
| `tests/test_reference_plugin_egress.py` | New plugin-integration cases (block/exempt, canonicalized match, additive-to-PII, session keying, live reconfigure) |
| `tests/test_config.py` | New `source_taint_namespaces` / `taint_min_span_length` roundtrip + validation case |

## Test plan
- [x] `python -m pytest tests/test_session_taint.py tests/test_reference_plugin_egress.py tests/test_config.py tests/test_docs_usage_consistency.py -p no:cacheprovider` — 112/112 pass (audit trail: docs/specs/TODO/PET-134.test-output.txt)
- [x] `python -m pytest` full suite — 1815 passed, 2 pre-existing master failures deselected (Unicode-13 `test_default_ignorable_rejected`, stale-0.1.0 `test_get_about`)
- [x] `ruff check .` / `ruff format --check .` / `mypy --strict .` — clean
- [x] PET-128 doc drift-guard (`test_docs_config_sections_match_meta`) green after the +2 marker bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a “source-taint egress fence” control to block tool-call egress when tainted content is detected in configured source namespaces.
  * Added `source_taint_namespaces` and `taint_min_span_length` settings (off by default when namespaces are empty).
  * Exported the session taint store used by the feature.

* **Documentation**
  * Documented the fence’s behavior, limitations, and configuration expectations.

* **Tests**
  * Added coverage for enforcement behavior, canonicalized namespace matching, and reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->