### PR TITLE
feat(pet-139): keyed-HMAC attestation on the enforcement spool

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -121,7 +121,7 @@ burst of `unverifiable` rows. To avoid that artifact, clear the live spool file
 **and** remove any `<spool>.rot` segment beside it before (re)starting with the
 secret set:
 
-```
+```bash
 rm -f "<config-dir>/petasos-enforcement.jsonl" "<config-dir>/petasos-enforcement.jsonl.rot"
 ```
 

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -58,7 +58,7 @@ Two secrets, both environment-variable-first, never committed config:
 
 | Secret | Purpose | Handling |
 |---|---|---|
-| `PETASOS_SESSION_SECRET` | HMAC session binding — prevents session spoofing (FREQ-03) | base64 in env; decoded at dashboard init (`petasos/console/hermes/plugin_api.py:65-73`). Invalid base64 → a warning is logged and **session binding is silently disabled** — watch for that log line. |
+| `PETASOS_SESSION_SECRET` | HMAC session binding (FREQ-03) **and** enforcement-spool integrity (PET-139); see [§3.1](#31-enforcement-spool-integrity-pet-139) | base64 in env; decoded at dashboard init (`petasos/console/hermes/plugin_api.py:65-73`). Invalid base64 → a warning is logged and **session binding is silently disabled** — watch for that log line. |
 | `PETASOS_HASH_KEY` / `hash_key` | HMAC key for hash-mode PII anonymization | env override at `plugin_api.py:75-77`; required non-empty when `anonymize=True` and `redaction_mode="hash"` (`petasos/config.py:139-142`, SCAN-05). |
 
 Leak resistance is built in — and worth knowing the exact shape of:
@@ -84,6 +84,76 @@ Leak resistance is built in — and worth knowing the exact shape of:
 - [ ] Grep your logs once after deploy for the invalid-base64 warning;
       binding that silently disabled is worse than binding you never
       configured.
+
+### 3.1 Enforcement-spool integrity (PET-139)
+
+`PETASOS_SESSION_SECRET` does double duty. Beyond FREQ-03 session binding it is
+the root of a keyed-HMAC attestation on the cross-process enforcement spool
+(`petasos-enforcement.jsonl`). The gateway (writer) stamps every enforcement
+event with an HMAC over a canonical serialization of the record; the dashboard
+(reader) recomputes and verifies before trusting the row. A row that fails
+verification is still surfaced, but flagged `unverifiable` in the drill-down
+panel and never counted as a trusted block. The on-the-wire key is a
+domain-separated subkey, `HMAC-SHA256(session_secret,
+"petasos/enforcement-spool/v1")`, not the raw secret, so the two uses cannot
+cross-interfere.
+
+**The env contract (the one thing to get right):** integrity only holds when
+the writer and the reader derive the same key, and they are separate processes.
+That reduces to one rule: every process that touches the spool must launch with
+the identical `PETASOS_SESSION_SECRET`. In a gateway-paired deployment that is
+the gateway process and the dashboard process sharing one secret in their
+environment. For the low-level `serve()` / `create_app()` API the caller owns
+`session_secret` on the pipeline config it passes; populate it the same way
+(decode `PETASOS_SESSION_SECRET` into the config) to get attestation on that
+path. A writer-key / reader-key mismatch is a misconfiguration, not a silent
+blind spot: it surfaces as a burst of `unverifiable` rows plus the log token
+below with class `sig-mismatch`.
+
+**No secret set?** Integrity is simply off. Every event is `unattested`,
+surfaced and counted exactly as before PET-139. Setting the secret is opt-in;
+not setting it is the documented no-regression posture, not a downgrade.
+
+**Upgrade step (do this once, when first enabling integrity).** On a host that
+has already been running, the spool on disk still holds pre-PET-139 unsigned
+events. Those are genuine but unattestable, so they would surface as a one-time
+burst of `unverifiable` rows. To avoid that artifact, clear the live spool file
+**and** remove any `<spool>.rot` segment beside it before (re)starting with the
+secret set:
+
+```
+rm -f "<config-dir>/petasos-enforcement.jsonl" "<config-dir>/petasos-enforcement.jsonl.rot"
+```
+
+(`<config-dir>` is the resolved Hermes config directory, e.g.
+`%LOCALAPPDATA%/hermes/...` on Windows.) The block tally is in-memory and resets
+on a dashboard restart anyway, so clearing the spool loses only already-drained
+telemetry. Removing the `.rot` too matters: an orphan `.rot` recovered later
+would replay the same legacy-unsigned burst.
+
+**The greppable tripwire.** Every verification failure emits a rate-limited
+WARNING carrying the token `PETASOS_INTEGRITY_UNVERIFIABLE`, a failure class
+(`sig-missing` for an absent tag, `sig-mismatch` for a wrong one), the
+`scan_id`, and the `session_id`. `sig-mismatch` points at a forging process or a
+key mismatch; `sig-missing` over a freshly-enabled host is usually the
+legacy-unsigned rollout artifact above.
+
+**Threat model (what this does and does not defend).** The delivered property is
+forgery-evidence on the spool against a same-host process that is not Petasos
+and does not hold `session_secret` trying to inject or forge enforcement rows.
+It is **not** a defense against a compromised gateway (it legitimately holds the
+key), an attacker who can read `PETASOS_SESSION_SECRET` from the environment or
+config, byte-for-byte replay of a captured genuine line (it still verifies and
+still inflates the block tally, a named v1 limitation), or network-level
+tampering (that is PET-83's domain).
+
+**Checklist:**
+
+- [ ] For spool attestation, launch the gateway and the dashboard with the
+      **same** `PETASOS_SESSION_SECRET`.
+- [ ] On first enable over an existing host, clear the spool and its `.rot`.
+- [ ] Grep deploy logs for `PETASOS_INTEGRITY_UNVERIFIABLE`; a steady stream of
+      `sig-mismatch` means a key mismatch or a forging process, not noise.
 
 ## 4. Fail-mode
 

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -505,6 +505,21 @@ def _deferred_init() -> None:
                 on_alert=_handle_alert,
             )
 
+            # PET-139: install the enforcement-spool HMAC key (D3) so writer-side events are
+            # signed. Sourced from the `session_secret` already decoded by
+            # `_build_config_from_section` (no new env read). The reader (dashboard process)
+            # derives the same key from the same `PETASOS_SESSION_SECRET` under one documented
+            # env contract, so writer and reader agree. Wrapped fail-safe: a failure degrades
+            # to integrity-off (no `sig`), never breaks boot.
+            try:
+                from petasos.console._events import set_spool_key
+
+                set_spool_key(config.session_secret)
+            except Exception as exc:  # pragma: no cover - defensive; integrity is best-effort
+                logger.warning(
+                    "PETASOS_INTEGRITY spool-key install failed at boot: %s — integrity off", exc
+                )
+
             license_key = os.environ.get("PETASOS_LICENSE_KEY")
             if license_key:
                 from petasos import LicenseState
@@ -900,6 +915,21 @@ async def _apply_reconfigure(cfg: PetasosConfig) -> None:
     _guard.validate_config(cfg)
     # Phase 2: commit.
     _pipeline.reconfigure(cfg)
+    # PET-139: re-derive the enforcement-spool HMAC key from the adopted config (idempotent
+    # per D3 — session_secret is restart-required and env-reinjected, so this re-installs
+    # identical bytes). This single chokepoint covers BOTH the PET-126 hot-apply and the
+    # PET-132 re-bind, which reach the live pipeline only through `_apply_reconfigure`; do not
+    # add a separate call on the re-bind early-return branch (no `cfg` is built there, so a
+    # `set_spool_key(cfg...)` would NameError). Wrapped fail-safe: a failure degrades to
+    # integrity-off, never breaks the reconfigure.
+    try:
+        from petasos.console._events import set_spool_key
+
+        set_spool_key(cfg.session_secret)
+    except Exception as exc:  # pragma: no cover - defensive; integrity is best-effort
+        logger.warning(
+            "PETASOS_INTEGRITY spool-key re-install failed on reconfigure: %s — integrity off", exc
+        )
     _guard.apply_config(cfg)
     if _lineage_registry is not None:
         _lineage_registry.apply_config(cfg)

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -33,6 +33,8 @@ Never raises out of any public function.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import time
@@ -70,6 +72,67 @@ def _reset_events_state(path: str | None = None, cap: int | None = None) -> None
         SPOOL_CAP_BYTES = cap
 
 
+# PET-139: enforcement-event integrity. The spool key is a *domain-separated subkey*
+# derived from session_secret (D3), never the raw secret — so the FREQ-03 session-binding
+# use and this spool-attestation use cannot cross-interfere. ``None`` => integrity off: no
+# ``sig`` is stamped and the reader maps an unkeyed deployment to "unattested" (the PET-131
+# no-regression path). Held in its OWN global with a dedicated reset, decoupled from
+# _reset_events_state's path/cap reset, so a `_reset_events_state` call after `set_spool_key`
+# cannot silently disarm signing.
+_SPOOL_KEY: bytes | None = None
+
+
+def _derive_spool_key(secret: bytes) -> bytes:
+    """Domain-separated subkey for spool attestation (D3): HMAC-SHA256(secret, label).
+
+    The ``v1`` label leaves room for a future rotation without ambiguity and keeps this
+    key distinct from any other HMAC use of the same ``session_secret``.
+    """
+    return hmac.new(secret, b"petasos/enforcement-spool/v1", hashlib.sha256).digest()
+
+
+def set_spool_key(secret: bytes | None) -> None:
+    """Install the spool HMAC key derived from *secret*, or ``None`` to disable integrity.
+
+    Idempotent: re-deriving from the same secret installs identical bytes (session_secret is
+    restart-required and env-reinjected, so the derived key is invariant for a process
+    lifetime, D3). Order note: ``_reset_events_state`` does NOT touch the key, so a test that
+    needs both should call ``_reset_events_state(...)`` first, then ``set_spool_key(...)``.
+    """
+    global _SPOOL_KEY
+    _SPOOL_KEY = _derive_spool_key(secret) if secret else None
+
+
+def _reset_spool_key() -> None:
+    """Test seam: clear the writer key independently of path/cap reset."""
+    global _SPOOL_KEY
+    _SPOOL_KEY = None
+
+
+def verify_event(ev: object, key: bytes | None) -> bool:
+    """True iff *key* is set and ``ev["sig"]`` matches the recomputed HMAC. Never raises (D6).
+
+    Pure and total: a ``None`` key, a non-dict input, a missing/non-string ``sig``, or any
+    serialization error all resolve to ``False``. A ``None`` key returns ``False`` so the
+    caller can distinguish "no key configured" (which it maps to "unattested" — still trusted
+    and counted) from a real verify failure (mapped to "unverifiable"); the *caller* owns that
+    trust decision, not this function. The ``object`` annotation + explicit ``isinstance`` guard
+    keep it total under ``mypy --strict`` even though the live drain only ever passes dicts.
+    """
+    if key is None or not isinstance(ev, dict):
+        return False  # None-key => caller maps to "unattested", not "unverifiable"
+    try:
+        sig = ev.get("sig")
+        if not isinstance(sig, str):
+            return False
+        rest = {k: v for k, v in ev.items() if k != "sig"}
+        preimage = json.dumps(rest, sort_keys=True, separators=(",", ":"), default=str)
+        expected = hmac.new(key, preimage.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(sig, expected)
+    except Exception:
+        return False
+
+
 def emit_enforcement_event(event: dict[str, Any]) -> bool:
     """Append one enforcement event as a JSONL line. O(1), fail-open.
 
@@ -85,6 +148,18 @@ def emit_enforcement_event(event: dict[str, Any]) -> bool:
         # distinct from the playground `s-<hex>` keyspace.
         rec.setdefault("scan_id", f"e-{uuid.uuid4().hex}")
         rec.setdefault("timestamp", time.time())
+        # PET-139: stamp a keyed HMAC over the canonical serialization of the whole record
+        # (after the identity fields above, before `sig` is added), so the reader can attest
+        # provenance (D1). Signing the whole record — not a field whitelist — makes the tag
+        # cover every present and future field (e.g. PET-138's `bypassed_count`) automatically.
+        # `sort_keys=True` makes writer and reader agree regardless of insertion order;
+        # `default=str` mirrors the on-disk serialization below so preimage and line share one
+        # discipline. `None` key => integrity off (unsigned line, read as "unattested"). Stays
+        # inside the fail-open try (D6): a signing error returns False, never raises into the
+        # tool call. CPU-only microseconds — no fsync, no extra handle, O(1) append preserved.
+        if _SPOOL_KEY is not None:
+            preimage = json.dumps(rec, sort_keys=True, separators=(",", ":"), default=str)
+            rec["sig"] = hmac.new(_SPOOL_KEY, preimage.encode("utf-8"), hashlib.sha256).hexdigest()
         line = json.dumps(rec, default=str) + "\n"
         with open(_spool_path(), "a", encoding="utf-8") as f:
             f.write(line)

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -46,6 +46,9 @@ _BLOCK_EVENT_TYPES = frozenset({"block", "quarantine", "tier3"})
 _MAX_TALLY_SESSIONS = 10_000
 # Poll cadence of the dashboard's background enforcement-spool tailer (standalone).
 _ENFORCEMENT_TAIL_INTERVAL_S = 1.0
+# PET-139: rate-limit window for the integrity-failure tripwire (D9), mirroring the
+# reference plugin's `_DISARM_LOG_EVERY_S` cadence so a forging loop cannot spam the log.
+_INTEGRITY_LOG_EVERY_S = 30.0
 # Cap on the surfaced enforcement `reason` length. The raw matched value lives in a
 # finding's `matched_text` (never surfaced); `reason` is the structured scanner/guard
 # message (e.g. "PII detected: PERSON"), already returned to the agent. We cap it so a
@@ -183,7 +186,7 @@ def _build_playground_detail(result: Any, normalized: Any) -> dict[str, Any]:
         return {"findings": [], "detail_truncated": True, "detail_error": True}
 
 
-def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
+def _enforcement_summary(ev: dict[str, Any], *, provenance: str = "unattested") -> dict[str, Any]:
     """Build the unified `scan_history` summary for a drained enforcement event (D6).
 
     One schema, two producers: `run_scan` writes playground summaries (no `source`,
@@ -192,6 +195,11 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
     `safe=False` so the existing `safe === false` tile loop counts it with no
     tile-math change; a `bypassed_disarmed` event sets `safe=True` (visible row,
     never counted as blocked).
+
+    PET-139: `provenance` (one of "genuine"/"unverifiable"/"unattested", D4) carries the
+    spool-integrity verdict to the drill-down "is this legit?" line. Keyword-only and
+    DEFAULTED so existing callers (playground summaries, the PET-131/137/138 enforcement
+    tests) stay green untouched — the default reflects "no key configured".
     """
     event_type = ev.get("event_type")
     is_block = event_type in _BLOCK_EVENT_TYPES
@@ -231,6 +239,8 @@ def _enforcement_summary(ev: dict[str, Any]) -> dict[str, Any]:
         # PET-138: cumulative per-session disarmed-bypass count (bypassed_disarmed
         # heartbeats only; None elsewhere). Drives the "bypassed (disarmed)" tile.
         "bypassed_count": bypassed_count,
+        # PET-139: spool-integrity verdict for the drill-down "is this legit?" line (D4).
+        "provenance": provenance,
     }
 
 
@@ -302,6 +312,21 @@ class ConsoleHandlers:
 
     def __init__(self, pipeline: "Pipeline") -> None:
         self.pipeline = pipeline
+        # PET-139: derive the reader-side spool-integrity key from the pipeline's config
+        # (D5). This is the single construction chokepoint for BOTH standalone (`build_app`)
+        # and embedded (`plugin_api.init_handlers`) modes, so `self._spool_key` is always
+        # bound (no AttributeError on any drain path) and both modes obtain the key from the
+        # `session_secret` the pipeline already carries. `None` => integrity off ("unattested").
+        from petasos.console import _events
+
+        self._spool_key: bytes | None = (
+            _events._derive_spool_key(s) if (s := pipeline.config.session_secret) else None
+        )
+        # PET-139: monotonic clock for the rate-limited integrity-failure tripwire (D9). A
+        # plain instance attribute is safe — every `_surface_enforcement_event` runs inside
+        # `_enforcement_lock`, which already serializes the read path (no `threading.Lock`
+        # needed, unlike the reference plugin's writer-thread module clocks).
+        self._integrity_log_last = 0.0
         self.scan_history = RingBuffer[dict[str, Any]](maxlen=500)
         self.sse = SSEBroadcaster()
         self._start_time = time.monotonic()
@@ -363,18 +388,65 @@ class ConsoleHandlers:
         if len(tally) > _MAX_TALLY_SESSIONS:
             del tally[next(iter(tally))]
 
+    def _log_integrity_failure(self, ev: dict[str, Any]) -> None:
+        """PET-139: rate-limited WARNING tripwire for a spool-integrity failure (D9). Never raises.
+
+        Greppable token `PETASOS_INTEGRITY_UNVERIFIABLE` plus a failure class so an operator can
+        tell a forging process (`sig-mismatch`) from a key-config mistake or a legacy unsigned
+        event on upgrade (`sig-missing`). Mirrors the codebase's greppable-attribution convention
+        (`PETASOS_DISARMED` / `PETASOS_ARMED_RESOLUTION`). The clock is a plain instance attribute
+        serialized by `_enforcement_lock` (the caller always holds it). Fail-safe and observable
+        are not in tension: this never raises and never gates the drain.
+        """
+        try:
+            now = time.monotonic()
+            if now - self._integrity_log_last < _INTEGRITY_LOG_EVERY_S:
+                return
+            self._integrity_log_last = now
+            failure_class = "sig-missing" if not isinstance(ev.get("sig"), str) else "sig-mismatch"
+            _logger.warning(
+                "PETASOS_INTEGRITY_UNVERIFIABLE class=%s scan_id=%s session_id=%s — spool row "
+                "failed HMAC verification (forged, misconfigured, or legacy unsigned)",
+                failure_class,
+                ev.get("scan_id"),
+                ev.get("session_id"),
+            )
+        except Exception:
+            pass
+
     async def _surface_enforcement_event(self, ev: dict[str, Any]) -> None:
-        """Fold one drained enforcement event into scan_history + the tally + SSE."""
-        summary = _enforcement_summary(ev)
+        """Fold one drained enforcement event into scan_history + the tally + SSE.
+
+        PET-139: classify provenance (D4) before folding. With NO key configured the event is
+        "unattested" and behaves exactly as pre-PET-139 — surfaced, and a block-class event
+        still bumps the tally (the no-regression path). With a key configured, a verified event
+        is "genuine"; a missing or invalid `sig` is "unverifiable" — surfaced and flagged,
+        logged (D9), and EXCLUDED from the authoritative block tally so a forged row can never
+        be counted as a trusted block.
+        """
+        from petasos.console import _events
+
+        verified = _events.verify_event(ev, self._spool_key)
+        key_on = self._spool_key is not None
+        provenance = "unattested" if not key_on else ("genuine" if verified else "unverifiable")
+        if key_on and not verified:
+            self._log_integrity_failure(ev)
+        summary = _enforcement_summary(ev, provenance=provenance)
         self.scan_history.push(summary)
         if ev.get("event_type") in _BLOCK_EVENT_TYPES:
-            sid = ev.get("session_id")
-            if isinstance(sid, str) and sid:
-                self._bump_block_tally(sid)
+            # unattested + genuine count; unverifiable does NOT (D4) — a forged/legacy-unsigned
+            # block is surfaced-but-flagged, never tallied as a trusted block.
+            if provenance != "unverifiable":
+                sid = ev.get("session_id")
+                if isinstance(sid, str) and sid:
+                    self._bump_block_tally(sid)
         elif ev.get("event_type") == "bypassed_disarmed":
             # PET-138: monotonic-max of the cumulative count (restart re-seed belt;
             # exactly-once delivery already comes from the forward offset / .rot
             # discipline). type(cnt) is int excludes bool; cnt > 0 skips no-ops.
+            # Intentionally NOT integrity-gated: a disarmed-bypass heartbeat is safe=True,
+            # never a trusted-block claim, so gating it would be scope creep (the v1 residual
+            # — a forged heartbeat can inflate _bypass_tally — is named in the spec threat model).
             sid = ev.get("session_id")
             cnt = ev.get("bypassed_count")
             if isinstance(sid, str) and sid and type(cnt) is int and cnt > 0:

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -401,6 +401,11 @@
 .pet .sd-prov-q { font-size: 11px; font-weight: 700; letter-spacing: .5px; color: var(--tx-bright); text-transform: uppercase; }
 .pet .sd-prov-line { font-size: 12px; color: var(--tx-mut); margin-top: 3px; }
 .pet .sd-prov-note { font-size: 10.5px; color: var(--tx-faint); margin-top: 4px; }
+/* PET-139: spool-integrity attestation badge on the "is this legit?" line. */
+.pet .sd-prov-att { font-size: 10.5px; margin-top: 4px; padding: 2px 7px; border-radius: 6px; border: 1px solid var(--border-soft); display: inline-block; }
+.pet .sd-prov-genuine { color: var(--ok); border-color: rgba(63,185,80,.3); background: var(--ok-soft); }
+.pet .sd-prov-unverifiable { color: var(--warn); border-color: rgba(232,177,58,.3); background: var(--med-soft); }
+.pet .sd-prov-unattested { color: var(--tx-faint); }
 .pet .sd-section { font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--tx-faint); margin-top: 4px; }
 .pet .sd-field { display: flex; gap: 8px; align-items: baseline; font-size: 12px; }
 .pet .sd-k { flex: 0 0 84px; color: var(--tx-faint); }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -705,8 +705,25 @@
         "source: " + source + "  ·  scan ran: " + scanRan + "  ·  armed: " + armedStr)
     );
     if (isEnf) {
-      prov.appendChild(Pet.h("div", { className: "sd-prov-note" },
-        "Self-reported by the enforcement spool; shown as far as the data allows, not proven."));
+      // PET-139: attestation state from the spool-integrity HMAC verdict (D4), extending
+      // PET-137's "is this legit?" line. Read summary.provenance; only the exact strings
+      // "genuine" / "unverifiable" map through — an absent / non-string / unknown value
+      // renders as "unattested" (not a crash, not a false "genuine"), gated the way the
+      // PET-138 bypassed_count path guards its input. No-em-dash house style for the copy.
+      var prv = e.provenance;
+      var provState = (prv === "genuine" || prv === "unverifiable") ? prv : "unattested";
+      var attClass, attText;
+      if (provState === "genuine") {
+        attClass = "sd-prov-att sd-prov-genuine";
+        attText = "Verified Petasos event: the signature checks out against the configured key.";
+      } else if (provState === "unverifiable") {
+        attClass = "sd-prov-att sd-prov-unverifiable";
+        attText = "Unverified: signature missing or invalid; this row may not be a genuine Petasos decision.";
+      } else {
+        attClass = "sd-prov-att sd-prov-unattested";
+        attText = "Integrity not configured: no signing key is set, so this row cannot be attested.";
+      }
+      prov.appendChild(Pet.h("div", { className: attClass }, attText));
     }
     wrap.appendChild(prov);
 

--- a/tests/js/enforcement-provenance.test.mjs
+++ b/tests/js/enforcement-provenance.test.mjs
@@ -1,0 +1,123 @@
+// PET-139: the drill-down "is this legit?" provenance line renders the three
+// integrity states (genuine / unverifiable / unattested) on an enforcement row.
+//
+// The badge reads summary.provenance. Only the exact strings "genuine" and
+// "unverifiable" map through; anything else (absent, null, non-string, unknown)
+// renders as "unattested" — never a crash, never a false "genuine". An
+// unverifiable row stays visible (surface-and-flag, not hide).
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped
+// petasos.js. Run with: node --test tests/js/enforcement-provenance.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// Minimal DOM shim — scanDetailPanel only builds elements + text nodes via Pet.h.
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute() {},
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// Recursively concatenate all text-node content under a rendered node.
+function textOf(node) {
+  if (!node) return "";
+  if (node.nodeType === 3) return node.nodeValue || "";
+  let s = "";
+  for (const c of (node.childNodes || [])) s += textOf(c);
+  return s;
+}
+// Collect every className present in the subtree.
+function classesOf(node, acc) {
+  acc = acc || [];
+  if (!node) return acc;
+  if (node.className) acc.push(node.className);
+  for (const c of (node.childNodes || [])) classesOf(c, acc);
+  return acc;
+}
+
+const enfBlock = (provenance) => ({
+  source: "enforcement",
+  event_type: "block",
+  tool: "send_email",
+  tier: "tier2",
+  reason: "blocked by escalation",
+  session_id: "sess-1",
+  armed: true,
+  provenance,
+});
+
+test("loader: petasos.js exposes scanDetailPanel", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.scanDetailPanel, "function");
+});
+
+test("genuine renders the verified marker", () => {
+  const el = Pet.scanDetailPanel(enfBlock("genuine"));
+  const txt = textOf(el);
+  assert.match(txt, /Verified Petasos event/);
+  assert.ok(classesOf(el).some((c) => c.includes("sd-prov-genuine")));
+  assert.doesNotMatch(txt, /Unverified/);
+});
+
+test("unverifiable renders the warn copy and stays visible", () => {
+  const el = Pet.scanDetailPanel(enfBlock("unverifiable"));
+  const txt = textOf(el);
+  assert.match(txt, /Unverified: signature missing or invalid/);
+  assert.ok(classesOf(el).some((c) => c.includes("sd-prov-unverifiable")));
+  // surface-and-flag, not hide: the decision body still renders (tool value present).
+  assert.match(txt, /send_email/);
+});
+
+test("unattested renders the neutral copy", () => {
+  const el = Pet.scanDetailPanel(enfBlock("unattested"));
+  const txt = textOf(el);
+  assert.match(txt, /Integrity not configured/);
+  assert.ok(classesOf(el).some((c) => c.includes("sd-prov-unattested")));
+});
+
+test("absent provenance renders as unattested, not a crash and not a false genuine", () => {
+  const ev = enfBlock(undefined);
+  delete ev.provenance;
+  const el = Pet.scanDetailPanel(ev);
+  const txt = textOf(el);
+  assert.match(txt, /Integrity not configured/);
+  assert.ok(classesOf(el).some((c) => c.includes("sd-prov-unattested")));
+  assert.doesNotMatch(txt, /Verified Petasos event/);
+});
+
+test("non-string and unknown provenance both fall back to unattested", () => {
+  for (const bad of [123, null, true, "bogus", ""]) {
+    const el = Pet.scanDetailPanel(enfBlock(bad));
+    const txt = textOf(el);
+    assert.match(txt, /Integrity not configured/, `provenance=${JSON.stringify(bad)}`);
+    assert.doesNotMatch(txt, /Verified Petasos event/, `provenance=${JSON.stringify(bad)}`);
+  }
+});
+
+test("playground rows carry no attestation badge", () => {
+  const el = Pet.scanDetailPanel({ source: "playground", safe: true });
+  const cls = classesOf(el);
+  assert.ok(!cls.some((c) => c.includes("sd-prov-att")));
+});

--- a/tests/test_enforcement_integrity.py
+++ b/tests/test_enforcement_integrity.py
@@ -31,9 +31,13 @@ if TYPE_CHECKING:
 import petasos.console._events as ev
 import petasos.console.server as server_mod
 from petasos import PetasosConfig, Pipeline
-from petasos.console.hermes import plugin_api
 from petasos.console.server import ConsoleHandlers
 from petasos.scanners.minimal import MinimalScanner
+
+# NOTE: `petasos.console.hermes.plugin_api` imports fastapi at module level, so it is
+# imported lazily inside the one embedded-path test (guarded by importorskip) rather than
+# here — the writer / verifier / key tests need no fastapi and must stay collectable without
+# the console extra.
 
 # A real 32-byte-ish secret; both the writer (set_spool_key) and the reader
 # (PetasosConfig.session_secret) derive their key from THIS value, so they agree.
@@ -169,6 +173,11 @@ async def test_genuine_event_round_trips_direct_construction() -> None:
 async def test_genuine_event_round_trips_embedded_drain_on_read() -> None:
     # The embedded Hermes path: plugin_api.init_handlers(pipeline) -> ConsoleHandlers(pipeline),
     # surfaced through get_scan_history's drain-on-read (server.py drain-on-read floor).
+    # plugin_api imports fastapi at module level; skip gracefully where the console extra is
+    # absent rather than failing collection.
+    pytest.importorskip("fastapi")
+    from petasos.console.hermes import plugin_api
+
     ev.set_spool_key(_SECRET)
     ev.emit_enforcement_event(_block(session_id="sess-B"))
     pipeline = Pipeline(

--- a/tests/test_enforcement_integrity.py
+++ b/tests/test_enforcement_integrity.py
@@ -1,0 +1,397 @@
+"""PET-139: keyed-HMAC attestation on the cross-process enforcement spool.
+
+The gateway (writer) stamps each enforcement event with an HMAC over a canonical
+serialization of the record; the dashboard (reader) recomputes and verifies before
+trusting the row. A row that fails verification is surfaced but flagged ``unverifiable``
+and is never counted as a trusted block. With no ``session_secret`` configured integrity
+is off and behavior is exactly pre-PET-139 (``unattested``, still counted) — the PET-131
+no-regression path.
+
+These tests cover both construction paths (standalone ``build_app``-style direct
+``ConsoleHandlers`` and the embedded ``plugin_api.init_handlers`` path), the writer/reader
+round-trip, the forgery/legacy-unsigned/replay cases, the fail-safe/fail-open posture, and
+key-derivation domain separation. The enforcement spool is redirected to a temp file by the
+autouse ``_isolate_enforcement_spool`` conftest fixture; the writer key is reset around each
+test here so it never leaks across tests (the conftest fixture only resets path/cap).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import petasos.console._events as ev
+import petasos.console.server as server_mod
+from petasos import PetasosConfig, Pipeline
+from petasos.console.hermes import plugin_api
+from petasos.console.server import ConsoleHandlers
+from petasos.scanners.minimal import MinimalScanner
+
+# A real 32-byte-ish secret; both the writer (set_spool_key) and the reader
+# (PetasosConfig.session_secret) derive their key from THIS value, so they agree.
+_SECRET = b"pet139-session-secret-0123456789ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_spool_key_around_test() -> Iterator[None]:
+    """Contain the module-global writer key within each test (the conftest spool-isolation
+    fixture resets path/cap but not the key)."""
+    ev._reset_spool_key()
+    yield
+    ev._reset_spool_key()
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _keyed_handlers(secret: bytes = _SECRET) -> ConsoleHandlers:
+    """A reader whose pipeline config carries *secret* (key on)."""
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=secret),
+        host_id="petasos-test",  # required when session_secret is set
+    )
+    return ConsoleHandlers(pipeline)
+
+
+def _unkeyed_handlers() -> ConsoleHandlers:
+    """A reader with no session_secret (key off → unattested)."""
+    pipeline = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    return ConsoleHandlers(pipeline)
+
+
+def _read_spool(path: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if s:
+                    out.append(json.loads(s))
+    except FileNotFoundError:
+        pass
+    return out
+
+
+def _append_raw(path: str, rec: dict[str, Any]) -> None:
+    """Append a raw JSON line (bypasses emit's signing — for forged / legacy lines)."""
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def _block(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "session_id": "sess-1",
+        "tool": "send_email",
+        "event_type": "block",
+        "tier": "tier2",
+        "reason": "blocked by escalation",
+        "armed": True,
+        "direction": "tool_call",
+    }
+    base.update(over)
+    return base
+
+
+async def _drain(h: ConsoleHandlers) -> list[dict[str, Any]]:
+    await h._drain_enforcement_into_history()
+    return h.scan_history.to_list(500)
+
+
+def _find(summaries: list[dict[str, Any]], **match: Any) -> dict[str, Any]:
+    for s in summaries:
+        if all(s.get(k) == v for k, v in match.items()):
+            return s
+    raise AssertionError(f"no summary matching {match} in {summaries}")
+
+
+# ---------------------------------------------------------------------------
+# Writer: keyed write stamps a real sig on disk (silent no-op guard, D6)
+# ---------------------------------------------------------------------------
+
+
+def test_keyed_write_produces_nonempty_sig_on_disk() -> None:
+    # Asserts the LITERAL on-disk line carries a `sig` string — catches a swallowed
+    # NameError from a missing `import hmac` (which would write unsigned forever).
+    ev.set_spool_key(_SECRET)
+    assert ev.emit_enforcement_event(_block()) is True
+    rows = _read_spool(ev._spool_path())
+    assert len(rows) == 1
+    assert isinstance(rows[0].get("sig"), str) and rows[0]["sig"], "keyed write must stamp a sig"
+
+
+def test_unkeyed_write_stamps_no_sig() -> None:
+    ev._reset_spool_key()
+    assert ev.emit_enforcement_event(_block()) is True
+    rows = _read_spool(ev._spool_path())
+    assert len(rows) == 1
+    assert "sig" not in rows[0]
+
+
+def test_sig_is_the_only_added_record_field() -> None:
+    # Compare an unkeyed vs a keyed write of the IDENTICAL payload (fixed scan_id/timestamp):
+    # the only key PET-139 adds is `sig`. No matched_text, no other new field.
+    path = ev._spool_path()
+    payload = _block(scan_id="e-fixed", timestamp=1.0)
+    ev._reset_spool_key()
+    ev.emit_enforcement_event(dict(payload))
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(dict(payload))
+    rows = _read_spool(path)
+    assert set(rows[1]) - set(rows[0]) == {"sig"}
+
+
+# ---------------------------------------------------------------------------
+# Reader: genuine round-trips in both construction paths (D5)
+# ---------------------------------------------------------------------------
+
+
+async def test_genuine_event_round_trips_direct_construction() -> None:
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(_block(session_id="sess-A"))
+    handlers = _keyed_handlers()
+    summaries = await _drain(handlers)
+    s = _find(summaries, event_type="block", session_id="sess-A")
+    assert s["provenance"] == "genuine"
+    assert handlers.block_tally_for("sess-A") == 1
+
+
+async def test_genuine_event_round_trips_embedded_drain_on_read() -> None:
+    # The embedded Hermes path: plugin_api.init_handlers(pipeline) -> ConsoleHandlers(pipeline),
+    # surfaced through get_scan_history's drain-on-read (server.py drain-on-read floor).
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(_block(session_id="sess-B"))
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=_SECRET),
+        host_id="dashboard",
+    )
+    plugin_api.init_handlers(pipeline)
+    handlers = plugin_api._handlers
+    assert handlers._spool_key is not None
+    await handlers.get_scan_history()  # drains on read
+    s = _find(handlers.scan_history.to_list(500), event_type="block", session_id="sess-B")
+    assert s["provenance"] == "genuine"
+    assert handlers.block_tally_for("sess-B") == 1
+
+
+# ---------------------------------------------------------------------------
+# Reader: attribute always bound — no embedded AttributeError (D6)
+# ---------------------------------------------------------------------------
+
+
+async def test_spool_key_attribute_always_bound_no_secret() -> None:
+    handlers = _unkeyed_handlers()
+    assert handlers._spool_key is None  # bound, not missing
+    ev._reset_spool_key()
+    ev.emit_enforcement_event(_block())
+    # The drain path must not raise AttributeError on self._spool_key.
+    await handlers._drain_enforcement_into_history()
+
+
+# ---------------------------------------------------------------------------
+# No-key deployment still surfaces (PET-131 no-regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_no_key_deployment_surfaces_and_counts(caplog: pytest.LogCaptureFixture) -> None:
+    ev._reset_spool_key()  # writer key off too
+    handlers = _unkeyed_handlers()
+    ev.emit_enforcement_event(_block(session_id="sess-C"))
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        summaries = await _drain(handlers)
+    s = _find(summaries, event_type="block", session_id="sess-C")
+    assert s["provenance"] == "unattested"
+    assert handlers.block_tally_for("sess-C") == 1  # still counted, exactly as pre-PET-139
+    assert "PETASOS_INTEGRITY_UNVERIFIABLE" not in caplog.text  # no integrity log when key off
+
+
+# ---------------------------------------------------------------------------
+# Forged line is not trusted; integrity tripwire fires with the right class (D4/D9)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("forged", "expected_class"),
+    [
+        (_block(session_id="sess-F1", scan_id="e-forge-1"), "sig-missing"),
+        (_block(session_id="sess-F2", scan_id="e-forge-2", sig="deadbeef"), "sig-mismatch"),
+    ],
+)
+async def test_forged_block_is_unverifiable_and_logs(
+    forged: dict[str, Any], expected_class: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Fresh handler per case so the rate-limited tripwire (D9) is open (clock at 0.0).
+    handlers = _keyed_handlers()
+    _append_raw(ev._spool_path(), forged)
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        summaries = await _drain(handlers)
+    s = _find(summaries, event_type="block", session_id=forged["session_id"])
+    assert s["provenance"] == "unverifiable"
+    assert handlers.block_tally_for(forged["session_id"]) == 0  # never counted as a trusted block
+    assert "PETASOS_INTEGRITY_UNVERIFIABLE" in caplog.text
+    assert f"class={expected_class}" in caplog.text
+
+
+async def test_forged_lines_both_surface_neither_counts() -> None:
+    # Both a no-sig and a wrong-sig block drain, both surface unverifiable, neither tallies.
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    _append_raw(path, _block(session_id="sess-G", scan_id="e-g1"))  # no sig
+    _append_raw(path, _block(session_id="sess-G", scan_id="e-g2", sig="0" * 64))  # wrong sig
+    summaries = await _drain(handlers)
+    s1 = _find(summaries, scan_id="e-g1")
+    s2 = _find(summaries, scan_id="e-g2")
+    assert s1["provenance"] == "unverifiable"
+    assert s2["provenance"] == "unverifiable"
+    assert handlers.block_tally_for("sess-G") == 0
+
+
+# ---------------------------------------------------------------------------
+# Legacy unsigned event over a configured key (transitional, D4)
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_unsigned_event_under_key_is_unverifiable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handlers = _keyed_handlers()
+    _append_raw(ev._spool_path(), _block(session_id="sess-L", scan_id="e-legacy"))  # pre-PET-139
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        summaries = await _drain(handlers)
+    s = _find(summaries, scan_id="e-legacy")
+    assert s["provenance"] == "unverifiable"
+    # missing tag is untrusted, not silently counted:
+    assert handlers.block_tally_for("sess-L") == 0
+    assert "class=sig-missing" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Tag is event-bound — cross-event lifting fails (D7)
+# ---------------------------------------------------------------------------
+
+
+def test_tag_is_event_bound() -> None:
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(_block(session_id="sess-T", scan_id="e-bound-1", timestamp=111.0))
+    genuine = _read_spool(ev._spool_path())[0]
+    key = ev._derive_spool_key(_SECRET)
+    assert ev.verify_event(genuine, key) is True
+
+    # Lift the genuine sig onto a different event (new scan_id + tool).
+    forged = dict(genuine)
+    forged["scan_id"] = "e-bound-2"
+    forged["tool"] = "http_request"
+    forged["sig"] = genuine["sig"]
+    assert ev.verify_event(forged, key) is False
+
+
+# ---------------------------------------------------------------------------
+# Schema-evolution coverage — the MAC covers every present field (D1)
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_evolution_bypassed_count_inside_mac() -> None:
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(
+        {
+            "session_id": "sess-S",
+            "tool": "send_email",
+            "event_type": "bypassed_disarmed",
+            "bypassed_count": 5,
+            "armed": False,
+            "direction": "tool_call",
+        }
+    )
+    rec = _read_spool(ev._spool_path())[0]
+    key = ev._derive_spool_key(_SECRET)
+    assert ev.verify_event(rec, key) is True
+
+    # Mutating bypassed_count after signing breaks verification (the count is inside the MAC).
+    mutated = dict(rec)
+    mutated["bypassed_count"] = 999
+    assert ev.verify_event(mutated, key) is False
+
+    # The PET-138 bypass-tally branch still updates for the genuine heartbeat (not regressed).
+    handlers = _keyed_handlers()
+    await _drain(handlers)
+    assert handlers.bypass_tally_for("sess-S") == 5
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe / fail-open (D6)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_event_total_never_raises() -> None:
+    key = ev._derive_spool_key(_SECRET)
+    assert ev.verify_event({"sig": 123}, key) is False  # non-str sig
+    assert ev.verify_event({"event_type": "block"}, key) is False  # missing sig
+    assert ev.verify_event("not-a-dict", key) is False  # non-dict input
+    assert ev.verify_event(None, key) is False
+    assert ev.verify_event({"sig": "abc"}, None) is False  # None key → not genuine
+
+
+def test_writer_signing_exception_returns_false_and_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Force a signing-path exception: a non-bytes key makes hmac.new raise inside the
+    # fail-open try. emit must return False and write NOTHING (the write follows signing).
+    monkeypatch.setattr(ev, "_SPOOL_KEY", 12345)  # not bytes → hmac.new raises
+    assert ev.emit_enforcement_event(_block()) is False
+    assert _read_spool(ev._spool_path()) == []
+
+
+# ---------------------------------------------------------------------------
+# No payload via the tag (D5 / brief)
+# ---------------------------------------------------------------------------
+
+
+async def test_no_matched_text_and_reason_capped() -> None:
+    ev.set_spool_key(_SECRET)
+    long_reason = "x" * (server_mod._MAX_REASON_LEN + 250)
+    ev.emit_enforcement_event(
+        _block(session_id="sess-P", reason=long_reason, matched_text="SECRET-VALUE-LEAK")
+    )
+    handlers = _keyed_handlers()
+    summaries = await _drain(handlers)
+    s = _find(summaries, session_id="sess-P", event_type="block")
+    assert "matched_text" not in s
+    assert isinstance(s["reason"], str)
+    assert len(s["reason"]) <= server_mod._MAX_REASON_LEN
+    assert s["provenance"] == "genuine"  # matched_text in the source dict is inside the MAC
+
+
+# ---------------------------------------------------------------------------
+# _enforcement_summary provenance default (additive, callers untouched)
+# ---------------------------------------------------------------------------
+
+
+def test_enforcement_summary_provenance_defaults_unattested() -> None:
+    s = server_mod._enforcement_summary({"event_type": "block", "session_id": "x"})
+    assert s["provenance"] == "unattested"
+    s2 = server_mod._enforcement_summary({"event_type": "block"}, provenance="genuine")
+    assert s2["provenance"] == "genuine"
+
+
+# ---------------------------------------------------------------------------
+# Key derivation determinism + domain separation (D3)
+# ---------------------------------------------------------------------------
+
+
+def test_key_derivation_deterministic_and_domain_separated() -> None:
+    s = b"some-session-secret"
+    assert ev._derive_spool_key(s) == ev._derive_spool_key(s)  # stable for equal input
+    assert ev._derive_spool_key(s) != s  # not the raw secret
+    other_label = hmac.new(s, b"petasos/some-other-label/v1", hashlib.sha256).digest()
+    assert ev._derive_spool_key(s) != other_label  # domain-separated from other labels


### PR DESCRIPTION
## Summary
- The dashboard can now prove a drained enforcement-spool row is a genuine Petasos decision rather than an append forged by another in-host process: the gateway (writer) stamps each event with a keyed HMAC over a canonical serialization of the record; the dashboard (reader) recomputes and verifies before trusting it.
- A row that fails verification is **surfaced but flagged `unverifiable`** and is **never counted as a trusted block** (excluded from the authoritative `_block_tally`). A deployment with no `session_secret` behaves exactly as before (`unattested`, still counted) — no PET-131/137/138 regression.
- The writer stays fail-open and O(1) (no `fsync`, no tool-call delay); the reader stays fail-safe (`self._spool_key` always bound, `verify_event` never raises). Key agreement is a config-equality question under one documented `PETASOS_SESSION_SECRET` env contract.

## Three provenance states (D4)
- **`unattested`** — no reader key configured. Integrity is off; events behave exactly as pre-PET-139 (surfaced, block-class still bumps the tally). The no-regression path.
- **`genuine`** — a reader key is configured and the event's `sig` verifies.
- **`unverifiable`** — a key is configured and `sig` is missing or invalid. Surfaced and flagged, logged (rate-limited), and excluded from the block tally. Missing and wrong `sig` both map here (a forger would just omit `sig` otherwise); they are distinguished only in the `PETASOS_INTEGRITY_UNVERIFIABLE` log class (`sig-missing` vs `sig-mismatch`).

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_events.py` | Adds `hmac`/`hashlib`, the `set_spool_key`/`_derive_spool_key`/`_reset_spool_key` key seam, `sig` stamping in `emit_enforcement_event`, and the pure-total `verify_event`. |
| `petasos/console/server.py` | Derives `self._spool_key` in `ConsoleHandlers.__init__`; defaulted keyword-only `provenance` on `_enforcement_summary`; provenance classification + tally gate + rate-limited integrity tripwire in `_surface_enforcement_event`. |
| `docs/deployment/reference_plugin/__init__.py` | Installs the writer key at `_deferred_init` (boot) and `_apply_reconfigure` (the chokepoint covering PET-126 hot-apply + PET-132 re-bind), wrapped fail-safe. |
| `petasos/console/static/petasos.js` | Extends PET-137's "is this legit?" line with the three attestation states; absent provenance renders as `unattested`. |
| `petasos/console/static/petasos.css` | Styles the genuine/unverifiable/unattested badge. |
| `docs/deployment/hardening.md` | Operator note: env contract, first-enable spool-clear upgrade step, log token, threat model. |
| `tests/test_enforcement_integrity.py` | New — recurrence tests across both construction paths. |
| `tests/js/enforcement-provenance.test.mjs` | New — the provenance-line render test. |

## Test plan
- [x] `python -m pytest tests/test_enforcement_integrity.py tests/test_enforcement_events.py tests/test_console_scan_detail.py` — 57/57 pass (full output: docs/specs/TODO/PET-139.test-output.txt)
- [x] `node --test tests/js/enforcement-provenance.test.mjs` — 7/7 pass
- [x] `ruff check` / `ruff format --check` (changed files) — clean
- [x] `mypy --strict petasos/console/_events.py petasos/console/server.py` — clean
- [x] Regression: reconfigure / reference-plugin / console-server suite (76 passed) + full JS suite (125 passed) — green, confirming integrity is additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-open, keyed HMAC attestation for enforcement spool events and verification provenance in scan history (“Verified”, “Unverified”, “Not Configured”).
  * Scan-history summaries now include provenance, with unverifiable items no longer counting toward authoritative per-session tallies.
  * Rate-limited integrity warnings are shown during verification failures.
* **Documentation**
  * Expanded the deployment hardening guide with enforcement-spool integrity details, threat model, and upgrade/checklist steps.
* **Tests**
  * Added comprehensive coverage for attestation, verification semantics, and UI rendering of provenance badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->