### PR TITLE
feat(pet-144): honest scan count + visible eviction for console history

### DIFF
--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -348,6 +348,12 @@ class ConsoleHandlers:
         # cumulative count carried on bypassed_disarmed heartbeats; bounded
         # drop-oldest; resets on a dashboard restart (in-memory by design).
         self._bypass_tally: dict[str, int] = {}
+        # PET-144: eviction-proof lifetime scan count. Decoupled from the 500-entry ring
+        # (mirrors the PET-131/138 tally pattern): monotonic, in-memory, resets on a
+        # dashboard restart by design. A single scalar, so no per-session bound.
+        self._scans_total = 0
+        # One-shot guard so the first ring overflow logs exactly once per run, not per scan.
+        self._ring_overflow_warned = False
 
         pipeline.add_audit_listener(self._on_audit)
         pipeline.add_alert_listener(self._on_alert)
@@ -414,6 +420,22 @@ class ConsoleHandlers:
         except Exception:
             pass
 
+    def _record_scan(self, summary: dict[str, Any]) -> None:
+        """Single record chokepoint: append to the ring AND bump the eviction-proof
+        total. Both the playground run_scan push and the drained-enforcement fold route
+        here so scans_total can never diverge from what was recorded (PET-144)."""
+        self.scan_history.push(summary)
+        self._scans_total += 1
+        if not self._ring_overflow_warned and self._scans_total > len(self.scan_history):
+            self._ring_overflow_warned = True
+            _logger.warning(
+                "console scan-history ring at capacity (%d entries); oldest rows now "
+                "evict silently. scans_total is authoritative; the history pane shows "
+                "the last %d.",
+                len(self.scan_history),
+                len(self.scan_history),
+            )
+
     async def _surface_enforcement_event(self, ev: dict[str, Any]) -> None:
         """Fold one drained enforcement event into scan_history + the tally + SSE.
 
@@ -432,7 +454,7 @@ class ConsoleHandlers:
         if key_on and not verified:
             self._log_integrity_failure(ev)
         summary = _enforcement_summary(ev, provenance=provenance)
-        self.scan_history.push(summary)
+        self._record_scan(summary)
         if ev.get("event_type") in _BLOCK_EVENT_TYPES:
             # unattested + genuine count; unverifiable does NOT (D4) — a forged/legacy-unsigned
             # block is surfaced-but-flagged, never tallied as a trusted block.
@@ -657,7 +679,7 @@ class ConsoleHandlers:
             # PET-137: bounded detail blob so a playground row can drill down (D2/D-CAP).
             "detail": _build_playground_detail(result, norm),
         }
-        self.scan_history.push(summary)
+        self._record_scan(summary)
         await self.sse.broadcast("scan_result", summary)
 
         return {
@@ -679,6 +701,7 @@ class ConsoleHandlers:
                 "scanner_count": len(self.pipeline.scanner_health()),
                 "config_hash": config_hash,
                 "uptime_seconds": round(time.monotonic() - self._start_time, 1),
+                "scans_total": self._scans_total,  # PET-144: eviction-proof lifetime count
             },
             "scanners": self.pipeline.scanner_health(),
             "feature_status": dict(self.pipeline._build_feature_status()),

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -967,6 +967,19 @@
     return total;
   };
 
+  // PET-144: honest scan-history subtitle. The ≤500 ring evicts silently; when the
+  // authoritative lifetime count (scans_total from /health) exceeds the buffered
+  // window, say so instead of implying the window is the whole record. Pure seam so
+  // the console JS harness can assert the label without driving renderDashboard.
+  Pet.scanHistorySubtitle = function (buffered, total) {
+    var b = Number(buffered); if (!Number.isFinite(b) || b < 0) b = 0;
+    var t = Number(total);
+    // total absent / non-numeric (health not yet loaded) or not actually evicting:
+    // fall back to the static subtitle, never a misleading "of NaN".
+    if (!Number.isFinite(t) || t <= b) return "recent evaluations";
+    return "showing last " + b + " of " + t;
+  };
+
   Pet.mergeScanHistory = function (buffer, entries) {
     var seen = new Set();
     for (var j = 0; j < buffer.length; j++) {
@@ -1126,7 +1139,12 @@
 
     // Scan history — rows derived from the same buffer (already most-recent-first).
     var historyPanel = Pet.Panel({
-      icon: "list", title: "scan history", place: "recent evaluations", flush: true,
+      icon: "list", title: "scan history", flush: true,
+      // PET-144: lifetime total (scans_total from /health) vs the buffered ≤500 window.
+      place: Pet.scanHistorySubtitle(
+        hist.length,
+        Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
+      ),
       help: Pet.HelpTip("<b>Scan History</b>: recent pipeline scans with severity, direction, and timing. Each row is one <code>Pipeline.evaluate()</code> call."),
       content: Pet.h("div", { style: { padding: "12px" } }, Pet.scanHistoryRows(hist)),
     });
@@ -1153,11 +1171,26 @@
     Pet.api.getHealth().then(function (d) {
       _healthLoaded = true;  // PET-127: settled (either arm) -> stop painting the skeleton
       if (!d.error) {
+        // PET-144: capture BEFORE the assignment whether this settle is the first to
+        // populate pipelineHealth, so the cold-mount re-render below fires on the
+        // null->set transition only.
+        var hadHealth = Pet.state.pipelineHealth !== null;
         Pet.state.scannerHealth = d.scanners || [];
         Pet.state.pipelineHealth = d.pipeline || null;
         var rows = Pet.scannerHealthRows(Pet.state.scannerHealth);
         var contentEl = healthPanel.querySelector("[style*='padding: 12px']") || healthPanel.querySelector("div > div");
         if (contentEl) { contentEl.innerHTML = ""; contentEl.appendChild(rows); }
+        // PET-144 cold-mount: this in-render fetch only patches the scanner-health
+        // panel above; the scan-history subtitle ("showing last N of M") is computed
+        // from scans_total at render time. On a cold mount against an already-evicting
+        // ring it would otherwise read "recent evaluations" until the first 10s poll.
+        // Re-render once so the honest label appears on first paint. The transition
+        // guard is load-bearing: this getHealth() fetch runs on EVERY renderDashboard
+        // (unlike the timer-gated poll :533 / one-shot seed :1190), so an
+        // unconditional re-render here would re-invoke the fetch without bound.
+        if (!hadHealth && Pet.state.pipelineHealth && Pet.state.tab === "obs" && _container) {
+          Pet.renderDashboard(_container);
+        }
       } else {
         var contentEl = healthPanel.querySelector("[style*='padding: 12px']") || healthPanel.querySelector("div > div");
         if (contentEl) {

--- a/tests/js/scan-history-count.test.mjs
+++ b/tests/js/scan-history-count.test.mjs
@@ -1,0 +1,101 @@
+// Unit tests for the PET-144 honest scan-history subtitle seam (petasos.js).
+//
+// The scan-history pane's subtitle must tell the truth about eviction: the <=500 ring
+// drops oldest rows silently, so once the authoritative lifetime count (scans_total
+// from /health) exceeds the buffered window, the subtitle reads "showing last N of M"
+// instead of implying the window is the whole record. Pet.scanHistorySubtitle is a pure
+// seam (mirrors Pet.bypassTotal / Pet.mergeScanHistory) so the harness can assert the
+// label without driving renderDashboard. It reads scans_total from the health stat, never
+// a separately-derived number that could silently disagree with the backend ring.
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped petasos.js.
+// Run with: node --test tests/js/scan-history-count.test.mjs
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// Minimal DOM shim -- these tests exercise a pure data seam, so document is only needed
+// for petasos.js to evaluate.
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute() {},
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+beforeEach(() => {
+  Pet.state.pipelineHealth = null; // isolate: Pet is shared across tests in this vm context
+});
+
+test("loader: petasos.js exposes Pet.scanHistorySubtitle", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.scanHistorySubtitle, "function");
+});
+
+test("total > buffered: the subtitle announces the lifetime total", () => {
+  assert.equal(Pet.scanHistorySubtitle(500, 612), "showing last 500 of 612");
+});
+
+test("total <= buffered: not evicting, fall back to the static subtitle", () => {
+  assert.equal(Pet.scanHistorySubtitle(500, 500), "recent evaluations"); // equal -> not evicting
+  assert.equal(Pet.scanHistorySubtitle(500, 12), "recent evaluations"); // fewer than buffered
+});
+
+test("health not loaded (null / undefined / NaN): static subtitle, never 'of NaN'", () => {
+  for (const total of [null, undefined, NaN, "not-a-number"]) {
+    const out = Pet.scanHistorySubtitle(500, total);
+    assert.equal(out, "recent evaluations");
+    assert.equal(out.includes("NaN"), false);
+  }
+});
+
+test("reads scans_total from the health stat shape (cannot mis-source the displayed total)", () => {
+  Pet.state.pipelineHealth = { scans_total: 700 };
+  assert.equal(
+    Pet.scanHistorySubtitle(500, Pet.state.pipelineHealth.scans_total),
+    "showing last 500 of 700"
+  );
+});
+
+test("buffered tracks the live count, not a hardcoded 500", () => {
+  // The denominator-of-rows follows hist.length post the petasos.js:483 mirror clamp,
+  // not a literal constant; the "500" in the cases above is a stand-in for that length.
+  assert.equal(Pet.scanHistorySubtitle(487, 700), "showing last 487 of 700");
+  // A negative / non-finite buffered is floored to 0 (never a misleading negative).
+  assert.equal(Pet.scanHistorySubtitle(-5, 700), "showing last 0 of 700");
+});
+
+test("cold-mount refresh: null health -> static; once scans_total settles -> honest label", () => {
+  // Pins the Design step-3 fix: before /health settles pipelineHealth is null and the
+  // subtitle is static; after the in-render settle populates scans_total the same
+  // (buffered, scans_total) call returns the honest label -- no new scan frame needed.
+  assert.equal(
+    Pet.scanHistorySubtitle(500, Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total),
+    "recent evaluations"
+  );
+  Pet.state.pipelineHealth = { scans_total: 612 };
+  assert.equal(
+    Pet.scanHistorySubtitle(500, Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total),
+    "showing last 500 of 612"
+  );
+});

--- a/tests/test_console_scans_total.py
+++ b/tests/test_console_scans_total.py
@@ -1,0 +1,93 @@
+"""PET-144: eviction-proof lifetime scan count surfaced in get_health.
+
+The console scan history is a fixed 500-entry ring (RingBuffer(maxlen=500)). Past
+entry 500 the oldest row drops, and before PET-144 nothing surfaced a total count, so
+an operator saw a <=500 window presented as the whole record. ConsoleHandlers now keeps
+``_scans_total`` -- a monotonic, in-memory counter decoupled from the ring (mirrors the
+PET-131 ``_block_tally`` / PET-138 ``_bypass_tally`` eviction-proof pattern) -- bumped
+through one private ``_record_scan`` chokepoint that BOTH push sites (the playground
+``run_scan`` and the drained-enforcement fold) route through, and exposes it as
+``get_health()["pipeline"]["scans_total"]``.
+
+Regression for PET-144: the count must stay accurate after the ring has evicted, both
+record paths must feed the same counter, and the first overflow must log exactly once
+(not per scan). The 500 ring stays a hard cap by design -- this makes it honest, not
+bigger.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console.server import ConsoleHandlers  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def handlers() -> ConsoleHandlers:
+    return ConsoleHandlers(
+        Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    )
+
+
+async def test_scans_total_starts_zero(handlers: ConsoleHandlers) -> None:
+    # Honest zero: a fresh handler reports scans_total == 0 before any scan -- the
+    # baseline the eviction-proof claim builds on.
+    health = await handlers.get_health()
+    assert health["pipeline"]["scans_total"] == 0
+
+
+async def test_scans_total_survives_ring_eviction(handlers: ConsoleHandlers) -> None:
+    # The count is accurate even though retention is capped (mirrors the eviction-proof
+    # assertion in test_disarm_bypass_counter.py): 600 recorded, 500 retained, total 600.
+    for i in range(600):
+        await handlers.run_scan(f"scan number {i} for ring eviction coverage")
+
+    # get_health does NOT drain, so the counter reflects exactly the 600 run_scan records.
+    health = await handlers.get_health()
+    assert health["pipeline"]["scans_total"] == 600
+
+    # The ring itself stays hard-capped at 500 (bounded-memory by design)...
+    assert len(handlers.scan_history) == 500
+    # ...and the public history surface returns at most that window, even asking for 1000.
+    history = await handlers.get_scan_history(limit=1000)
+    assert len(history["entries"]) == 500
+
+
+async def test_scans_total_counts_both_record_paths(handlers: ConsoleHandlers) -> None:
+    # Both chokepoint callers bump the same counter: one playground run_scan (+1) and one
+    # drained-enforcement fold (+1). Structurally guaranteed by the single _record_scan
+    # method; pinned here so the two paths can never diverge. The fold uses a minimal
+    # well-formed row; its await self.sse.broadcast(...) is a no-op (no subscribers on a
+    # fresh handler). We assert only the counter, not row contents.
+    await handlers.run_scan("one playground scan")
+    await handlers._surface_enforcement_event(
+        {"event_type": "block", "session_id": "s1", "scan_id": "e-1"}
+    )
+
+    health = await handlers.get_health()
+    assert health["pipeline"]["scans_total"] == 2
+
+
+async def test_ring_overflow_warns_once(
+    handlers: ConsoleHandlers, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The first ring overflow logs exactly one WARNING (no per-scan log spam). Filter by
+    # the "ring at capacity" substring rather than len(caplog.records): the same
+    # petasos.console.server logger also emits the enforcement-spool over-cap WARNING and
+    # the .rot unlink-failure WARNING; the pure run_scan path never triggers those, but
+    # the substring filter keeps the test robust if it later drains enforcement.
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        for i in range(600):
+            await handlers.run_scan(f"overflow scan {i}")
+
+    overflow_warnings = [r for r in caplog.records if "ring at capacity" in r.message]
+    assert len(overflow_warnings) == 1

--- a/tests/test_console_scans_total.py
+++ b/tests/test_console_scans_total.py
@@ -28,7 +28,7 @@ from petasos.console.server import ConsoleHandlers  # noqa: E402
 from petasos.pipeline import Pipeline  # noqa: E402
 from petasos.scanners.minimal import MinimalScanner  # noqa: E402
 
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Adds an eviction-proof, monotonic `_scans_total` lifetime scan counter (decoupled from the 500-entry ring) surfaced in `get_health`'s `pipeline` block.
- Routes both scan-record sites (the playground `run_scan` push and the drained-enforcement fold) through one private `_record_scan` chokepoint so the count cannot diverge; the first ring overflow logs one WARNING.
- Renders an honest scan-history pane subtitle ("showing last 500 of N") from a pure `Pet.scanHistorySubtitle` seam once the lifetime total exceeds the buffered window.

PET-144 is an observability-honesty fix, not a capacity change: the 500 ring stays a hard cap by design (caps-are-not-config-fields). The literal "back-pages" ask (retention beyond 500 → persistence) is deferred to follow-up ticket **PET-148**.

## One deviation from the spec (flagged)
§ Design Frontend step 3 specified an **unconditional** `Pet.renderDashboard(_container)` inside the in-render `getHealth().then()` success branch. That fetch fires on *every* `renderDashboard` (it is the steady-state scanner-health refresh, ungated — unlike the timer-gated poll `:533` and one-shot seed `:1190`), so an unconditional re-render in its callback would re-invoke the fetch without bound (recursive fetch/render loop). I implemented the spec's **stated intent** ("one re-render per health settle … honest label on first paint") with a transition-guarded re-render that fires only on the first `null→set` of `pipelineHealth`. It is provably loop-free and invisible to the seam tests (which assert `scanHistorySubtitle` directly).

## Files changed

| File | Change |
|------|--------|
| `petasos/console/server.py` | Adds `_scans_total` + `_ring_overflow_warned` state, the `_record_scan` chokepoint, reroutes both push sites, surfaces `scans_total` in `get_health`. |
| `petasos/console/static/petasos.js` | Adds the pure `Pet.scanHistorySubtitle` seam, wires the scan-history subtitle, adds the transition-guarded cold-mount re-render. |
| `tests/test_console_scans_total.py` | New — backend regression (eviction-survival, both-paths, warn-once, honest-zero). |
| `tests/js/scan-history-count.test.mjs` | New — frontend seam regression (label / fallback / stats-shape / cold-mount). |

## Test plan
- [x] `C:\python310\python.exe -m pytest tests/test_console_scans_total.py tests/test_console_handlers.py tests/test_ring_buffer.py -q` — 65/65 pass
- [x] `node --test tests/js/scan-history-count.test.mjs` — 7/7 pass
- [x] `ruff check .` / `ruff format --check .` — clean
- [x] `mypy --strict .` — clean (137 files)

(Full capture: `docs/specs/TODO/PET-144.test-output.txt` — `docs/specs` is gitignored, kept in the primary tree alongside the spec.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lifetime scan counter that tracks all evaluations independently of the rolling scan-history buffer.
  * Updated the health endpoint to include the total scan count.
  * Enhanced the observability dashboard scan-history subtitle to show either “recent evaluations” or “showing last N of M evaluations” as totals become available.

* **Tests**
  * Added regression coverage for the lifetime scan counter across both scan recording paths, including one-time ring-capacity warnings and cold-start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->