### PR TITLE
feat(pet-138): per-session disarmed-bypass counter on the Observability tab

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -74,6 +74,22 @@ _disarm_log_lock = threading.Lock()
 _last_disarm_log = 0.0
 _DISARM_LOG_EVERY_S = 30.0
 
+# PET-138: per-session count of tool calls bypassed while disarmed. Bumped on
+# EVERY disarmed _pre_tool_call (independent of the rate-limited heartbeat above),
+# so the operator sees an authoritative count, not a 30s sample. The cumulative
+# per-session total rides the rate-limited bypassed_disarmed heartbeat as
+# `bypassed_count`. _bypass_lock guards BOTH _bypass_counts AND the _session_ids
+# insert in _derive_session_id (which now runs on the disarm hot path, not once
+# per 30s). It is a non-reentrant Lock: _derive_session_id and _bump_bypass_count
+# each acquire and release it independently (sequential, never nested) — do not
+# wrap the whole disarm block in it. _MAX_DISARM_SESSIONS bounds the map
+# drop-oldest, mirroring server._MAX_TALLY_SESSIONS (an independent bound by
+# design; the plugin cannot import server without pulling aiohttp onto the hot
+# path).
+_bypass_lock = threading.Lock()
+_bypass_counts: dict[str, int] = {}
+_MAX_DISARM_SESSIONS = 10_000
+
 # PET-126: live config reload. The cross-process re-read (petasos.console._reload)
 # detects a config.yaml change on the hot path and _maybe_reconfigure applies it
 # to the running pipeline + guard + lineage registry. Two rate-limited streams
@@ -658,10 +674,39 @@ def _derive_session_id(task_id: str, kwargs: dict) -> str:
     agent = kwargs.get("_agent")
     if agent is not None:
         agent_id = id(agent)
-        if agent_id not in _session_ids:
-            _session_ids[agent_id] = f"desktop-{uuid.uuid4().hex[:12]}"
-        return _session_ids[agent_id]
+        # PET-138: this check-then-set on the process-global _session_ids dict now
+        # runs on every disarmed call (the disarm fast path), not once per 30s, so
+        # it must be thread-safe on the multi-threaded gateway. Guard with
+        # _bypass_lock so two threads racing a fresh _agent cannot mint two ids
+        # (split count) or trigger an unsafe concurrent dict resize.
+        with _bypass_lock:
+            if agent_id not in _session_ids:
+                _session_ids[agent_id] = f"desktop-{uuid.uuid4().hex[:12]}"
+            return _session_ids[agent_id]
     return f"anon-{uuid.uuid4().hex[:8]}"
