### PR TITLE
fix(pet-147): prove dormant live-rebind handler is host-callable end-to-end

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -325,6 +325,24 @@ re-bind does fire, the pipeline/guard config is process-wide, so it applies to
 every session the process hosts; in-flight sessions see the new shared config at
 their next tool call (the swap does not drain them first).
 
+PET-147 status: the PET-132 re-bind worker is now proven **host-callable
+end-to-end**, not just call-correct. An in-process host-stub test
+(`test_hermes_signal_triggers_rebind_end_to_end`) registers the plugin against a
+fake Hermes ctx, captures the `on_profile_change` handler the way a real host
+would, fires it, and asserts the live pipeline actually retargets (fail_mode and
+egress set move to the new profile, and the binding line re-emits naming it). A
+companion test (`test_unregistered_host_still_degrades_to_restart`) proves the
+inverse at the tool-call level: a host that rejects the hook leaves no handler to
+fire, so the pipeline stays pinned to the boot profile until a restart. This
+closes the Petasos-side verification gap; it does **not** make live re-bind work
+in production. The sole remaining gate is the external, operator-trusted Hermes
+emitter that fires `on_profile_change` from the trusted swap path (never from the
+agent-writable `active_profile`); until Hermes ships it, the restart contract
+above stays the only supported way to change a security-bearing gateway's
+profile. The assumed signal contract is pinned (`on_profile_change(profile_name,
+profile_home)`, `profile_home` an existing absolute dir); reconciling it to the
+real Hermes name and payload is tracked on the Hermes-side work item.
+
 ### The source-taint egress fence is verbatim, defense-in-depth (PET-134)
 
 `source_taint_namespaces` adds a content-agnostic egress fence: once a tool in a

