### PR TITLE
fix(pet-143): retire fold_leet from the console config surface

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -26,9 +26,9 @@ The editor shows 11 sections, in this render order:
 10. Alerting
 11. Session Management
 
-Together these cover 61 editable fields.
+Together these cover 60 editable fields.
 
-<!-- petasos-doc-assert: config_field_count=61 -->
+<!-- petasos-doc-assert: config_field_count=60 -->
 
 Each field below is named exactly as it appears in config files and the editor.
 Where a field has a safe range or a fixed set of choices, it is given.
@@ -176,16 +176,12 @@ operators leave this on as-is.*
 - `detect_rtl_override`: flag characters that reverse the reading direction of
   text, a trick that disguises content by displaying it backwards. This only
   raises the flag; the actual removal is handled by `strip_zero_width`.
-- `fold_leet`: add a decoded copy of leetspeak text (such as "1gn0r3" for
-  "ignore") for the injection rules to check; the original is never altered. Note
-  that the built-in syntactic scanner always decodes leetspeak regardless of this
-  toggle, which affects only direct `normalize()` callers.
 - `decode_encoded_payloads`: decode and rescan base64, hex, and ROT13 blobs so a
   wrapped injection is caught at full severity instead of slipping through as a
-  low-priority flag. Unlike `fold_leet`, turning this off does disable the decode
-  stage inside the syntactic scanner, reopening the encoded-payload gap. Decoding
-  is bounded by size, count, and depth caps, so it adds no false positives on
-  ordinary encoded data.
+  low-priority flag. Unlike leetspeak decoding (which is always on), turning this
+  off does disable the decode stage inside the syntactic scanner, reopening the
+  encoded-payload gap. Decoding is bounded by size, count, and depth caps, so it
+  adds no false positives on ordinary encoded data.
 
 ## 7. Escalation Tiers
 
@@ -304,17 +300,20 @@ deployments.*
 
 ## Advanced: not in the Config Editor
 
-One field of the runtime configuration is deliberately not exposed in the editor,
-so do not conclude this page is incomplete if you cannot find it:
+Two fields of the runtime configuration are deliberately not exposed in the
+editor, so do not conclude this page is incomplete if you cannot find them:
 
 - `session_secret`: the secret used to bind and verify session identity. It is
-  excluded from the editor by design (it is the single field in the difference
-  between the full runtime config and the editor's field set) and is set out of
-  band, not through the UI.
+  excluded from the editor by design (a secret, never sent to the UI) and is set
+  out of band, not through the UI.
+- `fold_leet`: retained in the runtime config for direct `normalize()` callers but
+  not exposed in the editor, because leetspeak decoding is always on in the
+  built-in scanner (PET-97 Decision 6), so the flag cannot change detection. It is
+  not a live operator control (PET-143).
 
 ---
 
 <!-- Drift-guard index: the full set of editor-surfaced field names documented
      above. Kept in sync with petasos.console._config_meta._FIELD_META by
      tests/test_docs_usage_consistency.py. -->
-<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,detect_rtl_override,fold_leet,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones,source_taint_namespaces,taint_min_span_length -->
+<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,detect_rtl_override,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones,source_taint_namespaces,taint_min_span_length -->

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -51,11 +51,17 @@ class PetasosConfig:
     strip_zero_width: bool = True
     map_homoglyphs: bool = True
     detect_rtl_override: bool = True
+    # By design not a detection control: leet folding is an always-on syntactic
+    # posture (PET-97 Decision 6) and the built-in scanner re-folds internally with
+    # hardcoded defaults regardless of this flag. Retained for normalize()-parity
+    # (direct callers and tests); not surfaced as a console control (PET-143).
     fold_leet: bool = True
     # Decode-and-rescan reversible encodings (base64/hex/ROT13) inside the
-    # built-in syntactic scanner (PET-98). Unlike fold_leet, this toggle is
-    # threaded into MinimalScanner's constructor, so turning it off genuinely
-    # disables the decode stage in every pipeline build path.
+    # built-in syntactic scanner (PET-98). Leet folding above is an intentional
+    # always-on syntactic posture (not threaded into the scanner by design, no
+    # longer a console control); decode_encoded_payloads, by contrast, IS threaded
+    # into MinimalScanner's constructor, so turning it off genuinely disables the
+    # decode stage in every pipeline build path.
     decode_encoded_payloads: bool = True
 
     # Scanning

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -71,31 +71,17 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         ),
         "section": "normalization",
     },
