### PR TITLE
feat(pet-133): Gavin banking egress fencing (local-inference gate + egress-sink classification)

### DIFF
--- a/docs/deployment/gavin-banking-egress.md
+++ b/docs/deployment/gavin-banking-egress.md
@@ -1,0 +1,230 @@
+# Gavin banking egress fencing
+
+How to make "financial data must not egress the box" true for Gavin's Hermes
+banking profile, and what that guarantee does and does not cover. The guarantee
+is primarily architectural (local-only inference); Petasos is the enforcement
+point on the agent-to-off-box-tool boundary, plus defense-in-depth and audit.
+
+> **Before you start:** read the [deployment hardening checklist](hardening.md)
+> for where Petasos sits in your security model (it is a detection layer, not a
+> boundary), and [Deploying Petasos on Hermes Desktop](hermes-desktop.md) for
+> the base install, the `petasos:` config section, and the profile config path.
+> This note adds only the banking-profile specifics on top of that baseline.
+
+**Ticket:** PET-133 (decisions D3, D4 of the Gavin Banking Observability work)  
+**Petasos version:** 0.1.2+  
+**Profile:** the active Hermes profile Gavin runs under (for example `gibson`)
+
+---
+
+## 1. The guarantee and its honest limits
+
+The primary guarantee is architectural, not content inspection:
+
+- **Local inference (D3).** Gavin's model runs on the box (LM Studio, llama.cpp,
+  or a local OpenAI-compatible server), so the inference call itself never ships
+  context off-box. This is the load-bearing control; sections 2 and 5 make it a
+  checkable hard gate.
+- **The bank MCP is reachable only as a local stdio subprocess**, with no inbound
+  webhook, so the only way bank data leaves is through a tool the agent calls.
+- **Petasos fences that agent-to-off-box-tool boundary** and provides the audit
+  trail.
+
+**Honest limit (read this before you rely on it).** Petasos blocks PII findings
+on egress sinks, and the source-taint fence (section 4) blocks verbatim relay of
+content pulled from the bank. But most banking *figures* (balances, amounts,
+merchant names) are not Presidio entities, so the PII-egress block alone does not
+stop them. Petasos here is defense-in-depth, audit, and the agent-to-off-box
+enforcement point; it is not a content-aware "no figure leaves" guarantee. The
+PET-134 taint wiring (section 4) narrows the gap for content relayed verbatim
+from a bank tool, but a model that paraphrases a balance into a new sentence and
+hands it to an egress tool is outside what the fence can see. The architectural
+controls above, not Petasos content matching, are what make the box safe.
+
+---
+
+## 2. D3: local inference is a hard gate
+
+The leak Petasos cannot intercept is the LLM inference call. The plugin registers
+`pre_tool_call` / `post_tool_call` / `on_session_start`, never `pre_llm_call`, so
+once bank data is in Gavin's context a *cloud* model would transmit it off-box on
+the next turn, a path no hook can stop. D3 closes this by configuration: Gavin's
+profile must point at a local inference endpoint. A cloud `model:` is a release
+blocker.
+
+That requirement is enforced by a checkable predicate so a profile edit cannot
+silently reopen it. Gavin's profile CI (and your own pre-flight check) runs:
+
+```python
+from petasos.profile_lint import is_local_inference_endpoint
+
+# provider + base_url come from the profile's model: section.
+assert is_local_inference_endpoint(provider, base_url), (
+    "D3 blocker: Gavin's inference endpoint is not local"
+)
+```
+
+The predicate is fail-secure: anything it cannot positively recognize as the
+local box returns `False`. It is imported module-qualified
+(`from petasos.profile_lint import ...`); it is intentionally not on the package's
+top-level `petasos` export surface. See section 6 for the exact `base_url` forms
+it accepts and the ones it rejects by design.
+
+---
+
+## 3. D4: egress-sink classification
+
+Petasos blocks PII findings at HIGH or worse only on tools classified as egress
+sinks; internal tools are exempt by design. For Gavin:
+
+- **Every off-box tool Gavin can reach is an egress sink.** The Vigil MCP
+  outbound / ingest tools, any `web_fetch` / `http` / `fetch`, and any messaging
+  `*_send` go in `egress_sink_tools`, by their full single-underscore wire name
+  (see the canonicalization note in `hermes-desktop.md`).
+- **The `mcp_bank_*` tools are sources, never sinks.** The agent pulls data in
+  through them, so they are absent from `egress_sink_tools`. Listing a bank tool
+  as a sink would be a miscategorization; the regression
+  `test_bank_pii_blocked_to_egress_sink` pins that a bank source tool is not
+  blocked while a real sink is.
+- **Presidio is enabled with `anonymize: true`**, so the classic high-severity
+  identifiers (full account / routing number, SSN, card) are blocked or redacted
+  on egress.
+
+This classification is operator config in the profile, not a code change. No
+banking-specific tool names ship in the Petasos library defaults; they live only
+in Gavin's profile, this note, and the test fixtures.
+
+---
+
+## 4. Source-taint wiring for `mcp_bank_`
+
+The content-agnostic provenance fence (PET-134) blocks content returned by a tool
+in a declared source namespace from leaving verbatim through an egress sink, even
+when it carries no PII span. Wire it for Gavin in the `petasos:` section:
+
+```yaml
+  source_taint_namespaces: ["mcp_bank_"]
+  taint_min_span_length: 12
+```
+
+`source_taint_namespaces` is matched as a single-underscore wire prefix against a
+producing tool's canonical name, so `mcp_bank_list_accounts`,
+`mcp_bank_query_transactions`, and their case / CamelCase / `_tool` variants all
+taint. `taint_min_span_length` (default 12) is the false-positive floor: a
+captured span shorter than this is never stored, so a low-entropy value like
+`$5.00` cannot poison every later argument. Leave it at the default unless you see
+false positives (raise it) or want broader coverage (lower it). The regression
+`test_tainted_nonpii_blocked_to_egress_sink` already proves a non-PII
+`$4,000 at Whole Foods` string captured from `mcp_bank_list_accounts` is blocked
+when relayed to `send_email`.
+
+---
+
+## 5. Example compliant profile
+
+A minimal Gavin-shaped `model:` plus `petasos:` block. Edit the **profile's**
+`config.yaml`, not the root one (Hermes v0.16+):
+
+```text
+# Windows: %LOCALAPPDATA%\hermes\profiles\gibson\config.yaml
+# macOS:   ~/.hermes/profiles/gibson/config.yaml
+```
+
+```yaml
+# Local inference endpoint (D3 hard gate). is_local_inference_endpoint() must
+# pass for this provider + base_url.
+model:
+  provider: "lmstudio"
+  base_url: "http://127.0.0.1:1234/v1"
+
+petasos:
+  enabled: true
+  fail_mode: "closed"
+  host_id: "gavin-banking"
+
+  # D4: PII on egress is blocked or redacted.
+  anonymize: true
+  pii_entities: ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD", "US_SSN", "US_BANK_NUMBER"]
+  redaction_mode: "hash"
+
+  # D4: every off-box tool Gavin can reach is an egress sink. Bank tools are
+  # sources (pulled in), so they are deliberately NOT listed here.
+  egress_sink_tools:
+    - send_email
+    - send_message
+    - http_request
+    - send_webhook
+    - mcp_vigil_harbor_memory_ingest
+
+  # PET-134: content from the bank namespace may not leave verbatim.
+  source_taint_namespaces: ["mcp_bank_"]
+  taint_min_span_length: 12
+```
+
+After applying it, run the section 2 lint against the live `model:` values and do
+a full app restart (plugin discovery runs at startup; see `hermes-desktop.md`).
+
+---
+
+## 6. Local-endpoint troubleshooting
+
+`is_local_inference_endpoint` is fail-secure, so a malformed local endpoint reads
+as "not local" and blocks the release. Write `base_url` as one of:
+
+```text
+http://127.0.0.1:<port>
+http://localhost:<port>
+```
+
+The rules behind that, and the traps the predicate rejects by design:
+
+- **The `http://` (or `https://`) scheme is mandatory.** A bare `localhost:1234`
+  or `127.0.0.1:1234` parses with no host (the token before the first `:` is read
+  as the URL scheme), so it returns `False`. Always write the scheme.
+- **Never `127.1`.** IPv4 dotted-shorthand is not a valid address literal, so it
+  is rejected. Write the full `127.0.0.1`.
+- **Never a zero-padded octet** (`127.0.0.01`, `127.000.000.001`). Leading zeros
+  are rejected for octal ambiguity. Write the canonical `127.0.0.1`.
+- **Never `0.0.0.0` or a LAN address** (`10.x`, `172.16-31.x`, `192.168.x`). A
+  server may *bind* `0.0.0.0`, but the profile `base_url` must still name the
+  loopback (`127.0.0.1` or `localhost`); `0.0.0.0` and LAN addresses fail by
+  design, because they are reachable from off the box.
+- **An unlisted local runtime needs an explicit loopback `base_url`.** The
+  provider-only fallback recognizes a fixed allowlist (`lmstudio`, `llama.cpp`,
+  `llamacpp`, `ollama`, `local`, `localai`). A legitimate but unlisted runtime
+  (`vllm`, `text-generation-webui`, `koboldcpp`, `tabbyapi`) returns `False` on
+  the provider name alone; set the explicit loopback `base_url` and it passes
+  (`base_url` is authoritative over `provider`).
+
+---
+
+## 7. Windows model-switcher caveat
+
+On Windows, the Hermes Desktop UI model switcher rewrites the `model:` section and
+has, on some builds, wiped the top-level `petasos:` section with it (PET-115). If
+`petasos:` is gone, **both the egress fence and the taint fence are off**, and
+bank data can leave through any tool. Treat every model switch as suspect:
+
+1. **Detect.** After any model switch, re-run the section 2 lint against the new
+   `model:` values, and confirm the `petasos:` section is still present in the
+   live profile `config.yaml`:
+
+   ```bash
+   # Git Bash
+   grep -n '^petasos:' "$LOCALAPPDATA/hermes/profiles/gibson/config.yaml"
+   ```
+
+   ```powershell
+   # PowerShell
+   Select-String -Pattern '^petasos:' "$env:LOCALAPPDATA\hermes\profiles\gibson\config.yaml"
+   ```
+
+   No match means the section was wiped.
+
+2. **Recover.** Re-apply the section 5 snippet (`petasos:` plus a local `model:`),
+   then do a full app restart so the plugin reloads it.
+
+3. **Do not resume until recovered.** If `petasos:` is absent after a switch, the
+   egress fence and the `mcp_bank_` taint fence are both off; bank data can egress
+   unblocked. Re-apply the snippet and restart before letting Gavin run any
+   banking task.

