### PR TITLE
fix(pet-129): token-aware served console (in-UI entry, 401 degradation, banner honesty, poll-stop)

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -273,7 +273,7 @@ Operational notes:
   and a "clear token" affordance drops the credential and returns to the
   authenticate state. An authenticated client or a credential-injecting reverse
   proxy still works for scripted access, for example:
-  `curl -H "Authorization: Bearer <token>" -X POST http://127.0.0.1:8384/api/armed -d '{"armed": true}'`.
+  `curl -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -X POST http://127.0.0.1:8384/api/armed -d '{"armed": true}'`.
 - **Where the token lives in the browser:** the console holds the operator-supplied
   token in `sessionStorage`, so it survives a reload within the tab and is cleared
   when the tab closes. It is no stronger than the operator's browser session: any

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -252,6 +252,10 @@ What it covers, and what it does not:
   the agent's own process environment and is readable by a shell-capable agent
   (which could also just use Vector A). The primary mitigation remains deployment
   posture (config and console out of reach, separate uid or netns).
+- It is most useful when the console is **not** loopback-only. Keep the section 2
+  binding guidance (loopback, or reach it over Tailscale/WireGuard) even with the
+  token on: the token raises the bar for a network-reachable console but does not
+  replace the network posture.
 
 Operational notes:
 
@@ -261,17 +265,27 @@ Operational notes:
 - The token is compared **verbatim**: do not rely on leading or trailing
   whitespace being meaningful, trimmed for you, or preserved in transit.
 - The scheme match is case-sensitive (`Bearer`, not `bearer`).
-- With the token on, the bundled browser UI cannot drive the `/api` routes by
-  plain navigation (it sends no `Authorization` header yet): the shell loads but
-  its panels show errors. Use an authenticated client or a reverse proxy that
-  injects the credential, for example:
+- With the token on, the bundled browser console now drives the `/api` routes
+  itself (PET-129). Opening the served console shows a clear **authenticate** state
+  (not broken tiles, not skeletons): enter the token in the unlock field and all
+  panels (config, scan, scan-history, armed, SSE) function. A 401 stops the 10
+  second health and fallback polls and renders an honest banner instead of looping,
+  and a "clear token" affordance drops the credential and returns to the
+  authenticate state. An authenticated client or a credential-injecting reverse
+  proxy still works for scripted access, for example:
   `curl -H "Authorization: Bearer <token>" -X POST http://127.0.0.1:8384/api/armed -d '{"armed": true}'`.
-- **Known limitation until the served-UI follow-up ships:** with the token on,
-  the browser Observability tab still renders the equip banner as EQUIPPED even
-  though its armed read is being 401'd. Do not trust the in-browser banner when
-  the token is on; verify armed state with an authenticated `GET /api/armed`. The
-  follow-up ticket carries in-UI token entry, graceful 401 handling, equip-banner
-  correctness, and stopping the 10 second health/fallback polls on a 401.
+- **Where the token lives in the browser:** the console holds the operator-supplied
+  token in `sessionStorage`, so it survives a reload within the tab and is cleared
+  when the tab closes. It is no stronger than the operator's browser session: any
+  script on the origin can read it for the life of that tab. It is never written to
+  `localStorage` (which would persist a bearer indefinitely), and is never read from
+  the server or environment into the page (the operator supplies it in the browser).
+- **Served-UI follow-up (shipped, PET-129):** in-UI token entry, graceful 401
+  handling, equip-banner correctness (a 401'd armed read shows the authenticate
+  state, never a false EQUIPPED), and poll-stop are now in the browser client. This
+  is convenience plus a bar against a network-only or non-shell caller (Vector B);
+  it is **not** a defense against a shell-capable agent that can read the env or
+  config (Vector A), for which the primary mitigation remains deployment posture.
 - **Forward-looking invariant:** the dependency gates by the `/api/` path prefix,
   so every sensitive route must live under `/api/`. A future non-asset route
   added outside `/api/` would be served unauthenticated.

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -583,11 +583,13 @@
       var token = window.__HERMES_SESSION_TOKEN__;
       if (token) headers["X-Hermes-Session-Token"] = token;
       // PET-129 D1 (edge F-7): sse.connect is the single SSE client for both modes, so
-      // "standalone only" must be explicit here: use the same predicate as _req (no
-      // embedded Hermes plugin SDK). In embedded mode the fetch keeps its
-      // X-Hermes-Session-Token and gains NO Petasos Authorization, so the two
-      // credentials never coexist (the double-credentialing D5 forbids).
-      if (!window.__HERMES_PLUGIN_SDK__) {
+      // "standalone only" must be explicit here. Use the EXACT same embedded predicate
+      // as _req (`sdk && sdk.fetchJSON`), so a partial SDK object lacking fetchJSON is
+      // treated as standalone by both paths (no path divergence). In embedded mode the
+      // fetch keeps its X-Hermes-Session-Token and gains NO Petasos Authorization, so
+      // the two credentials never coexist (the double-credentialing D5 forbids).
+      var _sdk = window.__HERMES_PLUGIN_SDK__;
+      if (!(_sdk && _sdk.fetchJSON)) {
         var _ctok = Pet.token.get();
         if (_ctok) headers["Authorization"] = "Bearer " + _ctok;
       }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -669,8 +669,12 @@
         .catch(function (e) {
           if (gen !== self._gen) return;             // D12
           if (e.name === "AbortError") return;       // deliberate teardown — never reconnect
-          // D9: the terminal (non-retryable) set is exactly {401, 403}. The :422
-          // `throw new Error(resp.status)` makes e.message the status string.
+          // D9: the terminal (non-retryable) set is {401, 403}. PET-129 now intercepts
+          // a 401 upstream in the response handler (-> Pet.auth.on401, the authenticate
+          // state) before it can throw here, so in practice this branch fires for 403;
+          // the 401 arm is kept as belt-and-suspenders so any 401 that did reach here
+          // still concedes rather than reconnect-storms. The `throw new Error(resp.status)`
+          // makes e.message the status string.
           if (e.message === "401" || e.message === "403") {
             console.warn("Petasos SSE: auth rejected (" + e.message + "), using polling fallback");
             self._enableFallback();                  // terminal: a tab that will never re-authorize must not storm

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -342,11 +342,145 @@
     profiles: [],
     about: null,
     armed: true,  // PET-111: master Equipped/Unequipped bit; corrected by the mount fetch
+    // PET-129: first-class terminal "authenticate" state. Set true by Pet.auth.on401
+    // when a standalone /api call returns 401 (PETASOS_CONSOLE_TOKEN gate, PET-125);
+    // distinct from "offline". While true the dashboard renders the authenticate
+    // panel, both polls are stopped, and the banner reads AUTHENTICATE (never a false
+    // EQUIPPED). Cleared only by a verified re-auth (Pet.auth resume).
+    authRequired: false,
     // PET-114: per-session collapse choices { sectionKey: bool }. Written SOLELY
     // by an onToggle (an explicit user collapse/expand) or the apply-error reveal,
     // never seeded on render — so an upgrade from a stale all-expanded payload
     // re-applies each section's real default_collapsed for untouched sections.
     sectionCollapsed: {},
+  };
+
+  // ── PET-129: console token store + 401 auth chokepoint ──
+  // PET-125 shipped an optional, off-by-default PETASOS_CONSOLE_TOKEN Bearer gate on
+  // every standalone /api/* route (server.py:_require_console_token). This client
+  // teaches the browser about that credential: it stores the operator-supplied token
+  // here and attaches it on the standalone path only (D1). The embedded Hermes path
+  // authenticates through its own X-Hermes-Session-Token mount and must never gain a
+  // Petasos bearer (no double-credentialing).
+  //
+  // Persistence is sessionStorage (D2): survives a reload within the tab, dies when
+  // the tab closes; a deliberate middle ground between in-memory (re-enter on every
+  // reload) and localStorage (a long-lived bearer reachable by any script on the
+  // origin indefinitely). The store NEVER throws to its callers: sessionStorage can be
+  // absent (a headless node:vm load) or throw on setItem (private-browsing modes), so
+  // every access is wrapped and falls back to an in-module in-memory value.
+  var _tokenMem = null; // in-memory mirror / fallback when sessionStorage is unusable
+  var _TOKEN_KEY = "petasos.console.token";
+  Pet.token = {
+    get: function () {
+      try {
+        if (typeof sessionStorage !== "undefined" && sessionStorage) {
+          var v = sessionStorage.getItem(_TOKEN_KEY);
+          if (v != null) return v;
+        }
+      } catch (_) {}
+      return _tokenMem;
+    },
+    set: function (value) {
+      var v = value == null ? "" : String(value);
+      _tokenMem = v; // set the in-memory mirror FIRST so a throwing setItem still round-trips
+      try {
+        if (typeof sessionStorage !== "undefined" && sessionStorage) sessionStorage.setItem(_TOKEN_KEY, v);
+      } catch (_) {}
+      // D2 stale-submit guard: every credential change advances the auth generation
+      // so reads issued under a superseded token (their on401 included) are dropped.
+      Pet.auth._gen++;
+    },
+    clear: function () {
+      _tokenMem = null;
+      try {
+        if (typeof sessionStorage !== "undefined" && sessionStorage) sessionStorage.removeItem(_TOKEN_KEY);
+      } catch (_) {}
+      Pet.auth._gen++;
+    },
+  };
+
+  // Pet.auth.on401 is the one transport-agnostic 401 chokepoint (D3). It keys strictly
+  // on `_status === 401` (NOT on `.error`): a FastAPI 401 JSON body is { detail,
+  // _status: 401 } with no `.error` key, so the readers' `if (!d.error)` gate treats it
+  // as an empty success and the stale optimistic state survives. on401 must therefore
+  // be the FIRST statement of every /api reader's `.then`, strictly before any shape
+  // check. Keyed on _status (not "is standalone"), it would also cover a future
+  // embedded 401 without a rewrite (D-EMBEDDED-PARITY, forward-looking).
+  Pet.auth = {
+    _gen: 0, // D2 stale-submit generation counter; bumped on every token set/clear
+
+    on401: function (d) {
+      if (!(d && d._status === 401)) return false;
+      Pet.auth._enterAuthRequired();
+      return true;
+    },
+
+    // Idempotent transition into the authenticate state. Safe to run on every 401 and
+    // shared with the manual "clear token" affordance (D2): stop both polls, drop the
+    // SSE stream (resetting _usingFallback), clear the optimistic armed reassurance so
+    // the banner cannot read EQUIPPED, un-stick the connectivity blip, and re-render.
+    _enterAuthRequired: function () {
+      Pet.state.authRequired = true;
+      stopPolling();
+      stopFallbackPolling();
+      if (Pet.sse) Pet.sse.disconnect(); // aborts SSE, resets _usingFallback, stops the fallback poll
+      _armedSeeded = false;   // force a re-seed from server truth after re-auth (edge F-3)
+      _historySeeded = false; // ditto for the scan-history buffer
+      Pet.state.armed = null; // unknown until a verified read; bannerView keys authRequired first regardless
+      if (Pet.updateConnStatus) Pet.updateConnStatus(); // F-8: don't leave the blip stuck on POLLING
+      if (_container && Pet.renderDashboard) Pet.renderDashboard(_container);
+    },
+
+    // D2: store the submitted token and run the D4 resume sequence. Called by the
+    // authenticate panel's Unlock control; returns a promise of { ok, message? } so a
+    // wrong/transient result can re-enable the control with a reason.
+    submitToken: function (value) {
+      Pet.token.set(value); // bumps _gen
+      return Pet.auth._resume();
+    },
+
+    // D2: explicit "clear token" affordance. Runs the SAME idempotent teardown as
+    // on401 (not a mere panel swap) so a manual clear cannot leave polls running or
+    // flash a stale EQUIPPED banner (edge F-9).
+    clearToken: function () {
+      Pet.token.clear(); // bumps _gen
+      Pet.auth._enterAuthRequired();
+    },
+
+    // D4 re-auth resume. Verification read mirrors the mount sequence (getArmed, then
+    // getHealth). The captured generation (D2) gates reconciliation: a response from a
+    // superseded token (including its 401) is dropped, so a wrong-then-correct
+    // double-submit cannot let the wrong token's stale 401 tear down the correct
+    // token's session (edge F-6). authRequired is cleared ONLY after the verification
+    // read returns a non-401, well-shaped body (not optimistically on submit).
+    _resume: function () {
+      var gen = Pet.auth._gen;
+      _armedSeeded = false;   // re-derive from server truth, regardless of any stray frame (edge F-3)
+      _historySeeded = false;
+      return Pet.api.getArmed().then(function (d) {
+        if (gen !== Pet.auth._gen) return { ok: false, stale: true }; // superseded; drop (incl. a stale 401)
+        if (d && d._status === 401) return { ok: false, message: "Authentication failed. Check the token and retry." };
+        // round-2 edge F-3: a transient non-401 error (no boolean armed) keeps the
+        // authenticate state and re-enables the control with a distinct message.
+        if (!(d && typeof d.armed === "boolean")) return { ok: false, message: "Could not verify the token (transient error). Retry." };
+        Pet.state.authRequired = false;
+        Pet.state.armed = d.armed; // seed from the authenticated read, not the stale default
+        _armedSeeded = true;       // armed is verified; skip the dashboard's mount re-fetch
+        return Pet.api.getHealth().then(function (h) {
+          if (gen === Pet.auth._gen && h && !h.error && h._status !== 401) {
+            _healthLoaded = true;
+            Pet.state.scannerHealth = h.scanners || [];
+            Pet.state.pipelineHealth = h.pipeline || null;
+          }
+          startPolling();
+          if (Pet.sse && Pet.sse.connect) Pet.sse.connect();
+          if (Pet.updateConnStatus) Pet.updateConnStatus();
+          if (_container && Pet.renderDashboard) Pet.renderDashboard(_container);
+          return { ok: true };
+        });
+      });
+    },
   };
 
   // ── API client ──
@@ -368,6 +502,18 @@
             }
             return { error: msg };
           });