-    "fold_leet": {
-        "description": (
-            "Decode common leetspeak substitutions (1→i/l, 3→e, @→a, …) for rule matching."
-        ),
-        "help_plain": (
-            'Adds a decoded copy of leetspeak text (like "1gn0r3" for "ignore") for the'
-            " injection rules to check. The original text is never altered — the decoded"
-            " copy is used only for matching, so version numbers and code stay intact."
-            " Note: the built-in syntactic scanner always decodes leetspeak regardless of"
-            " this setting; this toggle affects only direct normalize() callers, so"
-            " turning it off does not disable leet detection."
-        ),
-        "section": "normalization",
-    },
     "decode_encoded_payloads": {
         "description": ("Decode base64/hex/ROT13 blobs and rescan the plaintext for injections."),
         "help_plain": (
             "Catches attacks hidden inside encoded blobs — a base64-, hex-, or"
             ' ROT13-wrapped "ignore all previous instructions" is decoded and rescanned,'
             " so it is caught at full severity instead of slipping through as a low-priority"
-            " encoding flag. Unlike the leetspeak setting above, turning this off DOES"
-            " disable the decode stage inside the built-in syntactic scanner, reopening the"
-            " encoded-payload gap. Decoding is bounded (size, count, and depth caps) and"
-            " only ever raises a flag on a real injection, so it adds no false positives on"
-            " ordinary encoded data."
+            " encoding flag. Unlike leetspeak decoding (which is always on), turning this"
+            " off DOES disable the decode stage inside the built-in syntactic scanner,"
+            " reopening the encoded-payload gap. Decoding is bounded (size, count, and depth"
+            " caps) and only ever raises a flag on a real injection, so it adds no false"
+            " positives on ordinary encoded data."
         ),
         "section": "normalization",
     },
@@ -669,7 +655,13 @@ _FIELD_META: dict[str, dict[str, Any]] = {
     },
 }
 
-_EXCLUDED_FIELDS = frozenset({"session_secret"})
+# Fields deliberately kept off the Config Editor surface. Two distinct rationales:
+# `session_secret` is a secret kept off the wire (never serialized to the UI);
+# `fold_leet` is a retired no-op control (PET-143): leet folding is always-on by
+# design (PET-97 Decision 6), so surfacing the flag would advertise a knob that
+# cannot move a detection outcome. The field is retained on PetasosConfig for
+# normalize()-parity but is not bindable here.
+_EXCLUDED_FIELDS = frozenset({"session_secret", "fold_leet"})
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/petasos/console/_presets.py
+++ b/petasos/console/_presets.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from petasos.config import PetasosConfig
 
-# D8: the preset-owned field set. Exactly these 13 config-level *strictness*
+# D8: the preset-owned field set. Exactly these 12 config-level *strictness*
 # fields participate in every preset bundle and in the Custom comparator.
 # Deliberately excluded: the scanner circuit-breaker timing fields (reliability,
 # not strictness) and the profile-axis levers (`confidence_floor`,
@@ -46,7 +46,6 @@ _PRESET_OWNED_FIELDS: Final[frozenset[str]] = frozenset(
         "strip_zero_width",
         "map_homoglyphs",
         "detect_rtl_override",
-        "fold_leet",
         "decode_encoded_payloads",
     }
 )
@@ -104,8 +103,8 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
         "Tin",
         0,
         "Loosest temper. Fail-open if an ML scanner breaks, tool-call guard off, "
-        "and the higher-false-positive transforms (RTL, leet, encoded-payload "
-        "decode) relaxed. Escalates latest. The always-on syntactic pre-filter "
+        "and the higher-false-positive transforms (RTL, encoded-payload decode) "
+        "relaxed. Escalates latest. The always-on syntactic pre-filter "
         "still runs and Tier-3 still terminates at the floor.",
         {
             "fail_mode": "open",
@@ -119,7 +118,6 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
             "strip_zero_width": True,
             "map_homoglyphs": True,
             "detect_rtl_override": False,
-            "fold_leet": False,
             "decode_encoded_payloads": False,
         },
     ),
@@ -141,7 +139,6 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
             "strip_zero_width": True,
             "map_homoglyphs": True,
             "detect_rtl_override": True,
-            "fold_leet": True,
             "decode_encoded_payloads": True,
         },
     ),
