### PR TITLE
chore: gitignore local scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,10 @@ docs/briefs/
 # Old console spec scaffolding - kept local, not published
 docs/console/petasos-console-frontend-handoff.md
 docs/console/handoff-extracted/
+docs/console/*.zip
+
+# Design-skill (impeccable) critique output - local scratch
+.impeccable/
+
+# Per-ticket presync backups - local safety nets, never committed
+*-presync-bak/


### PR DESCRIPTION
## Summary
Local-only working artifacts were cluttering `git status` and risked accidental commits. This adds them to `.gitignore`, alongside the existing local-tooling ignores (`.claude/`, `docs/briefs/`, `docs/console/handoff-extracted/`):

- `.impeccable/` — design-skill (impeccable) critique output
- `*-presync-bak/` — per-ticket presync safety backups
- `docs/console/*.zip` — console handoff export bundles (binary, not source)

No tracked files are removed; these paths are local-only by nature. Pure repo hygiene, no code change.

## Test plan
- [x] No code touched — `.gitignore`-only change; CI (lint/typecheck/test/js-test) is a formality here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5TE63LdHZhvJLwHvsqGRX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to improve project maintenance and development environment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->