--- a/tests/test_profile_rebind.py
+++ b/tests/test_profile_rebind.py
@@ -137,16 +137,31 @@ def _wire_live(
 
 
 class _FakeCtx:
-    """Minimal Hermes plugin ctx; captures registered hook names and can reject some."""
+    """Minimal Hermes plugin ctx; captures registered hook names and, additively (PET-147),
+    the handler objects so a test can FIRE a registered hook the way a real host would.
+
+    ``registered: list[str]`` and its ``register_hook`` append are load-bearing for existing
+    consumers (``.count(...)`` / ``set(...)``) and stay unchanged. ``handlers`` is the additive
+    firing capability: the handler is stored ONLY on the success path, after the reject-guard,
+    so a rejected hook appears in neither ``registered`` nor ``handlers`` (D-FAKECTX-ADDITIVE)."""
 
     def __init__(self, reject: set[str] | None = None) -> None:
         self.registered: list[str] = []
+        self.handlers: dict[str, object] = {}
         self._reject = reject or set()
 
     def register_hook(self, name: str, handler: object) -> None:
         if name in self._reject:
             raise ValueError(f"unknown hook: {name!r}")
         self.registered.append(name)
+        self.handlers[name] = handler  # PET-147: success path only (after the reject-guard)
+
+    def fire(self, name: str, **payload: Any) -> None:
+        """Invoke a registered hook exactly as a real Hermes host would. Raises ``KeyError``
+        if ``name`` was never registered, so a test cannot fire a phantom hook (PET-147)."""
+        handler = self.handlers[name]  # KeyError on an unregistered name
+        assert callable(handler)  # narrow object -> callable for mypy --strict; always true here
+        handler(**payload)
 
 
 @pytest.fixture(autouse=True)
@@ -482,6 +497,39 @@ def test_register_idempotent_rebind(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert ref._config.get("fail_mode") == "closed"
 
 
+def test_forced_rediscovery_rebinds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-147 (mechanism (b)): the forced-rediscovery PRODUCTION trigger — a
+    # single re-runnable register() under the new profile's env, with init already complete —
+    # re-pins AND re-applies X onto the LIVE pipeline. test_register_idempotent_rebind proves
+    # the hook-count invariant but never sets _initialized, so its re-bind takes the init-window
+    # branch and cannot prove live re-apply; this test wires a real pipeline first so register()
+    # routes through _rebind_to_resolution -> _apply_live (the same W->X axis as the E2E test).
+    ref = _import_reference_plugin()
+    w_section = {"enabled": True, "fail_mode": "degraded", "egress_sink_tools": ["w_tool"]}
+    pipe, _guard = _wire_live(ref, monkeypatch, w_section)
+    w_home = _profile_home(tmp_path, "w", w_section)
+    x_home = _profile_home(
+        tmp_path, "x", {"enabled": True, "fail_mode": "closed", "egress_sink_tools": ["x_tool"]}
+    )
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # defensive: first_boot is False
+    monkeypatch.setenv("HERMES_HOME", str(w_home))
+    monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
+    assert pipe.config.fail_mode == "degraded"  # boot-bound to W
+    assert ref._is_egress_sink("w_tool") is True
+
+    # Hermes re-runs discovery under X's env, then re-registers ONCE. _initialized is True and
+    # _init_thread_started is False, so first_boot is False -> register() re-captures X from the
+    # env and routes to _rebind_to_resolution(X) -> live branch -> _apply_live(X).
+    monkeypatch.setenv("HERMES_HOME", str(x_home))
+    ref.register(_FakeCtx())
+
+    assert _same_config(ref._session_resolution.path, x_home)  # re-pinned to X, no leaked W
+    assert pipe.config.fail_mode == "closed"  # X applied through the real loader
+    assert ref._is_egress_sink("x_tool") is True  # X's egress set is live
+    assert ref._is_egress_sink("w_tool") is False  # W's is gone
+    assert reload_mod.read_changed_section(ref._session_resolution) is None  # settled on X
+
+
 # ── observability + attributability ─────────────────────────────────────────────
 
 
@@ -600,6 +648,56 @@ def test_concurrent_rebinds_converge(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert reload_mod._RELOAD_CACHE is None  # not left committed to a superseded profile
 
 
+# ── PET-147: the dormant re-bind handler is host-callable (end-to-end) ──────────
+
+
+def test_hermes_signal_triggers_rebind_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-147: prove the PET-132 re-bind handler is HOST-CALLABLE, not merely
+    # call-correct. The 15 merged vectors call ref._on_profile_change(...) directly; this test
+    # drives the real register() -> captured-handler -> ctx.fire() path a trusted Hermes host
+    # would use, closing the gap between "the handler works when called" and "a host can call
+    # the dormant handler." Posture is asserted via pipe.config (not the armed bit) so a no-op
+    # _apply_live fails the test, mirroring test_rebind_reapplies_full_pipeline_config.
+    ref = _import_reference_plugin()
+    w_section = {"enabled": True, "fail_mode": "degraded", "egress_sink_tools": ["w_tool"]}
+    pipe, _guard = _wire_live(ref, monkeypatch, w_section)
+    w_home = _profile_home(tmp_path, "w", w_section)
+    x_home = _profile_home(
+        tmp_path, "x", {"enabled": True, "fail_mode": "closed", "egress_sink_tools": ["x_tool"]}
+    )
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # defensive: first_boot is False
+    monkeypatch.setenv("HERMES_HOME", str(w_home))
+
+    # first_boot is False (init already done by _wire_live), so register() takes the re-bind
+    # branch: it re-pins to W (a no-move) and registers on_profile_change into ctx.handlers.
+    ctx = _FakeCtx()
+    ref.register(ctx)
+    assert ctx.registered.count("on_profile_change") == 1  # hook registered exactly once
+    assert "on_profile_change" in ctx.handlers  # the capture path the fire() below depends on
+    assert pipe.config.fail_mode == "degraded"  # live pipeline still reflects boot W
+    assert ref._is_egress_sink("w_tool") is True
+
+    # Drive the REAL registered handler the way a trusted host would (NOT ref._on_profile_change
+    # directly — that is what the merged vectors already exercise).
+    with caplog.at_level(logging.INFO, logger="petasos.plugin"):
+        ctx.fire("on_profile_change", profile_name="x", profile_home=str(x_home))
+
+    # Mandatory move assertions: the live pipeline config moved W->X, not just the armed bit.
+    assert _same_config(ref._session_resolution.path, x_home)
+    assert pipe.config.fail_mode == "closed"  # X's pipeline policy is live
+    assert ref._is_egress_sink("x_tool") is True  # X's egress set is live
+    assert ref._is_egress_sink("w_tool") is False  # W's is gone
+    # Settled cache proves _apply_live actually moved (not a CONFIG_STALE no-op from a collision).
+    assert reload_mod.read_changed_section(ref._session_resolution) is None
+    # The re-bind re-emits the greppable binding line naming X (mirrors test_rebind_reemits...).
+    res_lines = [
+        r.getMessage() for r in caplog.records if "PETASOS_ARMED_RESOLUTION" in r.getMessage()
+    ]
+    assert any(str((x_home / "config.yaml").resolve(strict=False)) in m for m in res_lines)
+
+
 # ── the documented interim contract (no Hermes signal yet) ──────────────────────
 
 
@@ -627,3 +725,35 @@ def test_no_trusted_signal_means_restart_required(
         r for r in caplog.records if "register_hook(on_profile_change) rejected" in r.getMessage()
     ]
     assert len(rejected) == 1
+
+
+def test_unregistered_host_still_degrades_to_restart(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for PET-147 (D-NO-DUP-DEGRADE-TEST): the tool-call-level delta over
+    # test_no_trusted_signal_means_restart_required. That test locks the degrade at
+    # REGISTRATION time (_try_register_hook returns False, armed bit intact); this one proves
+    # the degrade is END-TO-END — a host that rejects on_profile_change leaves NO handler for
+    # any host to fire (the test literally cannot ctx.fire it), so the live pipeline stays
+    # pinned to the BOOT profile W until a process restart, which is exactly the hardening.md
+    # §6 contract. Posture is asserted via pipe.config (not a real _pre_tool_call) per the
+    # shared harness preconditions — avoids the cross-loop hazard and an armed-bit false green.
+    ref = _import_reference_plugin()
+    w_section = {"enabled": True, "fail_mode": "degraded", "egress_sink_tools": ["w_tool"]}
+    pipe, _guard = _wire_live(ref, monkeypatch, w_section)
+    w_home = _profile_home(tmp_path, "w", w_section)
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)  # defensive: first_boot is False
+    monkeypatch.setenv("HERMES_HOME", str(w_home))
+    ctx = _FakeCtx(reject={"on_profile_change"})
+
+    ref.register(ctx)  # must not raise
+
+    # Registration-time floor (mirrors the companion test): rejected hook absent, core present.
+    assert "on_profile_change" not in ctx.registered
+    assert "pre_tool_call" in ctx.registered
+    # New delta — the degrade is end-to-end: no handler exists for any host to fire...
+    assert "on_profile_change" not in ctx.handlers
+    # ...and the live pipeline still enforces the BOOT profile W (stuck on W until a restart).
+    assert _same_config(ref._session_resolution.path, w_home)
+    assert pipe.config.fail_mode == "degraded"
+    assert ref._is_egress_sink("w_tool") is True


### PR DESCRIPTION
## Summary
- Proves the PET-132 operator-trusted profile re-bind handler is **host-callable end-to-end**, not just call-correct, with **no production code change** (D-NO-PROD-CHANGE — the handler at `reference_plugin/__init__.py:1532` is already correct).
- Extends the file-local `_FakeCtx` harness additively so a test can fire a registered hook the way a real Hermes host would, then drives the real `register()` → captured-handler → `fire()` path.
- Reconciles the `hardening.md` §6 restart-contract prose: the Petasos half is now verified in-process; the restart contract stays in force until the external Hermes trusted emitter ships.

This is the **Petasos-closeable half** of PET-147 (parent PET-145). The load-bearing live-signal half (Hermes emitting `on_profile_change` from the trusted swap path) is external and tracked on a Hermes/GAV work item per D-SCOPE-SPLIT.

## Two-check interaction
The new E2E test asserts the binding **moves** via `pipe.config` (fail_mode degraded→closed, egress set w→x) plus a settled `read_changed_section`, never via the armed bit alone — so a no-op `_apply_live` fails the test. Its inverse, the degrade test, asserts a rejecting host leaves **no handler to fire**, so the live pipeline stays pinned to the boot profile until a restart (the §6 contract, proven at the tool-call level rather than only at registration time).

## Files changed

| File | Change |
|------|--------|
| `tests/test_profile_rebind.py` | Additive `_FakeCtx.handlers` + `fire()` (handler stored success-path-only, after the reject-guard; `fire` raises `KeyError` on an unregistered name); 3 new tests (`test_hermes_signal_triggers_rebind_end_to_end`, `test_unregistered_host_still_degrades_to_restart`, `test_forced_rediscovery_rebinds`). `registered: list[str]` unchanged. |
| `docs/deployment/hardening.md` | Reconciles §6 with a PET-147 status note: re-bind worker proven host-callable end-to-end; restart contract remains the supported production path until the Hermes emitter ships. |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/test_profile_rebind.py -v` — 18/18 pass (15 merged regression vectors + 3 new)
- [x] `C:/python310/python.exe -m pytest --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 1869 passed, 41 skipped, 1 deselected, 1 xfailed (the deselect is the pre-existing Unicode-13-vs-14 failure, unrelated to PET-147)
- [x] `ruff check .` — clean · `ruff format --check .` — 136 files already formatted
- [x] `mypy --strict .` — Success: no issues found in 136 source files (run under the Hermes venv, Python 3.11.14; `C:\python310` mypy is AppControl-blocked per PET-132)
- [x] Full gate captured: `docs/specs/TODO/PET-147.test-output.txt` (primary tree; `docs/specs/` is gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Hardening documentation now reflects verified profile rebinding capabilities and security constraints for production deployments.

* **Tests**
  * Added comprehensive regression tests for profile rebinding, including dynamic profile updates, signal handling, and secure fallback behaviors when profile changes are restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->