@@ -164,7 +161,6 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
             "strip_zero_width": True,
             "map_homoglyphs": True,
             "detect_rtl_override": True,
-            "fold_leet": True,
             "decode_encoded_payloads": True,
         },
     ),
@@ -186,7 +182,6 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
             "strip_zero_width": True,
             "map_homoglyphs": True,
             "detect_rtl_override": True,
-            "fold_leet": True,
             "decode_encoded_payloads": True,
         },
     ),
@@ -208,7 +203,6 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
             "strip_zero_width": True,
             "map_homoglyphs": True,
             "detect_rtl_override": True,
-            "fold_leet": True,
             "decode_encoded_payloads": True,
         },
     ),

--- a/tests/adversarial/normalization/test_unicode_bypass.py
+++ b/tests/adversarial/normalization/test_unicode_bypass.py
@@ -251,13 +251,21 @@ async def test_lossy_leet_not_claimed_by_syntactic() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fold_leet_config_false_still_detects() -> None:
-    """PET-97 Decision 6: the always-on syntactic pre-filter decodes leet
-    regardless of the config toggle — fold_leet=False gates only the
-    pipeline-level normalize() call, whose views nothing consumes today. A
-    future refactor that threads normalize flags into MinimalScanner must
-    consciously flip this pin."""
-    # Regression for PET-97: always-on enforcement posture under fold_leet=False
-    result = await _leet_pipeline(fold_leet=False).inspect(_FAITHFUL_LEET, direction="inbound")
-    rule_ids = {f.rule_id for f in result.findings}
-    assert "petasos.syntactic.injection.ignore-previous" in rule_ids
+async def test_fold_leet_not_a_detection_control() -> None:
+    """PET-143 (ratifies PET-97 Decision 6): leet folding is, by design, an
+    always-on syntactic posture, so the PetasosConfig.fold_leet toggle is not a
+    detection control. The built-in scanner re-folds internally with hardcoded
+    defaults; fold_leet gates only the pipeline-level normalize() call, whose
+    views nothing consumes. Detection is identical under fold_leet=True and
+    fold_leet=False. A future refactor that threads normalize flags into
+    MinimalScanner must consciously flip this pin."""
+    # Regression for PET-143: fold_leet is not a detection control (True == False).
+    # The fold_leet=True arm is an explicit positive control at the call site (not
+    # the helper default), so a future change to the _leet_pipeline default cannot
+    # silently turn this into a second negative arm.
+    on = await _leet_pipeline(fold_leet=True).inspect(_FAITHFUL_LEET, direction="inbound")
+    off = await _leet_pipeline(fold_leet=False).inspect(_FAITHFUL_LEET, direction="inbound")
+    on_rules = {f.rule_id for f in on.findings}
+    off_rules = {f.rule_id for f in off.findings}
+    assert "petasos.syntactic.injection.ignore-previous" in on_rules
+    assert "petasos.syntactic.injection.ignore-previous" in off_rules

--- a/tests/adversarial/normalization/test_unicode_bypass.py
+++ b/tests/adversarial/normalization/test_unicode_bypass.py
@@ -268,4 +268,7 @@ async def test_fold_leet_not_a_detection_control() -> None:
     on_rules = {f.rule_id for f in on.findings}
     off_rules = {f.rule_id for f in off.findings}
     assert "petasos.syntactic.injection.ignore-previous" in on_rules
-    assert "petasos.syntactic.injection.ignore-previous" in off_rules
+    # Full-set equality (not just the headline rule) is what proves the toggle is
+    # inert: any drift in the other findings between the two arms reds this. The
+    # positive control above keeps it non-vacuous (both arms must actually fire).
+    assert on_rules == off_rules