--- a/petasos/profile_lint.py
+++ b/petasos/profile_lint.py
@@ -1,0 +1,90 @@
+"""PET-133: a generic, fail-secure local-inference lint predicate (decision D3).
+
+The leak Petasos cannot intercept is the LLM inference call itself: the plugin
+registers ``pre_tool_call`` / ``post_tool_call`` / ``on_session_start``, never
+``pre_llm_call``. So once sensitive data is in an agent's context, a *cloud*
+model transmits it off-box on the next turn. D3 closes this by configuration:
+the profile must point at a local inference endpoint. This predicate makes that
+requirement checkable, so a profile edit cannot silently reopen the leak.
+
+The predicate is generic (no banking specifics) and reusable by any profile, so
+it does not violate the "no banking names in the library" invariant. It lives in
+core ``petasos/`` rather than the reference plugin because a profile's CI must
+``import`` it from the pip-installed package. It is deliberately NOT added to
+``petasos.__all__`` (the frozen public-API surface); import it module-qualified::
+
+    from petasos.profile_lint import is_local_inference_endpoint
+
+No new dependencies: stdlib ``urllib.parse`` + ``ipaddress`` only.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlsplit
+
+# Provider names that denote a local inference server. ``base_url``, when
+# present, is always authoritative over this fallback; the allowlist only
+# decides the provider-only case. Compared after ``.strip().lower()``.
+_LOCAL_PROVIDERS = frozenset({"lmstudio", "llama.cpp", "llamacpp", "ollama", "local", "localai"})
+
+
+def is_local_inference_endpoint(provider: str | None, base_url: str | None) -> bool:
+    """True iff the resolved inference endpoint is on the local box.
+
+    Fail-secure: ambiguous or unrecognized inputs return False, because the
+    caller uses this as a release-blocker gate ("financial data must not
+    egress the box"). The verdict errs toward "not local".
+    """
+    base = (base_url or "").strip()
+    provider_name = (provider or "").strip()
+
+    # 1. None/empty guard first, so the step-3 provider fallback never runs
+    #    ``.strip()`` on None and the predicate always returns a bool.
+    if not base and not provider_name:
+        return False
+
+    # 2. base_url is authoritative when non-blank. (A whitespace-only base_url
+    #    has already collapsed to "" above and falls through to step 3.)
+    if base:
+        try:
+            host = urlsplit(base).hostname
+        except ValueError:
+            # Malformed URL (e.g. an unclosed IPv6 bracket "http://[::1"):
+            # treat as not-local.
+            return False
+        if host is None:
+            # No host component: a scheme-less "localhost:1234" (urlsplit reads
+            # the token before the first ":" as the scheme) or a degenerate
+            # "::::". urlsplit returns hostname=None without raising.
+            return False
+        # urlsplit already lowercases the host and strips IPv6 brackets. Strip a
+        # single trailing dot so the absolute-FQDN form "localhost." is matched.
+        if host.endswith("."):
+            host = host[:-1]
+        try:
+            host_ip = ipaddress.ip_address(host)
+        except ValueError:
+            # host is a name, not an IP literal: only the exact "localhost" is
+            # local. This closes the symmetric fail-open traps -- both
+            # "127.0.0.1.evil.com" and "localhost.evil.com" are names (not IP
+            # literals, not equal to "localhost"), as are "127.1" and a
+            # zero-padded "127.0.0.01" (rejected by ipaddress). A
+            # ``host.startswith("127.")`` test is forbidden: it is fail-open.
+            return host == "localhost"
+        # Loopback by IP-literal parsing, never by prefix/substring. ipv4_mapped
+        # is handled explicitly so an IPv4-mapped loopback ("::ffff:127.0.0.1")
+        # is recognized on every interpreter: the stdlib's own is_loopback
+        # delegation to the mapped address is a 3.10.14+ / CVE-2024-4032
+        # backport, absent on older 3.10.x. This only ever flips a mapped
+        # *loopback* to True; a mapped LAN/routable address stays not-local.
+        if isinstance(host_ip, ipaddress.IPv6Address):
+            mapped = host_ip.ipv4_mapped
+            if mapped is not None:
+                return mapped.is_loopback
+        return host_ip.is_loopback
+
+    # 3. base_url absent/empty -> provider fallback against the documented
+    #    local-server allowlist. Any other provider (anthropic, openai,
+    #    openrouter, huggingface, unknown) is not local.
+    return provider_name.lower() in _LOCAL_PROVIDERS

--- a/tests/test_profile_lint.py
+++ b/tests/test_profile_lint.py
@@ -1,0 +1,112 @@
+"""PET-133: unit tests for the D3 local-inference lint predicate.
+
+Backend-free (no Presidio / LLM-Guard / LlamaFirewall import): runs on any
+interpreter with Petasos importable. Covers ``is_local_inference_endpoint``
+table-driven (at least one row per contract clause) plus the Gavin-shaped
+profile gate (``test_gavin_profile_is_local_inference``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from petasos.profile_lint import is_local_inference_endpoint
+
+# (provider, base_url, expected). At least one row per D3 contract clause.
+_CASES: list[tuple[str | None, str | None, bool]] = [
+    # --- local via base_url (authoritative when non-blank) ---
+    ("", "http://127.0.0.1:1234/v1", True),
+    ("", "http://localhost:8080", True),
+    ("", "http://[::1]:1234", True),
+    ("", "http://127.0.0.5:1234", True),  # all of 127.0.0.0/8 is loopback
+    ("", "http://LOCALHOST:1234", True),  # host lowercased by urlsplit
+    ("", "http://localhost.:8080", True),  # absolute-FQDN trailing dot stripped
+    ("", "http://[::ffff:127.0.0.1]:1234", True),  # IPv4-mapped IPv6 loopback
+    # --- local via provider fallback (empty/blank base_url) ---
+    ("lmstudio", "", True),
+    ("ollama", "", True),
+    ("llama.cpp", "", True),
+    ("  Ollama  ", "", True),  # .strip().lower() normalization
+    ("ollama", "   ", True),  # whitespace-only base_url -> provider fallback
+    # --- not local: cloud endpoints (fail-secure) ---
+    ("", "https://api.anthropic.com", False),
+    ("", "https://api.openai.com", False),
+    ("", "https://openrouter.ai/api/v1", False),
+    # --- not local: host-parse fail-open traps (the P0 regression) ---
+    ("", "http://127.0.0.1.evil.com/", False),
+    ("", "http://127.0.0.1.example.com:1234", False),
+    ("", "https://localhost.evil.com/", False),
+    # --- not local: non-loopback IP literals ---
+    ("", "http://0.0.0.0:1234", False),
+    ("", "http://192.168.1.10:1234", False),
+    ("", "http://10.0.0.4:1234", False),
+    ("", "http://127.1:1234", False),  # dotted-shorthand: not a valid literal
+    ("", "http://127.0.0.01:1234", False),  # zero-padded octet rejected
+    # --- not local: provider fallback misses ---
+    ("anthropic", "", False),
+    ("openai", "", False),
+    ("unknown", "", False),
+    # --- not local: None/empty guard (runs first) ---
+    (None, None, False),
+    ("", "", False),
+    (None, "", False),
+    ("", None, False),
+    # --- not local: degenerate base_url shapes ---
+    ("anthropic", "::::", False),  # urlsplit hostname=None, does NOT raise
+    ("anthropic", "http://[::1", False),  # malformed IPv6 bracket -> ValueError
+    ("anthropic", "localhost:1234", False),  # scheme-less -> hostname=None
+]
+
+
+@pytest.mark.parametrize(("provider", "base_url", "expected"), _CASES)
+def test_is_local_inference_endpoint(
+    provider: str | None, base_url: str | None, expected: bool
+) -> None:
+    # ``is`` (not ``==``): the predicate must always return a genuine bool.
+    assert is_local_inference_endpoint(provider, base_url) is expected
+
+
+def _gavin_profile() -> dict[str, Any]:
+    """A Gavin-shaped Hermes profile dict (constructed inline, no PyYAML dep).
+
+    The ``model:`` endpoint is local; the ``petasos:`` section pins the D4 +
+    PET-134 taint wiring at the config level. Gavin's own profile CI runs the
+    same ``is_local_inference_endpoint`` helper against the real YAML.
+    """
+    return {
+        "model": {
+            "provider": "lmstudio",
+            "base_url": "http://127.0.0.1:1234/v1",
+        },
+        "petasos": {
+            "source_taint_namespaces": ["mcp_bank_"],
+            "egress_sink_tools": [
+                "send_email",
+                "http_request",
+                "mcp_vigil_harbor_memory_ingest",
+            ],
+            "anonymize": True,
+        },
+    }
+
+
+def test_gavin_profile_is_local_inference() -> None:
+    profile = _gavin_profile()
+
+    # D3 hard gate: the local-endpoint profile passes the lint.
+    model = profile["model"]
+    assert is_local_inference_endpoint(model["provider"], model["base_url"]) is True
+
+    # D4 + PET-134 taint wiring pinned at the config level.
+    petasos_cfg = profile["petasos"]
+    assert "mcp_bank_" in petasos_cfg["source_taint_namespaces"]
+    assert petasos_cfg["egress_sink_tools"]  # non-empty
+    assert petasos_cfg["anonymize"] is True
+
+    # The same dict mutated to a cloud provider fails the gate, so a profile
+    # edit cannot silently reopen the inference leak.
+    profile["model"] = {"provider": "anthropic", "base_url": "https://api.anthropic.com"}
+    cloud = profile["model"]
+    assert is_local_inference_endpoint(cloud["provider"], cloud["base_url"]) is False

--- a/tests/test_reference_plugin_egress.py
+++ b/tests/test_reference_plugin_egress.py
@@ -177,6 +177,36 @@ def test_pii_finding_blocks_egress_tool(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 # ---------------------------------------------------------------------------
+# PET-133: bank-framed egress-sink specialization of the PII gate (D4)
+# ---------------------------------------------------------------------------
+
+# A Gavin-shaped egress set: every off-box tool (messaging, http, the Vigil
+# ingest sink) is an egress sink; the mcp_bank_* tools are sources, never sinks,
+# so they are deliberately absent.
+_GAVIN_EGRESS = frozenset({"send_email", "http_request", "mcp_vigil_harbor_memory_ingest"})
+
+
+def test_bank_pii_blocked_to_egress_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-133: a HIGH+ PII finding is blocked on an egress sink,
+    # but the SAME finding to a bank *source* tool and to an internal tool is
+    # not, pinning that bank tools are never miscategorized as sinks (D4).
+    gr = _guard_result(findings=(_pii(Severity.HIGH),), param_scan_unsafe=True)
+
+    # (a) PII -> egress sink: blocked.
+    out = _drive(monkeypatch, "send_email", gr, egress=_GAVIN_EGRESS)
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+    assert "send_email" in out["message"] and "PII" in out["message"]
+
+    # (b) the same PII -> a bank source tool (not in the egress set, not
+    # read-only): NOT blocked. Bank tools pull data in; they are never sinks.
+    assert _drive(monkeypatch, "mcp_bank_query_transactions", gr, egress=_GAVIN_EGRESS) is None
+
+    # (c) the same PII -> an internal tool: NOT blocked (internal-exempt parity).
+    assert _drive(monkeypatch, "write_file", gr, egress=_GAVIN_EGRESS) is None
+
+
+# ---------------------------------------------------------------------------
 # PET-118: classification canonicalizes to the guard's shared form
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Ship the Petasos-side slice of the Gavin Banking Observability work (decisions D3, D4) that makes "financial data must not egress the box" true for Gavin's Hermes profile. The guarantee is primarily architectural (local-only inference); Petasos is the agent-to-off-box-tool enforcement point plus defense-in-depth and audit.
- Adds a generic, fail-secure local-inference lint predicate (D3), a bank-framed egress-sink regression (D4), and an operator note documenting the honest limits and the example compliant profile.
- Reuses the PET-134 source-taint fence rather than rebuilding it: the `mcp_bank_` wiring is documented and pinned by the existing `test_tainted_nonpii_blocked_to_egress_sink` regression (no duplicate test). No banking-specific names enter the library defaults.

## Two-check interaction
For an off-box tool, two independent fences compose at `pre_tool_call`: (1) the source-taint fence (PET-134) blocks content pulled verbatim from an `mcp_bank_*` source namespace, even with no PII span; (2) the PII-egress block (D4) blocks HIGH+ PII findings, but only on tools classified as egress sinks. Bank tools are sources (never listed in `egress_sink_tools`), so PII routed to a bank tool or an internal tool is not blocked, while the same finding to a real sink is. D3 sits upstream of both: it is enforced by configuration (a local `model:` endpoint), since Petasos registers no `pre_llm_call` hook and cannot intercept the inference call itself.

## Files changed

| File | Change |
|------|--------|
| `petasos/profile_lint.py` | New. `is_local_inference_endpoint(provider, base_url)`: stdlib-only (urllib.parse + ipaddress), loopback by IP-literal parsing (never prefix/substring), provider allowlist fallback, explicit IPv4-mapped-loopback handling for cross-interpreter correctness. Module-qualified import; not on `petasos.__all__`. |
| `tests/test_profile_lint.py` | New. Table-driven `test_is_local_inference_endpoint` (a row per contract clause) + `test_gavin_profile_is_local_inference`. |
| `tests/test_reference_plugin_egress.py` | Adds `test_bank_pii_blocked_to_egress_sink` (PII to an egress sink blocks; same PII to an `mcp_bank_*` source tool and to an internal tool does not) via the existing `_drive` harness. |
| `docs/deployment/gavin-banking-egress.md` | New operator note: D3 requirement, D4 classification + Presidio/anonymize, honest-limits framing, `mcp_bank_` taint wiring, example compliant `petasos:` + `model:` profile, local-endpoint troubleshooting, and the actionable Windows model-switcher caveat. No em dashes; matches `hermes-desktop.md`. |

## Test plan
- [x] `python -m pytest tests/test_profile_lint.py tests/test_reference_plugin_egress.py -q` — 76/76 pass (full output: `docs/specs/TODO/PET-133.test-output.txt`)
- [x] `ruff check` + `ruff format --check` (all three changed py files) — clean
- [x] `mypy --strict petasos/profile_lint.py` — clean
- [x] Full suite — 1883 passed, 41 skipped, 1 deselected (the documented pre-existing `test_console_validation.py::test_default_ignorable_rejected`, a Unicode 13-vs-14 artifact of the 3.10.6 interpreter, unrelated to this change)
- Note: the spec's `python -m pytest` was pinned to `C:/python310/python.exe` because this machine's `python` (3.14.3) has no petasos install; petasos resolves to the worktree under module-form invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guide for enforcing banking data egress protection, including configuration examples and troubleshooting steps.

* **New Features**
  * Added local inference endpoint validation with fail-secure security checks.
  * Added banking data egress enforcement with PII detection and anonymization capabilities.

* **Tests**
  * Added comprehensive test coverage for endpoint validation and banking profile security enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->