+
+
+def _bump_bypass_count(session_id: str) -> int:
+    """PET-138: increment the per-session disarmed-bypass counter and return the new
+    total. O(1) under _bypass_lock. Drop-oldest by insertion order when the map
+    exceeds _MAX_DISARM_SESSIONS (mirrors server._bump_block_tally's bound).
+    """
+    with _bypass_lock:
+        new_count = _bypass_counts.get(session_id, 0) + 1
+        _bypass_counts[session_id] = new_count
+        if len(_bypass_counts) > _MAX_DISARM_SESSIONS:
+            del _bypass_counts[next(iter(_bypass_counts))]
+        return new_count
+
+
+def _reset_bypass_counts() -> None:
+    """Test seam — clear the per-session disarmed-bypass counters (mirrors
+    _reset_disarm_log). Also clears _session_ids so a concurrency test can assert
+    a clean mint."""
+    global _session_ids
+    with _bypass_lock:
+        _bypass_counts.clear()
+        _session_ids = {}
 
 
 def _fallback_pre_tool_call(
@@ -763,10 +808,16 @@ def _emit_enforcement_event(
     reason: str = "",
     param_scan_degraded: bool = False,
     armed: bool = True,
+    bypassed_count: int | None = None,
 ) -> None:
     """PET-131: emit a structured enforcement event onto the cross-process spool the
     dashboard drains, beside the existing decision-point log line (one emit per log
     line — log and surface share one source of truth, spec D1/D4).
+
+    PET-138: ``bypassed_count`` carries the cumulative per-session count of
+    disarmed bypasses on the rate-limited ``bypassed_disarmed`` heartbeat so the
+    dashboard can surface an authoritative count, not a 30s sample. None for all
+    other event types.
 
     Self-guarded and fail-open (spec D5): surfacing a block must never gate, delay,
     or break the tool call, so the whole body is wrapped and swallows everything.
@@ -789,6 +840,7 @@ def _emit_enforcement_event(
                 "param_scan_degraded": param_scan_degraded,
                 "direction": "tool_call",
                 "armed": armed,
+                "bypassed_count": bypassed_count,
             }
         )
     except Exception:
@@ -1100,14 +1152,21 @@ def _pre_tool_call(
     # ABOVE _ensure_initialized so it covers the initialized, init-failed, and
     # init-in-progress windows uniformly (a disarmed boot skips the fallback scan).
     if not _is_armed():
+        # PET-138: count EVERY bypassed call (authoritative tally, not a sample),
+        # independent of the rate-limited heartbeat below. O(1) locked bump; no
+        # scan, no _guard.evaluate — the zero-overhead disarm invariant holds.
+        session_id = _derive_session_id(task_id, kwargs)
+        new_count = _bump_bypass_count(session_id)
         # PET-131: emit a "bypassed (disarmed)" event 1:1 with the rate-limited
         # PETASOS_DISARMED log line so the operator can confirm "off means off".
+        # PET-138: carry the cumulative per-session count on that heartbeat.
         if _log_disarmed_bypass(tool_name):
             _emit_enforcement_event(
-                session_id=_derive_session_id(task_id, kwargs),
+                session_id=session_id,
                 tool=tool_name,
                 event_type="bypassed_disarmed",
                 armed=False,
+                bypassed_count=new_count,
             )
         return None
     if not _ensure_initialized():

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -198,12 +198,17 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
     reason = ev.get("reason")
     if isinstance(reason, str) and len(reason) > _MAX_REASON_LEN:
         reason = reason[:_MAX_REASON_LEN]
-    # PET-138: normalize the cumulative disarmed-bypass count to a positive int (or
-    # None) so a torn/legacy spool line, a float, or a bool can never reach the SSE
-    # frame / tile. bool is excluded via `type(...) is int` (isinstance(True, int)
-    # is True). The frontend integer-gates again before summing.
+    # PET-138: only a bypassed_disarmed heartbeat carries a count; gate on the event
+    # type so a malformed/legacy non-bypass event that stamps a stray bypassed_count
+    # can never feed the tile. Then normalize to a positive int (or None): a float or
+    # a bool is dropped (bool via `type(...) is int` — isinstance(True, int) is True).
+    # The frontend integer-gates again before summing.
     raw_count = ev.get("bypassed_count")
-    bypassed_count = raw_count if type(raw_count) is int and raw_count > 0 else None
+    bypassed_count = (
+        raw_count
+        if event_type == "bypassed_disarmed" and type(raw_count) is int and raw_count > 0
+        else None
+    )
     return {
         "scan_id": ev.get("scan_id"),
         "source": "enforcement",

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -198,6 +198,12 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
     reason = ev.get("reason")
     if isinstance(reason, str) and len(reason) > _MAX_REASON_LEN:
         reason = reason[:_MAX_REASON_LEN]
+    # PET-138: normalize the cumulative disarmed-bypass count to a positive int (or
+    # None) so a torn/legacy spool line, a float, or a bool can never reach the SSE
+    # frame / tile. bool is excluded via `type(...) is int` (isinstance(True, int)
+    # is True). The frontend integer-gates again before summing.
+    raw_count = ev.get("bypassed_count")
+    bypassed_count = raw_count if type(raw_count) is int and raw_count > 0 else None
     return {
         "scan_id": ev.get("scan_id"),
         "source": "enforcement",
@@ -217,6 +223,9 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
         # (D6). The plugin stamps `armed` on every event (reference_plugin emits
         # armed=True on the armed branch, armed=False on the disarmed bypass).
         "armed": ev.get("armed"),
+        # PET-138: cumulative per-session disarmed-bypass count (bypassed_disarmed
+        # heartbeats only; None elsewhere). Drives the "bypassed (disarmed)" tile.
+        "bypassed_count": bypassed_count,
     }
 
 
@@ -303,6 +312,12 @@ class ConsoleHandlers:
         self._enforcement_spool_path: str | None = None
         self._enforcement_lock = asyncio.Lock()
         self._block_tally: dict[str, int] = {}
+        # PET-138: per-session cumulative count of disarmed bypasses, a
+        # reconciliation/test source-of-truth mirroring _block_tally's role (NOT a
+        # UI feed — the tile reads dedicated frontend state). Monotonic-max of the
+        # cumulative count carried on bypassed_disarmed heartbeats; bounded
+        # drop-oldest; resets on a dashboard restart (in-memory by design).
+        self._bypass_tally: dict[str, int] = {}
 
         pipeline.add_audit_listener(self._on_audit)
         pipeline.add_alert_listener(self._on_alert)
@@ -325,6 +340,24 @@ class ConsoleHandlers:
             # Drop-oldest by insertion order (dict is insertion-ordered).
             del tally[next(iter(tally))]
 
+    def bypass_tally_for(self, session_id: str) -> int:
+        """PET-138: per-session cumulative count of disarmed bypasses. Reconciliation
+        source of truth (mirrors block_tally_for); resets on a dashboard restart."""
+        return self._bypass_tally.get(session_id, 0)
+
+    def _set_bypass_tally(self, session_id: str, count: int) -> None:
+        """PET-138: set-or-refresh (NOT increment) — the carried count is an absolute
+        cumulative, so the caller passes a monotonic max. An existing key is assigned
+        in place (preserves insertion order, so drop-oldest still evicts the genuine
+        oldest); a new key triggers the _MAX_TALLY_SESSIONS drop-oldest bound."""
+        tally = self._bypass_tally
+        if session_id in tally:
+            tally[session_id] = count
+            return
+        tally[session_id] = count
+        if len(tally) > _MAX_TALLY_SESSIONS:
+            del tally[next(iter(tally))]
+
     async def _surface_enforcement_event(self, ev: dict[str, Any]) -> None:
         """Fold one drained enforcement event into scan_history + the tally + SSE."""
         summary = _enforcement_summary(ev)
@@ -333,6 +366,14 @@ class ConsoleHandlers:
             sid = ev.get("session_id")
             if isinstance(sid, str) and sid:
                 self._bump_block_tally(sid)
+        elif ev.get("event_type") == "bypassed_disarmed":
+            # PET-138: monotonic-max of the cumulative count (restart re-seed belt;
+            # exactly-once delivery already comes from the forward offset / .rot
+            # discipline). type(cnt) is int excludes bool; cnt > 0 skips no-ops.
+            sid = ev.get("session_id")
+            cnt = ev.get("bypassed_count")
+            if isinstance(sid, str) and sid and type(cnt) is int and cnt > 0:
+                self._set_bypass_tally(sid, max(self.bypass_tally_for(sid), cnt))
         await self.sse.broadcast("scan_result", summary)
 
     async def _drain_and_clear_rot(self, rot_path: str) -> None:

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -327,6 +327,10 @@
     configPresets: null,
     configActivePreset: null,
     scanHistory: [],
+    // PET-138: session_id -> cumulative count of tool calls bypassed while disarmed.
+    // Dedicated, eviction-proof state (the count rides a single rate-limited
+    // heartbeat row that ages out of scanHistory); fed by Pet.accrueBypass.
+    bypassBySession: {},
     // PET-137: scan_id of the scan-history row whose detail panel is open (or null).
     // Persisted in state (not local DOM) so the panel survives renderDashboard's
     // per-SSE-frame rebuild; re-opened by scan_id, so an evicted row closes cleanly.
@@ -469,6 +473,7 @@
         // guard on read, but keeping the buffer object-only is the cheaper floor.
         if (d && typeof d === "object") {
           Pet.state.scanHistory.unshift(d);
+          Pet.accrueBypass([d]); // PET-138: fold this frame's bypass count into state
           // PET-13: announce the newest verdict to AT; the wholesale re-render below
           // is not screen-reader-followable on its own.
           var _v = d.safe === false ? "blocked" : "allowed";
@@ -541,6 +546,7 @@
         Pet.api.getScanHistory(100).then(function (d) {
           if (!d.error && d.entries && Array.isArray(d.entries)) {
             Pet.state.scanHistory = d.entries;
+            Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
             if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
           }
         }).then(function () {
@@ -551,6 +557,7 @@
     Pet.api.getScanHistory(100).then(function (d) {
       if (!d.error && d.entries && Array.isArray(d.entries)) {
         Pet.state.scanHistory = d.entries;
+        Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
         if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
       }
     });
@@ -891,6 +898,54 @@
   // `buffer` in place and returns it (the `return` is for test ergonomics).
   // Intentionally does NOT clamp to the SSE path's 500-entry cap — the request
   // limit bounds the fetched set and the next SSE frame re-clamps (out of scope).
+  // PET-138: fold an array of scan-history rows into Pet.state.bypassBySession, the
+  // dedicated eviction-proof per-session disarmed-bypass accumulator. Tiles
+  // recompute from the ≤500 buffer each render, but a bypass count lives on a single
+  // rate-limited heartbeat row that ages out — so the count is held here in state
+  // (not recomputed from the buffer) and survives eviction once seen. Integer-gated:
+  // a plain Number(x)||0 leaks a non-zero float (Number(3.7)||0 === 3.7), so only a
+  // clean positive integer contributes (the server normalizes too, but this helper
+  // is also called directly in tests with raw frames). Cumulative + Math.max, so a
+  // re-surfaced/lower frame never lowers the count. Bounded drop-oldest (mirrors
+  // server._MAX_TALLY_SESSIONS; the server tally is authoritative) so the frontend
+  // is not the lone unbounded per-session map. Never throws on a malformed entry.
+  var _MAX_BYPASS_SESSIONS = 10000; // mirrors server._MAX_TALLY_SESSIONS
+  Pet.accrueBypass = function (entries) {
+    if (!entries || typeof entries.length !== "number") return;
+    var map = Pet.state.bypassBySession;
+    for (var i = 0; i < entries.length; i++) {
+      var e = entries[i];
+      if (!e || typeof e !== "object" || e.event_type !== "bypassed_disarmed") continue;
+      var sid = e.session_id;
+      if (sid === null || sid === undefined || sid === "") continue;
+      var n = e.bypassed_count;
+      // Gate on number-type FIRST (excludes bool/string/null/undefined — Number(true)
+      // is 1, so a bare Number() would leak a bool), then positive-integer (excludes
+      // float/0/negative/NaN). Mirrors the server's `type(cnt) is int and cnt > 0`.
+      if (typeof n !== "number" || !Number.isInteger(n) || n <= 0) continue;
+      if (n > (map[sid] || 0)) {
+        var isNew = !(sid in map);
+        map[sid] = n; // refresh in place (existing) or insert (new)
+        if (isNew) {
+          var keys = Object.keys(map);
+          if (keys.length > _MAX_BYPASS_SESSIONS) delete map[keys[0]]; // drop-oldest by insertion
+        }
+      }
+    }
+  };
+
+  // PET-138: sum the per-session bypass accumulator for the tile. Pure seam (like
+  // Pet.mergeScanHistory) so the console JS harness can assert the displayed total
+  // without driving the full renderDashboard. Number()||0 is a belt over the
+  // already-integer-gated stored values.
+  Pet.bypassTotal = function () {
+    var map = Pet.state.bypassBySession || {};
+    var keys = Object.keys(map);
+    var total = 0;
+    for (var i = 0; i < keys.length; i++) total += (Number(map[keys[i]]) || 0);
+    return total;
+  };
+
   Pet.mergeScanHistory = function (buffer, entries) {
     var seen = new Set();
     for (var j = 0; j < buffer.length; j++) {
@@ -1002,6 +1057,9 @@
     // loading and from a true zero count); counts render literal 0 (Decision 4).
     var avgLatency = hist.length > 0 ? ((latencySum / hist.length).toFixed(1) + "ms") : "—";
     var sessions = sessionSet.size;
+    // PET-138: "bypassed (disarmed)" total — sum of the dedicated per-session
+    // accumulator (NOT recomputed from the buffer, so it survives row eviction).
+    var bypassed = Pet.bypassTotal();
 
     var metricsRow = Pet.h("div", { style: { display: "flex", gap: "10px" } });
     // Lean metric cells (not four identical icon-panels): an eyebrow label over a
@@ -1023,6 +1081,7 @@
     metricsRow.appendChild(valueTile("blocked", blocked, blocked > 0));
     metricsRow.appendChild(valueTile("avg latency", avgLatency, false));
     metricsRow.appendChild(valueTile("sessions", sessions, false));
+    metricsRow.appendChild(valueTile("bypassed (disarmed)", bypassed, false));
     wrapper.appendChild(metricsRow);
 
     // Scanner health
@@ -1106,6 +1165,7 @@
           // PET-99 D6/D9: shape-guarded seed-merge (skips non-object entries on
           // both sides before reading .scan_id) — replaces the inline dedup loops.
           Pet.mergeScanHistory(Pet.state.scanHistory, d.entries);
+          Pet.accrueBypass(d.entries); // PET-138: seed bypass counts from the pre-existing buffer
           if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
         }
       });

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -917,16 +917,20 @@
       var e = entries[i];
       if (!e || typeof e !== "object" || e.event_type !== "bypassed_disarmed") continue;
       var sid = e.session_id;
-      if (sid === null || sid === undefined || sid === "") continue;
+      if (typeof sid !== "string" || sid === "") continue; // only string session ids (matches server isinstance(sid, str))
       var n = e.bypassed_count;
       // Gate on number-type FIRST (excludes bool/string/null/undefined — Number(true)
       // is 1, so a bare Number() would leak a bool), then positive-integer (excludes
       // float/0/negative/NaN). Mirrors the server's `type(cnt) is int and cnt > 0`.
       if (typeof n !== "number" || !Number.isInteger(n) || n <= 0) continue;
-      if (n > (map[sid] || 0)) {
-        var isNew = !(sid in map);
+      // hasOwnProperty (not `in` / bare `map[sid]`) so a session id colliding with an
+      // inherited Object member (e.g. "toString", "constructor") is read and stored as
+      // an OWN property, never miscounted against a prototype member.
+      var has = Object.prototype.hasOwnProperty.call(map, sid);
+      var prev = has ? map[sid] : 0;
+      if (n > prev) {
         map[sid] = n; // refresh in place (existing) or insert (new)
-        if (isNew) {
+        if (!has) {
           var keys = Object.keys(map);
           if (keys.length > _MAX_BYPASS_SESSIONS) delete map[keys[0]]; // drop-oldest by insertion
         }

--- a/tests/js/disarm-bypass-counter.test.mjs
+++ b/tests/js/disarm-bypass-counter.test.mjs
@@ -1,0 +1,128 @@
+// Unit tests for the PET-138 disarmed-bypass counter surface (petasos.js).
+//
+// The "bypassed (disarmed)" tile must reflect an authoritative per-session count
+// that survives buffer eviction. The count rides a single rate-limited
+// bypassed_disarmed heartbeat row, so it is held in dedicated state
+// (Pet.state.bypassBySession) via Pet.accrueBypass — NOT recomputed from the
+// ≤500-entry scan-history buffer — and summed for the tile by Pet.bypassTotal.
+// accrueBypass integer-gates the carried count (a non-integer / bool / null / zero
+// contributes nothing) and keeps a monotonic max per session, bounded drop-oldest.
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped
+// petasos.js. Run with: node --test tests/js/disarm-bypass-counter.test.mjs
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// Minimal DOM shim — these tests exercise pure data seams (accrueBypass /
+// bypassTotal), so document is only needed for petasos.js to evaluate.
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute() {},
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+const bypass = (session_id, bypassed_count) => ({
+  source: "enforcement",
+  event_type: "bypassed_disarmed",
+  session_id,
+  bypassed_count,
+  scan_id: "e-" + session_id + "-" + String(bypassed_count),
+});
+
+beforeEach(() => {
+  Pet.state.bypassBySession = {}; // isolate: Pet is shared across tests in this vm context
+});
+
+test("loader: petasos.js exposes accrueBypass + bypassTotal + bypassBySession state", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.accrueBypass, "function");
+  assert.equal(typeof Pet.bypassTotal, "function");
+  assert.equal(typeof Pet.state.bypassBySession, "object");
+});
+
+test("live frame with an integer count updates state and the tile total", () => {
+  Pet.accrueBypass([bypass("s1", 3)]);
+  assert.equal(Pet.state.bypassBySession.s1, 3);
+  assert.equal(Pet.bypassTotal(), 3);
+});
+
+test("monotonic max: a later higher count raises it; a lower count does not lower it", () => {
+  Pet.accrueBypass([bypass("s1", 3)]);
+  Pet.accrueBypass([bypass("s1", 7)]); // higher -> adopt
+  assert.equal(Pet.state.bypassBySession.s1, 7);
+  Pet.accrueBypass([bypass("s1", 5)]); // re-surfaced lower -> ignored
+  assert.equal(Pet.state.bypassBySession.s1, 7);
+  assert.equal(Pet.bypassTotal(), 7);
+});
+
+test("seed path: an array of pre-existing rows populates state (mount seed, not a live frame)", () => {
+  // Mirrors Pet.accrueBypass(d.entries) on the one-shot history seed.
+  Pet.accrueBypass([bypass("s1", 2), bypass("s2", 5), { event_type: "block", session_id: "s3" }]);
+  assert.equal(Pet.state.bypassBySession.s1, 2);
+  assert.equal(Pet.state.bypassBySession.s2, 5);
+  assert.equal("s3" in Pet.state.bypassBySession, false); // non-bypass row ignored
+  assert.equal(Pet.bypassTotal(), 7); // summed across sessions
+});
+
+test("coercion: non-integer float / null / 'undefined' / missing / bool / zero / negative contribute 0", () => {
+  Pet.accrueBypass([
+    bypass("a", 3.7),
+    bypass("b", null),
+    bypass("c", "undefined"),
+    bypass("d", undefined),
+    bypass("e", true),
+    bypass("f", 0),
+    bypass("g", -4),
+    { event_type: "bypassed_disarmed", session_id: "h" }, // no bypassed_count
+  ]);
+  assert.deepEqual(Pet.state.bypassBySession, {}); // nothing admitted
+  assert.equal(Pet.bypassTotal(), 0);
+  // The tile renders the integer 0 honestly (never the string "undefined").
+  assert.equal(String(Pet.bypassTotal()), "0");
+});
+
+test("eviction-proof: the count persists in state independent of the scan-history buffer", () => {
+  Pet.accrueBypass([bypass("s1", 4)]);
+  // Simulate the source row aging out of the buffer (buffer cleared); state is not
+  // recomputed from the buffer, so the tile total is unchanged.
+  Pet.state.scanHistory = [];
+  assert.equal(Pet.bypassTotal(), 4);
+});
+
+test("malformed input never throws and is skipped", () => {
+  assert.doesNotThrow(() => Pet.accrueBypass(null));
+  assert.doesNotThrow(() => Pet.accrueBypass(undefined));
+  assert.doesNotThrow(() => Pet.accrueBypass([null, 42, "x", {}]));
+  assert.equal(Pet.bypassTotal(), 0);
+});
+
+test("bounded drop-oldest: more than the cap distinct sessions stays bounded, oldest dropped", () => {
+  const CAP = 10000; // mirrors _MAX_BYPASS_SESSIONS / server._MAX_TALLY_SESSIONS
+  for (let i = 0; i <= CAP; i++) Pet.accrueBypass([bypass("s" + i, 1)]); // CAP+1 sessions
+  const keys = Object.keys(Pet.state.bypassBySession);
+  assert.equal(keys.length, CAP); // bounded
+  assert.equal("s0" in Pet.state.bypassBySession, false); // genuine oldest evicted
+  assert.equal(Pet.state.bypassBySession["s" + CAP], 1); // newest retained
+});

--- a/tests/test_disarm_bypass_counter.py
+++ b/tests/test_disarm_bypass_counter.py
@@ -1,0 +1,217 @@
+"""PET-138: per-session disarmed-bypass counter (plugin side).
+
+While Petasos is disarmed (Unequipped), ``_pre_tool_call`` short-circuits with no
+scan and emits a ``bypassed_disarmed`` heartbeat only when the 30s rate-limiter
+opens — a sample, not a count. PET-138 adds an in-process per-session counter
+bumped on EVERY disarmed call (decoupled from the heartbeat) and carries the
+cumulative count on the heartbeat so the dashboard can surface an authoritative
+tally.
+
+Regression for PET-138: the operator could not see how many tool calls were
+bypassed while disarmed (the heartbeat is a 30s sample); "off means off" was
+unverifiable from the UI. The counter must not weaken the zero-overhead disarm
+invariant (no scan, no ``_guard.evaluate``).
+
+Backend-free: the guard is stubbed; the spool is redirected by the autouse
+``_isolate_enforcement_spool`` conftest fixture.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import petasos.console._events as ev  # noqa: E402
+from petasos import GuardResult  # noqa: E402
+
+if TYPE_CHECKING:
+    import types
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet138", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _raise_on_scan(self: Any, *a: Any, **k: Any) -> None:
+    raise AssertionError("a scan ran while disarmed (zero-overhead invariant violated)")
+
+
+def _setup_disarmed(ref: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the plugin into a disarmed, initialized state with a guard that SCREAMS
+    if anything tries to scan on the disarm fast path."""
+    monkeypatch.setattr(ref, "_initialized", True)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_is_armed", lambda: False)
+    monkeypatch.setattr(ref, "_guard", type("SpyGuard", (), {"evaluate": _raise_on_scan})())
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+    ref._reset_disarm_log()
+    ref._reset_bypass_counts()
+
+
+def _allowed() -> GuardResult:
+    return GuardResult(
+        allowed=True,
+        reason="allowed",
+        findings=(),
+        tier="none",
+        param_scan_unsafe=False,
+        param_scan_degraded=False,
+    )
+
+
+def _read_spool(spool: str) -> list[dict[str, Any]]:
+    if not Path(spool).exists():
+        return []
+    with open(spool, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+@pytest.fixture()
+def spool() -> str:
+    return ev._spool_path()
+
+
+def test_t1_full_count_in_one_window(spool: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # K disarmed calls in one 30s window are ALL counted in-process, even though the
+    # rate-limited heartbeat fires at most once. The single heartbeat carries the
+    # count at emit time (1 — the first call opened the window).
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)
+    k = 5
+    for _ in range(k):
+        assert ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-A") is None
+    assert ref._bypass_counts["sess-A"] == k  # in-process count is exact
+
+    events = _read_spool(spool)
+    assert len(events) == 1  # heartbeat is rate-limited to <=1 per window
+    assert events[0]["event_type"] == "bypassed_disarmed"
+    assert events[0]["bypassed_count"] == 1  # count at emit time (first call)
+
+
+def test_t2_zero_overhead_no_scan(spool: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-138: counting must NOT introduce a scan. A disarmed
+    # _pre_tool_call runs no scanner, never enters the async guard path, returns None
+    # — but the call IS counted.
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)
+    run_calls: list[Any] = []
+    monkeypatch.setattr(ref, "_run_async", lambda coro: run_calls.append(coro))
+
+    out = ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-B")
+
+    assert out is None  # hard bypass
+    assert run_calls == []  # async guard path never entered (the spy guard would also raise)
+    assert ref._bypass_counts["sess-B"] == 1  # counted without scanning
+
+
+def test_t4_count_advances_with_window_closed_then_next_window_carries_total(
+    spool: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The count advances on every call (window open or closed); a later window's
+    # heartbeat carries the running cumulative total — decoupled from the 1/window
+    # heartbeat cadence.
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)
+    # First call opens the window -> 1 event (count 1). Two more in the same window:
+    # counted in-process, no new event.
+    for _ in range(3):
+        ref._pre_tool_call("t", {}, task_id="s")
+    assert ref._bypass_counts["s"] == 3
+    assert len(_read_spool(spool)) == 1
+
+    # Window reopens (simulate 30s elapsed); the next heartbeat carries the total.
+    ref._reset_disarm_log()
+    ref._pre_tool_call("t", {}, task_id="s")
+    assert ref._bypass_counts["s"] == 4
+    events = _read_spool(spool)
+    assert len(events) == 2
+    assert events[1]["bypassed_count"] == 4  # cumulative, not a per-window delta
+
+
+def test_t3_counts_bounded_drop_oldest(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)
+    monkeypatch.setattr(ref, "_MAX_DISARM_SESSIONS", 3)
+    for i in range(5):
+        ref._pre_tool_call("t", {}, task_id=f"s{i}")
+    assert len(ref._bypass_counts) == 3
+    assert set(ref._bypass_counts) == {"s2", "s3", "s4"}  # s0, s1 dropped (oldest)
+
+
+def test_tconc_concurrent_desktop_agent_single_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-138 / edge F-3: _derive_session_id's _session_ids write now
+    # runs on the disarm hot path. N threads racing one fresh desktop _agent (empty
+    # task_id) must mint exactly ONE id and count every call (locked check-then-set;
+    # no split count, no dict-resize error).
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)  # also resets _session_ids + _bypass_counts
+    agent = object()
+    n = 50
+    ids: list[str] = []
+    ids_lock = threading.Lock()
+    barrier = threading.Barrier(n)
+
+    def worker() -> None:
+        barrier.wait()  # maximize contention on the fresh-agent insert
+        ref._pre_tool_call("t", {}, task_id="", _agent=agent)
+        sid = ref._derive_session_id("", {"_agent": agent})
+        with ids_lock:
+            ids.append(sid)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(ids)) == 1  # exactly one desktop-* id across all threads
+    sid = ids[0]
+    assert sid.startswith("desktop-")
+    assert len(ref._session_ids) == 1  # one entry for the agent (race collapsed)
+    assert ref._bypass_counts[sid] == n  # every call counted, no split
+
+
+def test_trearm_cumulative_across_rearm(spool: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The per-session count is cumulative across disarm episodes within a session
+    # (no reset on re-arm); an armed call does NOT bump the bypass counter.
+    ref = _import_reference_plugin()
+    _setup_disarmed(ref, monkeypatch)
+
+    ref._pre_tool_call("t", {}, task_id="s")
+    ref._pre_tool_call("t", {}, task_id="s")
+    assert ref._bypass_counts["s"] == 2
+
+    # Re-arm: an armed (allowed) call must NOT touch the bypass counter.
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_guard", type("G", (), {"evaluate": lambda self, *a, **k: None})())
+    monkeypatch.setattr(ref, "_run_async", lambda coro: _allowed())
+    assert ref._pre_tool_call("t", {}, task_id="s") is None
+    assert ref._bypass_counts["s"] == 2  # unchanged by the armed call
+
+    # Disarm again: cumulative continues from 2, not reset.
+    monkeypatch.setattr(ref, "_is_armed", lambda: False)
+    monkeypatch.setattr(ref, "_guard", type("SpyGuard", (), {"evaluate": _raise_on_scan})())
+    ref._reset_disarm_log()
+    ref._pre_tool_call("t", {}, task_id="s")
+    assert ref._bypass_counts["s"] == 3  # no reset on re-arm

--- a/tests/test_disarm_bypass_counter.py
+++ b/tests/test_disarm_bypass_counter.py
@@ -170,21 +170,27 @@ def test_tconc_concurrent_desktop_agent_single_id(monkeypatch: pytest.MonkeyPatc
     n = 50
     ids: list[str] = []
     ids_lock = threading.Lock()
+    errors: list[Exception] = []
     barrier = threading.Barrier(n)
 
     def worker() -> None:
-        barrier.wait()  # maximize contention on the fresh-agent insert
-        ref._pre_tool_call("t", {}, task_id="", _agent=agent)
-        sid = ref._derive_session_id("", {"_agent": agent})
-        with ids_lock:
-            ids.append(sid)
+        try:
+            barrier.wait(timeout=10)  # don't block forever if a thread never arrives
+            ref._pre_tool_call("t", {}, task_id="", _agent=agent)
+            sid = ref._derive_session_id("", {"_agent": agent})
+            with ids_lock:
+                ids.append(sid)
+        except Exception as exc:  # capture (incl. BrokenBarrierError) for the main thread
+            errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(n)]
     for t in threads:
         t.start()
     for t in threads:
-        t.join()
+        t.join(timeout=15)  # fail rather than hang if a worker is unresponsive
 
+    assert not any(t.is_alive() for t in threads), "a worker thread hung"
+    assert not errors, f"worker thread(s) raised: {errors!r}"
     assert len(set(ids)) == 1  # exactly one desktop-* id across all threads
     sid = ids[0]
     assert sid.startswith("desktop-")

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -689,3 +689,130 @@ def test_fallback_init_window_block_emits_event(
     assert events[0]["session_id"] == "sess-F"
     assert events[0]["tool"] == "send_email"
     assert events[0]["rule_id"] == "petasos.injection.x"
+
+
+# ---------------------------------------------------------------------------
+# PET-138: per-session disarmed-bypass counter — event payload, dashboard tally,
+# summary passthrough, and the cross-process (both-modes) round trip.
+# ---------------------------------------------------------------------------
+
+
+def _emit_bypass(session_id: str, **kw: Any) -> None:
+    """Emit a bypassed_disarmed event directly onto the spool (dashboard-side tests)."""
+    ev.emit_enforcement_event(
+        {
+            "session_id": session_id,
+            "tool": "send_email",
+            "event_type": "bypassed_disarmed",
+            "armed": False,
+            **kw,
+        }
+    )
+
+
+def test_bypassed_event_carries_count(spool: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # PET-138 (T5): the bypassed_disarmed heartbeat carries an integer
+    # bypassed_count >= 1 alongside tool/event_type/armed, and no matched_text leaks.
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch, armed=False)
+    ref._reset_disarm_log()
+    ref._reset_bypass_counts()
+
+    assert ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-C") is None
+
+    events = _read_spool(spool)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event_type"] == "bypassed_disarmed"
+    assert isinstance(e["bypassed_count"], int) and not isinstance(e["bypassed_count"], bool)
+    assert e["bypassed_count"] >= 1
+    assert "matched_text" not in e
+
+
+@pytest.mark.asyncio
+async def test_bypass_tally_monotonic_max_and_isolated(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # PET-138 (T6): the dashboard bypass tally takes the monotonic max of the carried
+    # cumulative count, ignores non-int / bool / zero, and is isolated from the block
+    # tally (both directions).
+    _emit_bypass("s", bypassed_count=3)
+    _emit_bypass("s", bypassed_count=7)
+    _emit_bypass("s", bypassed_count=5)  # re-surfaced lower value must NOT lower it
+    _emit_bypass("s", bypassed_count=True)  # bool ignored (isinstance(True, int) is True)
+    _emit_bypass("s", bypassed_count=0)  # zero ignored (no-op slot)
+    await handlers._drain_enforcement_into_history()
+    assert handlers.bypass_tally_for("s") == 7
+    assert handlers.block_tally_for("s") == 0  # a bypass never touches the block tally
+
+    # And a block event never touches the bypass tally.
+    ev.emit_enforcement_event({"session_id": "s", "tool": "t", "event_type": "block"})
+    await handlers._drain_enforcement_into_history()
+    assert handlers.bypass_tally_for("s") == 7
+    assert handlers.block_tally_for("s") == 1
+
+
+@pytest.mark.asyncio
+async def test_bypass_tally_refresh_preserves_insertion_order(
+    spool: str, handlers: ConsoleHandlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PET-138 (T6): refreshing an existing session's tally must assign IN PLACE (not
+    # del+reinsert), so drop-oldest still evicts the genuine oldest. A del+reinsert
+    # bug would move the refreshed key to the end and evict the wrong session.
+    import petasos.console.server as srv
+
+    monkeypatch.setattr(srv, "_MAX_TALLY_SESSIONS", 2)
+    _emit_bypass("s0", bypassed_count=1)
+    _emit_bypass("s1", bypassed_count=1)
+    await handlers._drain_enforcement_into_history()
+    _emit_bypass("s0", bypassed_count=9)  # refresh the OLDEST key (must not move it)
+    await handlers._drain_enforcement_into_history()
+    _emit_bypass("s2", bypassed_count=1)  # over bound -> drop genuine oldest (s0)
+    await handlers._drain_enforcement_into_history()
+
+    assert handlers.bypass_tally_for("s0") == 0  # s0 evicted despite the refresh
+    assert handlers.bypass_tally_for("s1") == 1
+    assert handlers.bypass_tally_for("s2") == 1
+
+
+def test_enforcement_summary_normalizes_bypassed_count() -> None:
+    # PET-138 (T7): _enforcement_summary passes a positive int through, normalizes
+    # any non-int / bool / non-positive to None, keeps safe=True / finding_count=0,
+    # and never carries matched_text.
+    from petasos.console.server import _enforcement_summary
+
+    ok = _enforcement_summary(
+        {"event_type": "bypassed_disarmed", "session_id": "s", "bypassed_count": 4, "armed": False}
+    )
+    assert ok["bypassed_count"] == 4
+    assert ok["safe"] is True and ok["finding_count"] == 0
+    assert "matched_text" not in ok
+
+    for bad in (0, -1, 3.5, True, "4", None):
+        s = _enforcement_summary({"event_type": "bypassed_disarmed", "bypassed_count": bad})
+        assert s["bypassed_count"] is None, f"{bad!r} should normalize to None"
+
+    # A block event has no bypassed_count -> None.
+    assert _enforcement_summary({"event_type": "block"})["bypassed_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_bypass_count_round_trips_in_process(
+    spool: str, handlers: ConsoleHandlers, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PET-138 (T-plugin-mode): the plugin emit -> spool -> dashboard drain -> tally
+    # path is identical in standalone and Hermes-plugin modes. Exercise it end-to-end
+    # in-process, satisfying the brief's "both modes" recurrence test via the shared
+    # drain path.
+    ref = _import_reference_plugin()
+    _setup_plugin(ref, monkeypatch, armed=False)
+    ref._reset_disarm_log()
+    ref._reset_bypass_counts()
+
+    assert ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-P") is None
+    await handlers._drain_enforcement_into_history()
+
+    assert handlers.bypass_tally_for("sess-P") == 1
+    rows = handlers.scan_history.to_list()
+    assert rows[0]["bypassed_count"] == 1
+    assert rows[0]["safe"] is True

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -792,8 +792,14 @@ def test_enforcement_summary_normalizes_bypassed_count() -> None:
         s = _enforcement_summary({"event_type": "bypassed_disarmed", "bypassed_count": bad})
         assert s["bypassed_count"] is None, f"{bad!r} should normalize to None"
 
-    # A block event has no bypassed_count -> None.
-    assert _enforcement_summary({"event_type": "block"})["bypassed_count"] is None
+    # Event-type isolation: non-bypass event types never carry a bypassed_count,
+    # even if a malformed/legacy producer stamps one (guards the summary's event-type
+    # gate so a stray count cannot feed the tile).
+    for et in ("block", "quarantine", "tier3", "allowed", "notification"):
+        assert _enforcement_summary({"event_type": et})["bypassed_count"] is None
+        assert (
+            _enforcement_summary({"event_type": et, "bypassed_count": 5})["bypassed_count"] is None
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds an authoritative per-session count of tool calls bypassed while Petasos is disarmed (Unequipped), surfaced as a "bypassed (disarmed)" tile, so an operator can verify "off means off" instead of inferring it from the 30s heartbeat sample.
- The count is bumped on **every** disarmed `_pre_tool_call`, decoupled from the rate-limited heartbeat (which still fires ≤1/30s and now carries the cumulative count).
- Preserves the zero-overhead disarm invariant: no scan, no `_guard.evaluate`, returns `None`; the only added per-call work is an O(1) locked counter bump and a now-thread-safe session-id derivation.

## Layered defense / data path
Plugin in-process counter (exact, per session) → cumulative `bypassed_count` on the existing `bypassed_disarmed` spool heartbeat → dashboard `_bypass_tally` (reconciliation/test source of truth, monotonic-max, bounded) + normalized passthrough onto the `scan_history` row & SSE frame → eviction-proof `Pet.state.bypassBySession` (held across renders, not recomputed from the ≤500 buffer) → `bypassed (disarmed)` tile.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/__init__.py` | Adds `_bypass_counts` + `_bump_bypass_count` + `_bypass_lock` (guards the counter AND the `_session_ids` insert, now on the hot path); extends `_emit_enforcement_event` with `bypassed_count`; bumps + carries the count on the disarmed fast path |
| `petasos/console/server.py` | Adds bounded `_bypass_tally` + `bypass_tally_for` + `_set_bypass_tally` (set-or-refresh, monotonic-max); folds `bypassed_disarmed` events into it; normalizes `bypassed_count` onto the summary row/SSE frame |
| `petasos/console/static/petasos.js` | Adds `Pet.state.bypassBySession`, `Pet.accrueBypass` (integer-gated max, bounded drop-oldest) wired into the SSE arm + mount seed + fallback-poll paths, `Pet.bypassTotal` seam, and the new tile |
| `tests/test_disarm_bypass_counter.py` | New — full count, zero-overhead invariant, bound, concurrency (`_session_ids` race), re-arm cumulative |
| `tests/test_enforcement_events.py` | Adds event-payload, tally max/order/isolation, summary normalization, and in-process (both-modes) round-trip tests |
| `tests/js/disarm-bypass-counter.test.mjs` | New — tile total, coercion (float/null/bool/zero), eviction-persistence, bound |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/test_disarm_bypass_counter.py tests/test_enforcement_events.py -p no:cacheprovider` — 38/38 pass (full output: docs/specs/TODO/PET-138.test-output.txt, gitignored)
- [x] `node --test tests/js/disarm-bypass-counter.test.mjs tests/js/enforcement-history.test.mjs` — 14/14 pass
- [x] `ruff check .` — clean · `ruff format --check` — clean · `mypy --strict .` — no issues (135 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-session counting for tool calls bypassed while operators are disarmed.
  * Dashboard now includes a **“bypassed (disarmed)”** metric with cumulative totals and per-session tracking.
  * Enforcement events for bypasses now carry a cumulative **bypassed count** for auditability.

* **Bug Fixes / Improvements**
  * Bypass tallies are monotonic and capped, evicting the oldest sessions to keep data bounded.

* **Tests**
  * Added unit and integration coverage for bypass counting, event payloads, dashboard aggregation, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->