--- a/tests/js/preset-dial.test.mjs
+++ b/tests/js/preset-dial.test.mjs
@@ -123,19 +123,19 @@ const IRON = {
   fail_mode: "degraded", tier1_threshold: 15, tier2_threshold: 30, tier3_threshold: 50,
   presidio_score_threshold: 0.35, anonymize: false, tool_guard_enabled: true,
   normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
-  detect_rtl_override: true, fold_leet: true, decode_encoded_payloads: true,
+  detect_rtl_override: true, decode_encoded_payloads: true,
 };
 const BRONZE = {
   fail_mode: "degraded", tier1_threshold: 25, tier2_threshold: 45, tier3_threshold: 65,
   presidio_score_threshold: 0.5, anonymize: false, tool_guard_enabled: true,
   normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
-  detect_rtl_override: true, fold_leet: true, decode_encoded_payloads: true,
+  detect_rtl_override: true, decode_encoded_payloads: true,
 };
 const TIN = {
   fail_mode: "open", tier1_threshold: 40, tier2_threshold: 60, tier3_threshold: 80,
   presidio_score_threshold: 0.6, anonymize: false, tool_guard_enabled: false,
   normalize_nfkc: true, strip_zero_width: true, map_homoglyphs: true,
-  detect_rtl_override: false, fold_leet: false, decode_encoded_payloads: false,
+  detect_rtl_override: false, decode_encoded_payloads: false,
 };
 function presets() {
   return [

--- a/tests/test_config_meta.py
+++ b/tests/test_config_meta.py
@@ -6,6 +6,7 @@ import pytest
 
 from petasos.config import _SECRET_FIELDS, PetasosConfig
 from petasos.console._config_meta import (
+    _EXCLUDED_FIELDS,
     _FIELD_META,
     _SECTION_REGISTRY,
     ConfigSection,
@@ -36,12 +37,20 @@ _COMMON_SECTIONS = {"profiles", "anonymization", "fail_mode", "tool_guard", "sca
 
 
 def test_every_field_present() -> None:
-    """Every non-excluded PetasosConfig field appears in metadata."""
+    """Every non-excluded PetasosConfig field appears in metadata; every excluded
+    field is absent.
+
+    The exclusion set is pinned to an authored literal (PET-143) so a field cannot
+    be silently dropped from the console by an unreviewed addition to
+    _EXCLUDED_FIELDS: driving this test off the set alone would let an unintended
+    exclusion pass green, so the literal is the silent-drop tripwire.
+    """
+    assert frozenset({"session_secret", "fold_leet"}) == _EXCLUDED_FIELDS
     meta = generate_config_metadata()
     meta_names = {m["name"] for m in meta}
     for f in dataclasses.fields(PetasosConfig):
-        if f.name == "session_secret":
-            assert f.name not in meta_names, "session_secret should be excluded"
+        if f.name in _EXCLUDED_FIELDS:
+            assert f.name not in meta_names, f"{f.name} should be excluded"
         else:
             assert f.name in meta_names, f"Field {f.name!r} missing from metadata"
 
@@ -50,6 +59,15 @@ def test_session_secret_excluded() -> None:
     meta = generate_config_metadata()
     names = {m["name"] for m in meta}
     assert "session_secret" not in names
+
+
+def test_config_meta_omits_fold_leet() -> None:
+    # Regression for PET-143: fold_leet is retired from the console surface (an
+    # always-on syntactic posture, not a live operator control), so it must not
+    # appear among the generated config-metadata field names.
+    meta = generate_config_metadata()
+    names = {m["name"] for m in meta}
+    assert "fold_leet" not in names
 
 
 def test_bool_type_derivation() -> None:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -20,7 +20,7 @@ from petasos.console._presets import (
 )
 from petasos.scanners.minimal import _UNSUPPRESSIBLE_RULE_IDS, MinimalScanner
 
-# The exact owned-field set (D8): 13 config-level strength fields, no reliability
+# The exact owned-field set (D8): 12 config-level strength fields, no reliability
 # or profile levers. Pinned here so a drift in either the registry or the
 # allowlist is caught.
 _EXPECTED_OWNED_FIELDS = frozenset(
@@ -36,7 +36,6 @@ _EXPECTED_OWNED_FIELDS = frozenset(
         "strip_zero_width",
         "map_homoglyphs",
         "detect_rtl_override",
-        "fold_leet",
         "decode_encoded_payloads",
     }
 )
@@ -111,7 +110,10 @@ def test_all_presets_cover_same_fields() -> None:
     # Symmetric comparator: each preset's key set equals _PRESET_OWNED_FIELDS,
     # which equals the pinned expected set.
     assert _PRESET_OWNED_FIELDS == _EXPECTED_OWNED_FIELDS
-    assert len(_PRESET_OWNED_FIELDS) == 13
+    assert len(_PRESET_OWNED_FIELDS) == 12
+    # Regression for PET-143: fold_leet retired from the preset surface, so no
+    # preset can imply leet-off (leet folding is always-on by design).
+    assert "fold_leet" not in _PRESET_OWNED_FIELDS
     for preset in _PRESET_REGISTRY:
         assert set(preset.overrides.keys()) == _PRESET_OWNED_FIELDS, preset.key
 


### PR DESCRIPTION
## Summary
- Resolves PET-143 on the record: `fold_leet` is **not** load-bearing, by design. Leet decoding is an always-on syntactic posture (PET-97 Decision 6); the `PetasosConfig.fold_leet` toggle cannot move a detection outcome because the syntactic scanner re-normalizes internally with `fold_leet=True` hardcoded.
- Retires `fold_leet` from the three user-facing surfaces (presets, console config-meta registry, user doc) so the config surface no longer advertises a no-op knob. **Zero detector change.**
- Keeps the `PetasosConfig.fold_leet` field, its `_BOOL_FIELDS` membership, and the `normalize()` parameter as the legitimate programmatic surface (published-package field; the headline regression test constructs it).

## Layered honesty edit (no detector change)
1. **Console config-meta** (`_config_meta.py`): drops the `fold_leet` `_FIELD_META` entry and adds `"fold_leet"` to `_EXCLUDED_FIELDS` (reuses the existing exclusion mechanism, with a two-rationale comment separating the `session_secret` secret-redaction case from this retired-control case). `generate_config_metadata()` skips excluded fields, so the frontend stops receiving `fold_leet`.
2. **Presets** (`_presets.py`): removes `fold_leet` from `_PRESET_OWNED_FIELDS` (13 to 12) and from every preset body, so the Tin preset no longer implies leet-off; fixes the Tin description and count comment.
3. **Config dataclass** (`config.py`): retains the field; annotates it as not-a-detection-control; reframes the `decode_encoded_payloads` contrast comment that referenced `fold_leet`.
4. **User doc** (`configuration.md`): moves `fold_leet` to "Advanced: not in the Config Editor", decrements the prose count and `config_field_count` marker (61 to 60), drops it from the `config_fields` drift-guard CSV, and rewords the `decode_encoded_payloads` and `session_secret` cross-references.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_config_meta.py` | Removes `fold_leet` registry entry; adds it to `_EXCLUDED_FIELDS`; rewrites decode cross-reference |
| `petasos/console/_presets.py` | Drops `fold_leet` from owned-set + 5 preset bodies; fixes Tin prose/count |
| `petasos/config.py` | Annotates retained `fold_leet` field; reframes decode contrast comment |
| `docs/usage/configuration.md` | Moves `fold_leet` to Advanced; counts 61 to 60; CSV + decode/session_secret rewording |
| `tests/test_config_meta.py` | Drives `test_every_field_present` off `_EXCLUDED_FIELDS` + literal pin; adds `test_config_meta_omits_fold_leet` |
| `tests/test_presets.py` | Owned-set 13 to 12; explicit `fold_leet not in _PRESET_OWNED_FIELDS` retirement pin |
| `tests/adversarial/normalization/test_unicode_bypass.py` | Renames the PET-97 pin to `test_fold_leet_not_a_detection_control` + explicit `fold_leet=True` positive control |
| `tests/js/preset-dial.test.mjs` | Drops `fold_leet` from IRON/BRONZE/TIN fixtures |

## Test plan
- [x] `python -m pytest tests/ -p no:cacheprovider --deselect "tests/test_console_validation.py::test_default_ignorable_rejected"` (pinned C:\python310, 3.10.6) — **1867 passed, 41 skipped, 1 deselected, 1 xfailed**
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 136 files already formatted
- [x] `mypy --strict .` — Success, no issues in 136 source files
- [x] `node --test tests/js/preset-dial.test.mjs` — 14/14 pass
- [x] PET-128 drift guard `test_docs_config_sections_match_meta` green (doc field set + count reconcile to the 60-entry `_FIELD_META`)

Deselect note: `test_default_ignorable_rejected` is a pre-existing Unicode-13-vs-14 environmental failure on the local 3.10 interpreter (fails on clean master too), unrelated to PET-143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration and guidance text to clarify leetspeak handling is always enabled, while `decode_encoded_payloads` governs whether the decode-and-rescan step runs.

* **Console Config Editor / Presets**
  * Removed `fold_leet` from Config Editor field exposure.
  * Updated built-in strength presets so the active-preset/tuning dial no longer includes `fold_leet`.

* **Tests**
  * Strengthened coverage by verifying identical detection outcomes across `fold_leet` on/off and updating preset fixture expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->