+      }
+      // PET-129 D1: attach the optional console bearer on the standalone path only
+      // (this branch is reached only when there is no embedded Hermes SDK above). Sent
+      // verbatim as "Bearer " + token to match the server's case-sensitive scheme check
+      // and its hmac.compare_digest verbatim comparison (server.py). Shallow-copy so a
+      // caller's opts/headers literal (e.g. _post's { "Content-Type": ... }) is
+      // preserved and never mutated; tolerate opts === undefined (_get passes none).
+      // No token -> no Authorization key at all (byte-for-byte the token-off request).
+      var _tok = Pet.token.get();
+      if (_tok) {
+        opts = Object.assign({}, opts);
+        opts.headers = Object.assign({}, opts.headers, { Authorization: "Bearer " + _tok });
       }
       return fetch(url, opts).then(function (r) {
         return r.json().then(function (data) {
@@ -436,6 +582,15 @@
       var headers = { "Accept": "text/event-stream" };
       var token = window.__HERMES_SESSION_TOKEN__;
       if (token) headers["X-Hermes-Session-Token"] = token;
+      // PET-129 D1 (edge F-7): sse.connect is the single SSE client for both modes, so
+      // "standalone only" must be explicit here: use the same predicate as _req (no
+      // embedded Hermes plugin SDK). In embedded mode the fetch keeps its
+      // X-Hermes-Session-Token and gains NO Petasos Authorization, so the two
+      // credentials never coexist (the double-credentialing D5 forbids).
+      if (!window.__HERMES_PLUGIN_SDK__) {
+        var _ctok = Pet.token.get();
+        if (_ctok) headers["Authorization"] = "Bearer " + _ctok;
+      }
 
       self._abortCtrl = new AbortController();
       fetch(url, {
@@ -445,6 +600,13 @@
       })
         .then(function (resp) {
           if (gen !== self._gen) return;             // D12: superseded connection — drop silently
+          // PET-129 D4: a 401 here is the auth-required terminal state, NOT transient
+          // offline. Route it to the chokepoint (which stops the polls + disconnects,
+          // cancelling PET-142's reconnect) instead of letting it fall to the .catch
+          // reconnect, which would re-open and 401 forever. Genuine offline (a network
+          // reject or a non-401 non-ok status) still throws below -> the .catch keeps
+          // PET-142's bounded-backoff reconnect, so the live/polling indicator is intact.
+          if (resp.status === 401) { Pet.auth.on401({ _status: 401 }); return; }
           if (!resp.ok) throw new Error(resp.status);
           if (!resp.body) throw new Error("no response body");
           var reader = resp.body.getReader();
@@ -583,6 +745,11 @@
         // authoritative pushed value into Pet.state.armed and re-renders, mirroring
         // the scan_result arm. renderDashboard rebuilds the banner from
         // Pet.state.armed and re-runs its per-entry seed guard.
+        // PET-129 (edge F-3): a buffered armed frame racing the 401 teardown must not
+        // mutate armed/_armedSeeded while authentication is required (it would re-seed
+        // a false EQUIPPED via a side channel). Bail first; resume re-derives from
+        // server truth, and bannerView keys on authRequired regardless.
+        if (Pet.state.authRequired) return;
         if (_armedBusy) return;                 // don't clobber this tab's in-flight optimistic toggle
         if (d && typeof d.armed === "boolean") {
           Pet.state.armed = d.armed;            // adopt file-truth pushed by the originating tab
@@ -619,6 +786,7 @@
     if (_pollInterval) return;
     _pollInterval = setInterval(function () {
       Pet.api.getHealth().then(function (d) {
+        if (Pet.auth.on401(d)) return; // PET-129 D3/D4: first statement; a 401 stops the poll, never an empty-success no-op
         if (!d.error) {
           _healthLoaded = true;  // PET-127: a poll settle that beats a slow in-render fetch flips the gate, not the skeleton
           Pet.state.scannerHealth = d.scanners || [];
@@ -637,6 +805,7 @@
     function schedule() {
       _fallbackPollInterval = setTimeout(function () {
         Pet.api.getScanHistory(100).then(function (d) {
+          if (Pet.auth.on401(d)) return; // PET-129 D4: on401 nulls _fallbackPollInterval before the reschedule .then runs, so the re-arm below no-ops
           if (!d.error && d.entries && Array.isArray(d.entries)) {
             Pet.state.scanHistory = d.entries;
             Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
@@ -648,6 +817,7 @@
       }, 10000);
     }
     Pet.api.getScanHistory(100).then(function (d) {
+      if (Pet.auth.on401(d)) return; // PET-129 D4: a 401 on the initial fallback read enters the authenticate state
       if (!d.error && d.entries && Array.isArray(d.entries)) {
         Pet.state.scanHistory = d.entries;
         Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
@@ -659,6 +829,20 @@
   function stopFallbackPolling() {
     if (_fallbackPollInterval) { clearTimeout(_fallbackPollInterval); _fallbackPollInterval = null; }
   }
+
+  // PET-129 D4: read-only testability seam over the module-private poll timers
+  // (PET-103 D9 / scanner-health-help style: exposes state, adds no behavior).
+  // startHealth/startFallback are thin wrappers so the headless node:vm harness can
+  // start each poll directly (the health poll is otherwise reachable only through
+  // Pet.mount, which the DOM shim cannot drive), making the poll-stop assertion
+  // load-bearing rather than vacuously green. state() is the read-only probe.
+  Pet._poll = {
+    startHealth: function () { startPolling(); },
+    startFallback: function () { startFallbackPolling(); },
+    state: function () { return { health: !!_pollInterval, fallback: !!_fallbackPollInterval }; },
+  };
+  // Convenience alias for the read-only probe (some call sites reference Pet._pollState).
+  Pet._pollState = Pet._poll.state;
 
   // ── Surface renderers ──
 
@@ -1088,37 +1272,153 @@
     return buffer;
   };
 
+  // PET-129 D3: pure banner label/sub/class decision, authRequired-FIRST. Extracted
+  // from paintBanner so the headless node:vm harness (no querySelector) can assert the
+  // decision directly. When authRequired is set, the banner renders an explicit
+  // AUTHENTICATE state and NEVER EQUIPPED, regardless of the optimistic armed default
+  // (closes defect #2). The non-auth branch is byte-for-byte today's paintBanner logic
+  // for a boolean armed value (no-regression for the token-off path).
+  Pet.bannerView = function (state) {
+    state = state || {};
+    if (state.authRequired) {
+      return {
+        label: "AUTHENTICATE",
+        sub: "Enter the console token to view enforcement state",
+        cls: "equip-banner unknown",
+        on: false,
+        confirming: false,
+        authRequired: true,
+      };
+    }
+    var on = state.armed !== false && state.armed != null;
+    var confirming = on && !!state.confirming;
+    return {
+      label: confirming ? "CONFIRM UNEQUIP?" : (on ? "EQUIPPED" : "UNEQUIPPED"),
+      sub: confirming
+        ? "Click again to disable all enforcement"
+        : (on ? "Enforcement is ON" : "Enforcement is OFF for every session"),
+      cls: "equip-banner" + (on ? "" : " disarmed") + (confirming ? " confirming" : ""),
+      on: on,
+      confirming: confirming,
+      authRequired: false,
+    };
+  };
+
+  // PET-129 D2: the authenticate panel rendered (instead of the dashboard tiles) while
+  // Pet.state.authRequired is set. Shows the honest banner (bannerView authRequired ->
+  // AUTHENTICATE, never EQUIPPED), a token field + Unlock submit, and an explicit
+  // "clear token" affordance. Crucially it issues NO /api reads, so a token-gated
+  // console renders a clear authenticate state rather than 401-looping broken tiles.
+  // The submit runs the D4 resume sequence with the stale-submit generation guard; the
+  // control is disabled while a resume is in flight and re-enabled with a reason on a
+  // wrong/transient result. Clear runs the same idempotent teardown as on401 (F-9).
+  Pet.renderAuthPanel = function () {
+    var view = Pet.bannerView({ authRequired: true });
+    var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "16px", height: "100%" } });
+
+    wrapper.appendChild(Pet.h("div", { className: view.cls },
+      Pet.h("img", { className: "equip-mark", src: Pet.asset("img/petasos-unequipped.png"), alt: "" }),
+      Pet.h("div", { className: "equip-text" },
+        Pet.h("div", { className: "equip-label" }, view.label),
+        Pet.h("div", { className: "equip-sub" }, view.sub)
+      )
+    ));
+
+    var msg = Pet.h("div", { className: "mono", style: { fontSize: "12px", color: "var(--tx-faint)", minHeight: "16px" } });
+    var input = Pet.h("input", {
+      type: "password", placeholder: "Console token", ariaLabel: "Console token",
+      style: {
+        flex: "1", minWidth: "0", padding: "10px 12px", borderRadius: "var(--r-panel)",
+        background: "var(--bg-panel)", border: "1px solid var(--border)",
+        color: "var(--tx)", fontFamily: "var(--font-mono)", fontSize: "13px"
+      }
+    });
+    var submitBtn = Pet.h("button", {
+      type: "button", className: "btn",
+      style: { padding: "10px 16px", whiteSpace: "nowrap" }
+    }, "Unlock");
+    var clearBtn = Pet.h("button", {
+      type: "button", className: "btn",
+      style: { padding: "8px 12px", fontSize: "12px", alignSelf: "flex-start", color: "var(--tx-faint)" }
+    }, "Clear token");
+
+    var doSubmit = function () {
+      var val = input.value;
+      if (!val || submitBtn.disabled) return;
+      submitBtn.disabled = true;                 // belt-and-suspenders against a double-submit (D2)
+      msg.textContent = "Verifying...";
+      Pet.auth.submitToken(val).then(function (res) {
+        if (res && res.ok) return;               // resume cleared authRequired and re-rendered the dashboard
+        if (res && res.stale) return;            // superseded by a later submit; that submit owns the outcome
+        submitBtn.disabled = false;
+        msg.textContent = (res && res.message) || "Authentication failed. Check the token and retry.";
+      });
+    };
+    submitBtn.addEventListener("click", doSubmit);
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") { e.preventDefault(); doSubmit(); }
+    });
+    clearBtn.addEventListener("click", function () { Pet.auth.clearToken(); });
+
+    var help = Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", lineHeight: "1.5" } },
+      "This console requires a token (PETASOS_CONSOLE_TOKEN). It is held for this browser tab only and is no stronger than your browser session.");
+
+    var row = Pet.h("div", { style: { display: "flex", gap: "10px", alignItems: "center" } }, input, submitBtn);
+    wrapper.appendChild(Pet.h("div", {
+      style: {
+        display: "flex", flexDirection: "column", gap: "10px",
+        padding: "16px", borderRadius: "var(--r-panel)",
+        background: "var(--bg-panel)", border: "1px solid var(--border)"
+      }
+    }, row, msg, help, clearBtn));
+
+    return wrapper;
+  };
+
   Pet.renderDashboard = function (container) {
     container.innerHTML = "";
+    // PET-129 D2/D3: in the authenticate state, render the token-entry panel and issue
+    // NO data reads (no getArmed/getHealth/getScanHistory), so a token-gated console
+    // shows a clear authenticate state instead of 401-looping skeletons/broken tiles.
+    if (Pet.state.authRequired) {
+      container.appendChild(Pet.renderAuthPanel());
+      return;
+    }
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "16px", height: "100%" } });
 
     // ── PET-111: Equipped/Unequipped master switch (first child of the tab) ──
     // paintBanner re-queries the LIVE banner node each call (never closes over a
     // captured node): renderDashboard rebuilds the banner on every SSE/poll frame,
     // and _container is null after unmount — so guard container-truthiness first.
+    // PET-129 D3: paintBanner derives ALL of its live outputs (label, .equip-banner
+    // class, .switch/aria-checked, helmet art) from the pure Pet.bannerView decision,
+    // which keys on authRequired first. So a 401 (or an operator click while
+    // unauthenticated) can never repaint EQUIPPED on the live node.
     var paintBanner = function () {
       var b = _container && _container.querySelector(".equip-banner");
       if (!b) return;
-      var on = Pet.state.armed !== false;
-      var confirming = on && _armedConfirmPending;
-      b.className = "equip-banner" + (on ? "" : " disarmed") + (confirming ? " confirming" : "");
+      var view = Pet.bannerView({
+        authRequired: Pet.state.authRequired,
+        armed: Pet.state.armed,
+        confirming: _armedConfirmPending,
+      });
+      b.className = view.cls;
       var lbl = b.querySelector(".equip-label");
-      if (lbl) lbl.textContent = confirming ? "CONFIRM UNEQUIP?" : (on ? "EQUIPPED" : "UNEQUIPPED");
+      if (lbl) lbl.textContent = view.label;
       var sub = b.querySelector(".equip-sub");
-      if (sub) sub.textContent = confirming
-        ? "Click again to disable all enforcement"
-        : (on ? "Enforcement is ON" : "Enforcement is OFF for every session");
+      if (sub) sub.textContent = view.sub;
       var sw = b.querySelector(".switch");
       if (sw) {
-        sw.className = "switch" + (on && !confirming ? " on" : "");
-        sw.setAttribute("aria-checked", on ? "true" : "false");
-        sw.setAttribute("aria-label", "Petasos enforcement: " + (on ? "equipped, click to unequip" : "unequipped, click to equip"));
+        sw.className = "switch" + (view.on && !view.confirming ? " on" : "");
+        sw.setAttribute("aria-checked", view.on ? "true" : "false");
+        sw.setAttribute("aria-label", "Petasos enforcement: " + (view.on ? "equipped, click to unequip" : "unequipped, click to equip"));
       }
       // PET-13: two-state helmet art - worn (equipped) when armed, off (unequipped) when not.
       var mark = b.querySelector(".equip-mark");
-      if (mark) mark.src = Pet.asset(on ? "img/petasos-equipped.png" : "img/petasos-unequipped.png");
+      if (mark) mark.src = Pet.asset(view.on ? "img/petasos-equipped.png" : "img/petasos-unequipped.png");
     };
     var doToggle = function () {
+      if (Pet.state.authRequired) return; // PET-129 D3: no toggling (or EQUIPPED repaint) while unauthenticated
       if (_armedBusy) return;  // ignore rapid re-clicks while a write is in flight
       var on = Pet.state.armed !== false;
       // Disarming is the high-stakes direction: require a confirming 2nd click.
@@ -1134,7 +1434,10 @@
       _armedBusy = true;
       Pet.state.armed = next; paintBanner();  // optimistic (live re-query, survives re-render)
       Pet.api.setArmed(next).then(function (d) {
-        _armedBusy = false;
+        _armedBusy = false; // cleared on EVERY path (incl. the 401 route below) so re-auth can re-seed
+        // PET-129 D3: a toggle that 401s also enters the authenticate state (on401
+        // already re-renders); route it through the chokepoint before reconciling.
+        if (Pet.auth.on401(d)) return;
         _armedSeeded = true;  // a settled write IS a fresh seed -> no spurious follow-up GET
         var ok = d && !d.error && (!d._status || d._status < 400) && typeof d.armed === "boolean";
         Pet.state.armed = ok ? d.armed : !next;  // reconcile to authoritative value, else revert
@@ -1252,6 +1555,7 @@
     if (!_armedSeeded && !_armedBusy) {
       _armedSeeded = true;
       Pet.api.getArmed().then(function (d) {
+        if (Pet.auth.on401(d)) return; // PET-129 D3: first statement; a 401 here must not be read as armed
         if (_armedBusy) return;
         if (d && !d.error && typeof d.armed === "boolean") {
           Pet.state.armed = d.armed;
@@ -1262,6 +1566,7 @@
 
     // Fetch initial data and render scanner health
     Pet.api.getHealth().then(function (d) {
+      if (Pet.auth.on401(d)) return; // PET-129 D3: first statement, before the _healthLoaded flip / shape gate
       _healthLoaded = true;  // PET-127: settled (either arm) -> stop painting the skeleton
       if (!d.error) {
         // PET-144: capture BEFORE the assignment whether this settle is the first to
@@ -1305,6 +1610,7 @@
     if (!_historySeeded) {
       _historySeeded = true;
       Pet.api.getScanHistory(500).then(function (d) {
+        if (Pet.auth.on401(d)) return; // PET-129 D3: first statement, before the shape-guarded seed-merge
         // startFallbackPolling response-shape guard, NOT the bare !d.error check:
         // _req never rejects on HTTP error (it resolves an error envelope), and a
         // 200 {} body lacking .entries would make the merge throw on .scan_id.
@@ -1445,6 +1751,10 @@
     return (opts.api || Pet.api).postScan(opts.text, opts.dir, opts.sid)
       .then(function (d) {
         Pet.restoreScanButton(scanBtn);
+        // PET-129 D3: chokepoint completeness. A playground scan that 401s enters the
+        // authenticate state rather than rendering a scanErrorBlock. (In practice a
+        // poll/mount reader 401s first; the bearer attach for postScan is via _req.)
+        if (Pet.auth.on401(d)) return;
         resultArea.innerHTML = "";
         if (d && (d.error || d.detail)) {
           var msg = d.error;
@@ -2049,6 +2359,7 @@
     );
 
     Pet.api.getConfig().then(function (d) {
+      if (Pet.auth.on401(d)) return; // PET-129 D3: a 401 on the config read enters the authenticate state, not "Config unavailable"
       if (d.error || !d.config || !d.fields) {
         formArea.innerHTML = "";
         formArea.appendChild(Pet.h("div", { style: { padding: "20px", color: "var(--err)", fontSize: "12px", fontFamily: "var(--font-mono)" } },

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -474,7 +474,13 @@
         Pet.state.armed = d.armed; // seed from the authenticated read, not the stale default
         _armedSeeded = true;       // armed is verified; skip the dashboard's mount re-fetch
         return Pet.api.getHealth().then(function (h) {
-          if (gen === Pet.auth._gen && h && !h.error && h._status !== 401) {
+          // A token set/clear during the /health round-trip supersedes this resume (a
+          // newer submit, or a clearToken, now owns the outcome). Drop the whole stale
+          // continuation — not just the health seed — so it cannot restart transports
+          // or re-render the dashboard under a superseded generation (e.g. re-arming
+          // polling/SSE that a concurrent clearToken just tore down).
+          if (gen !== Pet.auth._gen) return { ok: false, stale: true };
+          if (h && !h.error && h._status !== 401) {
             _healthLoaded = true;
             Pet.state.scannerHealth = h.scanners || [];
             Pet.state.pipelineHealth = h.pipeline || null;
@@ -2344,6 +2350,14 @@
 
   Pet.renderConfig = function (container) {
     container.innerHTML = "";
+    // PET-129: in the authenticate state render the token panel instead of issuing
+    // config reads that would only 401 (the obs dashboard does the same). The auth
+    // flow takes precedence when the config tab is opened while authRequired, so no
+    // redundant getProfiles/getConfig calls and no skeleton flash before on401 swaps in.
+    if (Pet.state.authRequired) {
+      container.appendChild(Pet.renderAuthPanel());
+      return;
+    }
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "16px", height: "100%" } });
 
     // PET-13: the "how saving works" disclosure moved to the sticky save bar at the

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -369,17 +369,23 @@
   // origin indefinitely). The store NEVER throws to its callers: sessionStorage can be
   // absent (a headless node:vm load) or throw on setItem (private-browsing modes), so
   // every access is wrapped and falls back to an in-module in-memory value.
-  var _tokenMem = null; // in-memory mirror / fallback when sessionStorage is unusable
+  var _UNSET = {};      // sentinel: no in-session set()/clear() has run yet
+  var _tokenMem = _UNSET; // in-memory truth once set/clear runs; falls back to sessionStorage before that
   var _TOKEN_KEY = "petasos.console.token";
   Pet.token = {
     get: function () {
+      // In-session truth wins: once set()/clear() has run, _tokenMem is authoritative
+      // even if its sessionStorage write threw — so a failed write never lets get()
+      // return a stale persisted token. Fall back to sessionStorage only before the
+      // first set/clear (so an operator's token survives a reload within the tab).
+      if (_tokenMem !== _UNSET) return _tokenMem;
       try {
         if (typeof sessionStorage !== "undefined" && sessionStorage) {
           var v = sessionStorage.getItem(_TOKEN_KEY);
           if (v != null) return v;
         }
       } catch (_) {}
-      return _tokenMem;
+      return null;
     },
     set: function (value) {
       var v = value == null ? "" : String(value);
@@ -580,16 +586,16 @@
       if (self._abortCtrl) self._abortCtrl.abort();  // defensive; inert on the reconnect path (disconnect nulled it)
       var url = Pet.api.baseUrl + "/events";
       var headers = { "Accept": "text/event-stream" };
-      var token = window.__HERMES_SESSION_TOKEN__;
-      if (token) headers["X-Hermes-Session-Token"] = token;
-      // PET-129 D1 (edge F-7): sse.connect is the single SSE client for both modes, so
-      // "standalone only" must be explicit here. Use the EXACT same embedded predicate
-      // as _req (`sdk && sdk.fetchJSON`), so a partial SDK object lacking fetchJSON is
-      // treated as standalone by both paths (no path divergence). In embedded mode the
-      // fetch keeps its X-Hermes-Session-Token and gains NO Petasos Authorization, so
-      // the two credentials never coexist (the double-credentialing D5 forbids).
+      // PET-129 D1/D5 (edge F-7): sse.connect is the single SSE client for both modes,
+      // so exactly ONE credential is attached, keyed on the SAME embedded predicate as
+      // _req (`sdk && sdk.fetchJSON`) — embedded -> Hermes session token only, standalone
+      // -> Petasos bearer only. The two never coexist (double-credentialing D5 forbids),
+      // and a partial SDK object lacking fetchJSON is treated as standalone by both paths.
       var _sdk = window.__HERMES_PLUGIN_SDK__;
-      if (!(_sdk && _sdk.fetchJSON)) {
+      if (_sdk && _sdk.fetchJSON) {
+        var _hs = window.__HERMES_SESSION_TOKEN__;
+        if (_hs) headers["X-Hermes-Session-Token"] = _hs;
+      } else {
         var _ctok = Pet.token.get();
         if (_ctok) headers["Authorization"] = "Bearer " + _ctok;
       }
@@ -2360,7 +2366,10 @@
     // (_get/_req return a fetch-based promise that resolves to {error} on failure
     // rather than rejecting, so the onRejected arm is belt-and-suspenders.)
     var profilesP = Pet.api.getProfiles().then(
-      function (resp) { return (resp && Array.isArray(resp.profiles)) ? resp.profiles : []; },
+      function (resp) {
+        if (Pet.auth.on401(resp)) return []; // PET-129: a profiles 401 enters the auth state (chokepoint completeness)
+        return (resp && Array.isArray(resp.profiles)) ? resp.profiles : [];
+      },
       function () { return []; }
     );
 
@@ -2422,6 +2431,7 @@
         clearPresetConfirm();
         dialApplyInFlight = true;  // in-flight guard, mirrors the Apply button
         Pet.api.putConfig(preset.overrides).then(function (resp) {
+          if (Pet.auth.on401(resp)) return; // PET-129: a config-save 401 enters the auth state, not a validation error
           var failMsg = null;
           if (resp && resp._status && resp.detail) {
             var raw = Array.isArray(resp.detail) ? resp.detail : [resp.detail];
@@ -2666,6 +2676,7 @@
             formArea.querySelectorAll(".pet-field-err").forEach(function (el) { el.remove(); });
             applyBtn.disabled = true;
             Pet.api.putConfig(Pet.state.configDirty).then(function (d) {
+              if (Pet.auth.on401(d)) return; // PET-129: a config-save 401 enters the auth state, not a validation error
               if (d._status && d.detail) {
                 var raw = Array.isArray(d.detail) ? d.detail : [d.detail];
                 var details = raw.map(function (el) {

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -629,3 +629,54 @@ test("test_clear_token_re_enters_authenticate_state", () => {
   assert.equal(Pet.token.get(), null, "clear drops the stored token");
   assert.equal(Pet.state.authRequired, true, "clear re-enters the authenticate state");
 });
+
+// A resume superseded DURING the /health round-trip (a concurrent clearToken / new
+// submit bumps Pet.auth._gen) must drop the whole stale continuation — it must NOT
+// restart polling/SSE under the superseded generation (would re-arm transports a
+// concurrent clearToken just tore down).
+test("test_resume_superseded_during_health_drops_stale_continuation", async () => {
+  const timers = makeTimers();
+  let pet;
+  const fetch = (url) => {
+    if (url.indexOf("/armed") >= 0) return Promise.resolve(jsonResp(200, { armed: true }));
+    if (url.indexOf("/health") >= 0) {
+      pet.auth.clearToken(); // a clearToken landing mid-resume bumps _gen AND re-enters authRequired
+      return Promise.resolve(jsonResp(200, { scanners: [] }));
+    }
+    if (url.indexOf("/events") >= 0) return Promise.resolve(sseResp());
+    return Promise.resolve(jsonResp(200, {}));
+  };
+  const { Pet } = loadPet({
+    fetch,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  });
+  pet = Pet;
+  Pet.auth.on401({ _status: 401 });
+  const res = await Pet.auth.submitToken("good");
+  await flush();
+  await flush();
+  assert.equal(res.ok, false, "a resume superseded during /health does not report success");
+  assert.ok(res.stale, "it returns the stale marker");
+  assert.equal(Pet.state.authRequired, true, "the concurrent clearToken wins (still the authenticate state)");
+  assert.equal(Pet._poll.state().health, false, "the stale resume did NOT restart polling under the superseded generation");
+});
+
+// In the authenticate state, opening the config tab renders the token panel and
+// issues NO config reads (no redundant getProfiles/getConfig 401s, no skeleton flash).
+test("test_config_tab_in_authenticate_state_renders_panel_no_reads", () => {
+  const calls = [];
+  const fetch = (url) => {
+    calls.push(url);
+    return Promise.resolve(jsonResp(200, {}));
+  };
+  const { Pet, document } = loadPet({ fetch });
+  Pet.state.authRequired = true;
+  const container = document.createElement("div");
+  Pet.renderConfig(container);
+  assert.ok(/AUTHENTICATE/.test(container.textContent), "config tab shows the authenticate panel");
+  assert.ok(!/EQUIPPED/.test(container.textContent), "never EQUIPPED");
+  assert.equal(calls.length, 0, "no /config or /profiles reads issued while authRequired");
+});

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -199,7 +199,15 @@ function makeTimers() {
       for (const fn of [...intervals.values()]) fn();
     },
     fireTimeouts() {
-      for (const fn of [...timeouts.values()]) fn();
+      // One-shot semantics: a timeout is consumed when it fires. Snapshot the due
+      // callbacks, remove them, THEN run — so a callback that reschedules registers a
+      // new timer that does not fire within this same invocation (matching real
+      // setTimeout, and never double-firing a callback on a later fireTimeouts()).
+      const due = [...timeouts.entries()];
+      for (const [id, fn] of due) {
+        timeouts.delete(id);
+        fn();
+      }
     },
     get totalIntervals() {
       return totalIntervals;

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -359,6 +359,28 @@ test("test_no_bearer_on_sse_embedded_path", () => {
   assert.ok(!h.Authorization, "no Petasos Authorization on the embedded SSE path");
 });
 
+// D5 mutual exclusivity: a partial SDK (no fetchJSON) is treated as standalone by the
+// SAME predicate _req uses, so the Petasos bearer is attached and the Hermes session
+// token is NOT — the two credentials never coexist, even in this odd partial state.
+test("test_sse_partial_sdk_is_standalone_no_double_credential", () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(sseResp());
+  };
+  const window = {
+    __HERMES_PLUGIN_SDK__: {}, // present but NO fetchJSON -> standalone, per _req's predicate
+    __HERMES_SESSION_TOKEN__: "hsess",
+  };
+  const { Pet } = loadPet({ window, fetch });
+  Pet.token.set("s3cr3t");
+  Pet.sse.connect();
+  assert.equal(calls.length, 1);
+  const h = calls[0].opts.headers;
+  assert.equal(h.Authorization, "Bearer s3cr3t", "partial SDK is standalone -> Petasos bearer attached");
+  assert.ok(!h["X-Hermes-Session-Token"], "no Hermes session token alongside the Petasos bearer (D5)");
+});
+
 // Defect #2: a 401 never renders EQUIPPED; on401 sets authRequired; the auth panel is
 // honest.
 test("test_401_does_not_render_equipped", () => {
@@ -438,6 +460,33 @@ test("test_token_store_degrades_without_sessionStorage", () => {
   assert.equal(Pet2.token.get(), "xyz", "falls back to in-memory when setItem throws");
   assert.doesNotThrow(() => Pet2.token.clear());
   assert.equal(Pet2.token.get(), null);
+});
+
+// In-session truth wins over a stale persisted token: a storage write that fails
+// AFTER a successful prior write must NOT let get() return the stale value (the
+// _UNSET sentinel makes _tokenMem authoritative once set/clear has run).
+test("test_token_store_inmemory_truth_wins_over_stale_storage", () => {
+  let failWrites = false;
+  const store = new Map();
+  const flaky = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      if (failWrites) throw new Error("quota");
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      if (failWrites) throw new Error("quota");
+      store.delete(k);
+    },
+  };
+  const { Pet } = loadPet({ sessionStorage: flaky });
+  Pet.token.set("first"); // persisted to storage
+  assert.equal(Pet.token.get(), "first");
+  failWrites = true;
+  Pet.token.set("second"); // setItem throws; storage still holds "first"
+  assert.equal(Pet.token.get(), "second", "in-memory truth wins over the stale persisted token");
+  Pet.token.clear(); // removeItem throws; storage still holds "first"
+  assert.equal(Pet.token.get(), null, "after clear, get() is null even if removeItem failed");
 });
 
 // Defect #3 (edge F-1): a 401 stops BOTH polls; the fallback does not reschedule; and

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -1,0 +1,574 @@
+// Unit tests for the PET-129 token-aware console client in
+// petasos/console/static/petasos.js.
+//
+// PET-125 shipped a server-side, off-by-default PETASOS_CONSOLE_TOKEN Bearer gate on
+// every standalone /api/* route. PET-129 teaches the browser client about that
+// credential. This suite pins each of the three defects the ticket fixes, plus the
+// round-1/round-2 edge cases the spec calls out:
+//
+//   1. No credential was ever attached -> the standalone _req / sse.connect now attach
+//      `Authorization: Bearer <token>` when a token is stored, and ONLY on the
+//      standalone path (the embedded Hermes SDK path is left untouched). (D1)
+//   2. The equip banner misread a 401 as EQUIPPED -> Pet.bannerView keys on
+//      authRequired FIRST, returning an explicit authenticate state, never EQUIPPED,
+//      and Pet.auth.on401 sets authRequired. (D3)
+//   3. The 10-second polls retried the 401 forever -> Pet.auth.on401 stops both polls
+//      with no auto-reschedule; a verified re-auth resumes them. (D4)
+//
+// Zero npm dependencies: Node's built-in test runner + assert, a DOM shim (mirrors
+// armed-sync.test.mjs / trap-burst.test.mjs), node:vm to evaluate the real shipped
+// petasos.js, plus a mock fetch (records url + opts), recording sandbox timers (the
+// trap-burst.test.mjs idiom), and AbortController/TextDecoder for the SSE path. Each
+// test loads a FRESH Pet (the client carries global state: authRequired, token, poll
+// timers), so they cannot cross-contaminate. Run with:
+//   node --test tests/js/console-token.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── DOM shim (mirrors trap-burst.test.mjs, + value/disabled/attrs for the panel) ──
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    value: "",
+    disabled: false,
+    attrs: {},
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    insertBefore(node, ref) {
+      const i = ref ? this.childNodes.indexOf(ref) : -1;
+      if (i < 0) this.childNodes.push(node);
+      else this.childNodes.splice(i, 0, node);
+      return node;
+    },
+    get firstChild() {
+      return this.childNodes[0] || null;
+    },
+    addEventListener(_type, _fn) {},
+    setAttribute(k, v) {
+      this.attrs[k] = String(v);
+    },
+    removeAttribute(k) {
+      delete this.attrs[k];
+    },
+    getAttribute(k) {
+      return this.attrs[k];
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      this.childNodes = [];
+      const s = v == null ? "" : String(v);
+      if (s !== "") {
+        const n = makeNode(3);
+        n.nodeValue = s;
+        this.childNodes.push(n);
+      }
+    },
+    set innerHTML(_v) {
+      this.childNodes = [];
+    },
+  };
+}
+
+function makeDocument() {
+  return {
+    createDocumentFragment() {
+      return makeNode(11);
+    },
+    createElement(tag) {
+      const el = makeNode(1);
+      el.tagName = tag.toUpperCase();
+      el.localName = tag;
+      return el;
+    },
+    createElementNS(_ns, tag) {
+      return this.createElement(tag);
+    },
+    createTextNode(t) {
+      const node = makeNode(3);
+      node.nodeValue = String(t);
+      return node;
+    },
+  };
+}
+
+// ── Sandbox helpers ──────────────────────────────────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  join(here, "..", "..", "petasos", "console", "static", "petasos.js"),
+  "utf8"
+);
+
+// Load the real petasos.js into a fresh vm context. Every option is overridable so a
+// test can inject its own fetch / timers / sessionStorage / window.
+function loadPet(opts = {}) {
+  const document = makeDocument();
+  const sandbox = {
+    window: opts.window || {},
+    document,
+    fetch: opts.fetch,
+    setInterval: opts.setInterval || (() => 0),
+    clearInterval: opts.clearInterval || (() => {}),
+    setTimeout: opts.setTimeout || (() => 0),
+    clearTimeout: opts.clearTimeout || (() => {}),
+    AbortController:
+      opts.AbortController ||
+      class {
+        constructor() {
+          this.signal = {};
+        }
+        abort() {}
+      },
+    TextDecoder:
+      opts.TextDecoder ||
+      class {
+        decode() {
+          return "";
+        }
+      },
+    console: { warn() {}, log() {}, error() {} },
+  };
+  // "sessionStorage" present as a key (even = undefined) means the test controls it;
+  // otherwise hand the store a working in-memory sessionStorage.
+  sandbox.sessionStorage = "sessionStorage" in opts ? opts.sessionStorage : makeSessionStorage();
+  vm.runInNewContext(src, sandbox);
+  return { Pet: sandbox.window.__PETASOS_CONSOLE__, sandbox, document };
+}
+
+function makeSessionStorage() {
+  const store = new Map();
+  return {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k) => {
+      store.delete(k);
+    },
+  };
+}
+
+// Recording timers (trap-burst idiom): record scheduled callbacks, expose totals, and
+// allow firing the still-active ones. clear* removes them from the active set, so a
+// re-fire after clear is a no-op (the no-reschedule pin relies on this).
+function makeTimers() {
+  let nextId = 1;
+  let totalIntervals = 0;
+  let totalTimeouts = 0;
+  const intervals = new Map();
+  const timeouts = new Map();
+  return {
+    setInterval: (fn) => {
+      const id = nextId++;
+      intervals.set(id, fn);
+      totalIntervals++;
+      return id;
+    },
+    clearInterval: (id) => {
+      intervals.delete(id);
+    },
+    setTimeout: (fn) => {
+      const id = nextId++;
+      timeouts.set(id, fn);
+      totalTimeouts++;
+      return id;
+    },
+    clearTimeout: (id) => {
+      timeouts.delete(id);
+    },
+    fireIntervals() {
+      for (const fn of [...intervals.values()]) fn();
+    },
+    fireTimeouts() {
+      for (const fn of [...timeouts.values()]) fn();
+    },
+    get totalIntervals() {
+      return totalIntervals;
+    },
+    get totalTimeouts() {
+      return totalTimeouts;
+    },
+  };
+}
+
+// A FastAPI-shaped JSON response for the mock fetch (what _req's standalone branch
+// consumes: r.ok / r.status / r.json()).
+function jsonResp(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+// An SSE-shaped response: a body whose reader never resolves, so sse.connect's pump
+// parks harmlessly after we have observed the request headers.
+function sseResp() {
+  return {
+    ok: true,
+    status: 200,
+    body: { getReader: () => ({ read: () => new Promise(() => {}) }) },
+  };
+}
+
+// Drain all pending microtasks (the _req fetch -> r.json() -> reader .then chain).
+const flush = () => new Promise((r) => setImmediate(r));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+// Seam-presence guard: a missing seam fails loudly here rather than letting a later
+// test pass vacuously.
+test("loader: petasos.js exports Pet.token, Pet.auth.on401, Pet.bannerView, Pet._poll", () => {
+  const { Pet } = loadPet();
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.token, "object");
+  for (const m of ["get", "set", "clear"]) {
+    assert.equal(typeof Pet.token[m], "function", `Pet.token.${m} missing`);
+  }
+  assert.equal(typeof Pet.auth, "object");
+  assert.equal(typeof Pet.auth.on401, "function");
+  assert.equal(typeof Pet.bannerView, "function");
+  assert.equal(typeof Pet._poll, "object");
+  for (const m of ["startHealth", "startFallback", "state"]) {
+    assert.equal(typeof Pet._poll[m], "function", `Pet._poll.${m} missing`);
+  }
+});
+
+// The headline regression pin (D1, defect #1).
+test("test_bearer_attached_on_standalone_path", async () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(jsonResp(200, { scanners: [] }));
+  };
+  const { Pet } = loadPet({ fetch });
+  Pet.token.set("s3cr3t");
+  await Pet.api.getHealth();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "/api/health");
+  // Verbatim "Bearer " + token, to match the server's case-sensitive scheme + verbatim
+  // hmac.compare_digest comparison.
+  assert.equal(calls[0].opts.headers.Authorization, "Bearer s3cr3t");
+});
+
+// The merge must not clobber a caller's headers literal (e.g. _post's Content-Type).
+test("test_bearer_merge_preserves_caller_headers", async () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(jsonResp(200, { armed: true }));
+  };
+  const { Pet } = loadPet({ fetch });
+  Pet.token.set("tok");
+  await Pet.api.setArmed(true); // _post: { "Content-Type": "application/json" }
+  const h = calls[0].opts.headers;
+  assert.equal(h["Content-Type"], "application/json");
+  assert.equal(h.Authorization, "Bearer tok");
+});
+
+// Embedded Hermes path is untouched: no Petasos Authorization, and the standalone
+// fetch is never reached (D1/D5).
+test("test_no_bearer_on_embedded_sdk_path", async () => {
+  const sdkCalls = [];
+  const window = {
+    __HERMES_PLUGIN_SDK__: {
+      fetchJSON: (url, opts) => {
+        sdkCalls.push({ url, opts });
+        return Promise.resolve({ scanners: [] });
+      },
+    },
+  };
+  let fetchCalled = false;
+  const fetch = () => {
+    fetchCalled = true;
+    return Promise.resolve(jsonResp(200, {}));
+  };
+  const { Pet } = loadPet({ window, fetch });
+  Pet.token.set("s3cr3t");
+  await Pet.api.getHealth();
+  assert.equal(fetchCalled, false, "embedded path must not hit the standalone fetch");
+  assert.equal(sdkCalls.length, 1);
+  const opts = sdkCalls[0].opts;
+  assert.ok(
+    !opts || !opts.headers || !opts.headers.Authorization,
+    "no Petasos Authorization injected on the embedded SDK path"
+  );
+});
+
+// Standalone SSE connect attaches the bearer (D1).
+test("test_sse_connect_sends_bearer_when_token_set", () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(sseResp());
+  };
+  const { Pet } = loadPet({ fetch });
+  Pet.token.set("s3cr3t");
+  Pet.sse.connect();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "/api/events");
+  assert.equal(calls[0].opts.headers.Accept, "text/event-stream");
+  assert.equal(calls[0].opts.headers.Authorization, "Bearer s3cr3t");
+});
+
+// Embedded SSE keeps X-Hermes-Session-Token only, no Petasos Authorization (edge F-7);
+// the two credentials never coexist.
+test("test_no_bearer_on_sse_embedded_path", () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(sseResp());
+  };
+  const window = {
+    __HERMES_PLUGIN_SDK__: { fetchJSON: () => Promise.resolve({}) },
+    __HERMES_SESSION_TOKEN__: "hsess",
+  };
+  const { Pet } = loadPet({ window, fetch });
+  Pet.token.set("s3cr3t");
+  Pet.sse.connect();
+  assert.equal(calls.length, 1);
+  const h = calls[0].opts.headers;
+  assert.equal(h["X-Hermes-Session-Token"], "hsess");
+  assert.ok(!h.Authorization, "no Petasos Authorization on the embedded SSE path");
+});
+
+// Defect #2: a 401 never renders EQUIPPED; on401 sets authRequired; the auth panel is
+// honest.
+test("test_401_does_not_render_equipped", () => {
+  const { Pet } = loadPet();
+  const v = Pet.bannerView({ authRequired: true, armed: true });
+  assert.notEqual(v.label, "EQUIPPED", "a 401'd armed read must never read EQUIPPED");
+  assert.equal(v.label, "AUTHENTICATE");
+  assert.equal(v.on, false);
+
+  assert.equal(Pet.state.authRequired, false);
+  assert.equal(Pet.auth.on401({ _status: 401 }), true);
+  assert.equal(Pet.state.authRequired, true);
+
+  // The live authenticate panel shows AUTHENTICATE, never EQUIPPED.
+  const panel = Pet.renderAuthPanel();
+  assert.ok(/AUTHENTICATE/.test(panel.textContent), "auth panel shows AUTHENTICATE");
+  assert.ok(!/EQUIPPED/.test(panel.textContent), "auth panel never shows EQUIPPED");
+});
+
+// on401 keys strictly on _status === 401, so it fires on BOTH envelope shapes and is
+// inert on non-401 / no-status bodies (edges F-2 / F-4).
+test("test_401_fires_on_both_envelope_shapes", () => {
+  // JSON 401 body { detail, _status } (FastAPI HTTPException default detail).
+  assert.equal(loadPet().Pet.auth.on401({ detail: "Unauthorized", _status: 401 }), true);
+  // Parse-failure envelope { error, _status }.
+  assert.equal(loadPet().Pet.auth.on401({ error: "401 Unauthorized", _status: 401 }), true);
+
+  // Negatives, on a single fresh Pet: none flips authRequired.
+  const { Pet } = loadPet();
+  assert.equal(Pet.auth.on401({ detail: "Forbidden", _status: 403 }), false, "403 is not the auth state");
+  assert.equal(Pet.auth.on401({ error: "boom" }), false, "no _status -> not a 401");
+  assert.equal(Pet.auth.on401(null), false);
+  assert.equal(Pet.auth.on401(undefined), false);
+  assert.equal(Pet.state.authRequired, false, "non-401 inputs must not flip authRequired");
+});
+
+// No-regression pin for the common token-off deployment: request shape is byte-for-byte
+// today's (no Authorization key at all).
+test("test_no_token_path_unchanged", async () => {
+  const calls = [];
+  const fetch = (url, opts) => {
+    calls.push({ url, opts });
+    return Promise.resolve(jsonResp(200, { scanners: [] }));
+  };
+  const { Pet } = loadPet({ fetch });
+  // _get with no token: opts stays undefined exactly as today (no headers object added).
+  await Pet.api.getHealth();
+  assert.equal(calls[0].opts, undefined, "token-off _get sends no opts (no Authorization key)");
+  // _post with no token: headers are exactly the caller's literal, no Authorization.
+  await Pet.api.setArmed(true);
+  const postHeaders = calls[1].opts.headers;
+  assert.deepEqual(Object.keys(postHeaders), ["Content-Type"]);
+  assert.equal(postHeaders.Authorization, undefined);
+});
+
+// The most security-relevant store must hold its never-throw invariant (edge F-5):
+// sessionStorage absent, and sessionStorage.setItem throwing, both round-trip via the
+// in-memory fallback without throwing to callers.
+test("test_token_store_degrades_without_sessionStorage", () => {
+  // (a) sessionStorage undefined (headless / blocked).
+  const { Pet } = loadPet({ sessionStorage: undefined });
+  assert.doesNotThrow(() => Pet.token.set("abc"));
+  assert.equal(Pet.token.get(), "abc");
+  assert.doesNotThrow(() => Pet.token.clear());
+  assert.equal(Pet.token.get(), null);
+
+  // (b) setItem throws (private-browsing quota).
+  const throwing = {
+    getItem: () => null,
+    setItem: () => {
+      throw new Error("denied");
+    },
+    removeItem: () => {},
+  };
+  const { Pet: Pet2 } = loadPet({ sessionStorage: throwing });
+  assert.doesNotThrow(() => Pet2.token.set("xyz"));
+  assert.equal(Pet2.token.get(), "xyz", "falls back to in-memory when setItem throws");
+  assert.doesNotThrow(() => Pet2.token.clear());
+  assert.equal(Pet2.token.get(), null);
+});
+
+// Defect #3 (edge F-1): a 401 stops BOTH polls; the fallback does not reschedule; and
+// re-driving the now-cleared recorded timers issues no further /api fetch.
+test("test_401_stops_health_and_fallback_polls", async () => {
+  const timers = makeTimers();
+  const fetchCalls = [];
+  const fetch = (url) => {
+    fetchCalls.push(url);
+    return Promise.resolve(jsonResp(401, { detail: "Unauthorized" }));
+  };
+  const { Pet } = loadPet({
+    fetch,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  });
+
+  // Health poll: start it via the seam, drive its body once, assert it stops on 401.
+  Pet._poll.startHealth();
+  assert.equal(Pet._poll.state().health, true, "health poll active after startHealth");
+  timers.fireIntervals(); // run the 10s health poll body -> getHealth (pending 401)
+  await flush();
+  await flush();
+  assert.equal(Pet._poll.state().health, false, "health poll stopped on a 401");
+
+  // Fallback poll: startFallback issues the initial read AND schedules the next tick.
+  // Fire the scheduled tick so its reschedule .then is actually exercised, then 401.
+  Pet._poll.startFallback();
+  assert.equal(Pet._poll.state().fallback, true, "fallback poll active after startFallback");
+  const timeoutsBeforeStop = timers.totalTimeouts;
+  timers.fireTimeouts(); // run the scheduled fallback body -> getScanHistory + reschedule .then
+  await flush();
+  await flush();
+  assert.equal(Pet._poll.state().fallback, false, "fallback poll stopped on a 401");
+  assert.equal(
+    timers.totalTimeouts,
+    timeoutsBeforeStop,
+    "fallback must NOT reschedule after a 401 (the re-arm guard no-ops on the nulled interval)"
+  );
+
+  // Re-driving the cleared timers issues no further /api fetch (no zombie polling).
+  const fetchesAfterStop = fetchCalls.length;
+  timers.fireIntervals();
+  timers.fireTimeouts();
+  await flush();
+  await flush();
+  assert.equal(fetchCalls.length, fetchesAfterStop, "no further /api fetch after the polls stop");
+});
+
+// Re-auth resume (edges F-3 / F-6, happy path): a valid token leaves the authenticate
+// state, restarts polling, and re-seeds armed from the authenticated read.
+test("test_reauth_resumes_polling_and_reseeds", async () => {
+  const timers = makeTimers();
+  const fetch = (url, opts) => {
+    const auth = opts && opts.headers && opts.headers.Authorization;
+    if (auth === "Bearer good") {
+      if (url.indexOf("/armed") >= 0) return Promise.resolve(jsonResp(200, { armed: false }));
+      if (url.indexOf("/health") >= 0) return Promise.resolve(jsonResp(200, { scanners: [], pipeline: null }));
+      if (url.indexOf("/scan-history") >= 0) return Promise.resolve(jsonResp(200, { entries: [] }));
+      if (url.indexOf("/events") >= 0) return Promise.resolve(sseResp());
+      return Promise.resolve(jsonResp(200, {}));
+    }
+    return Promise.resolve(jsonResp(401, { detail: "Unauthorized" }));
+  };
+  const { Pet } = loadPet({
+    fetch,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  });
+
+  // Enter the authenticate state via a 401, then submit a valid token.
+  Pet.auth.on401({ _status: 401 });
+  assert.equal(Pet.state.authRequired, true);
+  assert.equal(Pet.state.armed, null, "armed cleared to unknown on a 401");
+
+  const res = await Pet.auth.submitToken("good");
+  await flush();
+  await flush();
+  assert.equal(res.ok, true, "a valid token resumes");
+  assert.equal(Pet.state.authRequired, false, "authenticate state cleared after a verified re-auth");
+  // The default is true and on401 set it null; armed === false proves it came from the
+  // authenticated read, not the stale optimistic default.
+  assert.equal(Pet.state.armed, false, "armed re-seeded from the authenticated read");
+  assert.equal(Pet._poll.state().health, true, "health polling restarted after re-auth");
+});
+
+// Stale-submit generation guard (edge F-6): a wrong token then a correct token. The
+// wrong token's stale 401 must NOT tear down the correct token's established session.
+test("test_stale_submit_generation_guard", async () => {
+  const timers = makeTimers();
+  const fetch = (url, opts) => {
+    const auth = opts && opts.headers && opts.headers.Authorization;
+    if (url.indexOf("/armed") >= 0) {
+      return auth === "Bearer correct"
+        ? Promise.resolve(jsonResp(200, { armed: true }))
+        : Promise.resolve(jsonResp(401, { detail: "Unauthorized" }));
+    }
+    if (auth === "Bearer correct") {
+      if (url.indexOf("/health") >= 0) return Promise.resolve(jsonResp(200, { scanners: [] }));
+      if (url.indexOf("/events") >= 0) return Promise.resolve(sseResp());
+      return Promise.resolve(jsonResp(200, {}));
+    }
+    return Promise.resolve(jsonResp(401, { detail: "Unauthorized" }));
+  };
+  const { Pet } = loadPet({
+    fetch,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+    setTimeout: timers.setTimeout,
+    clearTimeout: timers.clearTimeout,
+  });
+  Pet.auth.on401({ _status: 401 });
+
+  // Wrong then correct, near-simultaneously (a double-submit). The wrong submit's read
+  // is issued under a now-superseded generation, so its 401 is dropped.
+  const pWrong = Pet.auth.submitToken("wrong");
+  const pCorrect = Pet.auth.submitToken("correct");
+  const [rWrong, rCorrect] = await Promise.all([pWrong, pCorrect]);
+  await flush();
+  await flush();
+
+  assert.equal(rWrong.ok, false, "the superseded (wrong) submit does not resume");
+  assert.ok(rWrong.stale || rWrong.message, "the wrong submit is dropped/reported, not a teardown");
+  assert.equal(rCorrect.ok, true, "the correct token resumes");
+  assert.equal(Pet.state.authRequired, false, "the correct token's session survives the stale 401");
+  assert.equal(Pet.state.armed, true, "armed seeded from the correct token's read");
+});
+
+// The "clear token" affordance runs the same idempotent teardown as on401 (edge F-9):
+// it clears the stored token and re-enters the authenticate state.
+test("test_clear_token_re_enters_authenticate_state", () => {
+  const { Pet } = loadPet();
+  Pet.token.set("tok");
+  Pet.state.authRequired = false;
+  Pet.auth.clearToken();
+  assert.equal(Pet.token.get(), null, "clear drops the stored token");
+  assert.equal(Pet.state.authRequired, true, "clear re-enters the authenticate state");
+});

--- a/tests/js/sse-reconnect.test.mjs
+++ b/tests/js/sse-reconnect.test.mjs
@@ -401,18 +401,36 @@ test("test_persistent_failure_bounded_then_polling", async () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Test 5 — 401/403 route straight to polling with zero reconnect attempts; a 5xx
-// control case DOES reconnect (Done-when 4; pins D9 "only auth is terminal").
+// Test 5 — auth statuses are non-retryable (zero reconnect attempts), but PET-129
+// supersedes the 401 case: a 401 is the auth-required terminal state (stop
+// everything and surface the token panel), NOT polling. A 403 keeps PET-142's
+// terminal-polling concede (a non-401 4xx is a proxy/deployment condition, not the
+// token-auth path — PET-129 D3 edge F-4). A 5xx control case still reconnects.
+// (Done-when 4; pins D9 "only auth is terminal" + the PET-129 401 reroute.)
 test("test_auth_401_routes_straight_to_polling", async () => {
-  for (const status of [401, 403]) {
-    const h = setup({ events: [HTTP(status)] });
+  // 401 → authenticate state (PET-129), NOT polling.
+  {
+    const h = setup({ events: [HTTP(401)] });
     h.sse.connect();
     await flush();
-    assert.equal(h.eventsCount(), 1, `${status}: exactly one /events fetch (zero reconnect attempts)`);
-    assert.equal(h.sse._reconnectTimer, null, `${status}: no reconnect scheduled`);
-    assert.equal(h.sse._reconnectAttempts, 0, `${status}: attempt budget untouched`);
-    assert.equal(h.sse._usingFallback, true, `${status}: terminal polling`);
-    assert.ok(h.warnings.some((w) => w.indexOf(String(status)) !== -1), `${status}: one auth console signal`);
+    assert.equal(h.eventsCount(), 1, "401: exactly one /events fetch (zero reconnect attempts)");
+    assert.equal(h.sse._reconnectTimer, null, "401: no reconnect scheduled");
+    assert.equal(h.sse._reconnectAttempts, 0, "401: attempt budget untouched");
+    assert.equal(h.sse._usingFallback, false, "401: PET-129 routes to the authenticate state, not polling");
+    assert.equal(h.Pet.state.authRequired, true, "401: authRequired set (token-entry panel)");
+  }
+
+  // 403 → terminal polling, unchanged from PET-142 (not the token-auth path).
+  {
+    const h = setup({ events: [HTTP(403)] });
+    h.sse.connect();
+    await flush();
+    assert.equal(h.eventsCount(), 1, "403: exactly one /events fetch (zero reconnect attempts)");
+    assert.equal(h.sse._reconnectTimer, null, "403: no reconnect scheduled");
+    assert.equal(h.sse._reconnectAttempts, 0, "403: attempt budget untouched");
+    assert.equal(h.sse._usingFallback, true, "403: terminal polling");
+    assert.equal(h.Pet.state.authRequired, false, "403: not the token-auth path (D3 edge F-4)");
+    assert.ok(h.warnings.some((w) => w.indexOf("403") !== -1), "403: one auth console signal");
   }
 
   // Control: a 500 is retryable, so it MUST schedule a reconnect.

--- a/tests/js/sse-reconnect.test.mjs
+++ b/tests/js/sse-reconnect.test.mjs
@@ -407,7 +407,7 @@ test("test_persistent_failure_bounded_then_polling", async () => {
 // terminal-polling concede (a non-401 4xx is a proxy/deployment condition, not the
 // token-auth path — PET-129 D3 edge F-4). A 5xx control case still reconnects.
 // (Done-when 4; pins D9 "only auth is terminal" + the PET-129 401 reroute.)
-test("test_auth_401_routes_straight_to_polling", async () => {
+test("test_auth_401_routes_to_authenticate_state_and_403_to_terminal_polling", async () => {
   // 401 → authenticate state (PET-129), NOT polling.
   {
     const h = setup({ events: [HTTP(401)] });


### PR DESCRIPTION
## Summary
- Teaches the bundled browser client (`petasos.js`) about PET-125's optional `PETASOS_CONSOLE_TOKEN` Bearer gate so the served standalone console works with the token on: in-UI token entry, `Authorization: Bearer <token>` on every standalone `/api/*` call and the `/api/events` SSE connect, a first-class `401` authenticate state, and a verified re-auth resume.
- Token-off deployments (the common path) are **byte-for-byte unchanged**; the embedded Hermes SDK path (authenticated via its own `X-Hermes-Session-Token` mount) is left untouched (no double-credentialing).
- `docs/deployment/hardening.md` §6 is updated in lockstep: the "Known limitation" note becomes "shipped", and the `sessionStorage` token-at-rest posture is recorded.

## Layered defense (how the three defects close)
1. **No credential attached** → `_req`'s standalone `fetch` branch and `sse.connect` attach the bearer verbatim, standalone-gated (`!window.__HERMES_PLUGIN_SDK__`), merged without clobbering caller headers. No token ⇒ no `Authorization` key at all.
2. **Banner misread a 401 as EQUIPPED** → `Pet.bannerView(state)` is a pure decision keyed on `authRequired` **first**; `paintBanner` derives all of its live outputs (label, class, switch/aria, helmet art) from it, and `doToggle` respects `authRequired`, so a 401 (or a click while unauthenticated) can never repaint EQUIPPED.
3. **Polls retried the 401 forever** → `Pet.auth.on401(d)` (keyed on `_status`, the first statement of every reader's `.then`) stops both polls; the fallback's reschedule no-ops because `stopFallbackPolling()` nulls the interval before the chained `.then` runs; a 401 in `sse.connect` routes to the authenticate state instead of the offline fallback.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Adds `Pet.token` / `Pet.auth` (on401 + resume + generation guard) / `Pet.bannerView` / `Pet.renderAuthPanel` / `Pet._poll` seam; wires the bearer attach, the 401 chokepoint into every `/api` reader, and the authenticate panel |
| `docs/deployment/hardening.md` | §6 prose: "shipped" follow-up, `sessionStorage` posture, §2/§6 binding cross-check (no code follows) |
| `tests/js/console-token.test.mjs` | New: 14 `node:test` + `node:vm` regressions over the real shipped `petasos.js` |

## Test plan
- [x] `node --test tests/js/*.test.mjs` — **139/139 pass** (14 new + 125 existing; no regression). Spec lists `node --test tests/js/`; the CI-canonical glob form is used because Node 25 needs it. (full output: `docs/specs/TODO/PET-129.test-output.txt`)
- [x] `C:/python310/python.exe -m pytest --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — **1866 passed, 41 skipped, 1 deselected, 1 xfailed** (no Python touched; server end already pinned by `tests/test_console_auth.py`, D7)
- [x] `ruff check .` — clean · `ruff format --check .` — 136 files formatted · `mypy --strict .` — no issues in 136 files
- [ ] Manual (live-DOM half the headless shim cannot assert): with `PETASOS_CONSOLE_TOKEN` set, confirm the Observability banner shows the authenticate state (never EQUIPPED) before a token is entered; a valid token loads all panels; a click while in the authenticate state does not repaint EQUIPPED; a wrong-then-correct token does not tear down the correct session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token-gated authenticate/clear-token experience for the console, including REST routes and the event stream.
  * Token persistence now uses browser `sessionStorage` with a safe in-memory fallback; when the embedded Hermes SDK is present, Authorization headers are omitted.
* **Bug Fixes**
  * Improved HTTP 401 handling: transitions to authenticate-required, stops health/fallback polling, and prevents SSE reconnect/auth retry loops.
* **Documentation**
  * Updated deployment hardening guidance to match served-UI token behavior and reaffirm required network posture.
* **Tests**
  * Expanded coverage for token behavior and auth UI/state transitions, plus refined SSE reconnect handling for 401 vs 403.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->