### PR TITLE
chore(docs): genericize banking egress guide for public audience

### DIFF
--- a/docs/deployment/banking-egress.md
+++ b/docs/deployment/banking-egress.md
@@ -1,9 +1,10 @@
-# Gavin banking egress fencing
+# Banking-data egress fencing
 
-How to make "financial data must not egress the box" true for Gavin's Hermes
-banking profile, and what that guarantee does and does not cover. The guarantee
-is primarily architectural (local-only inference); Petasos is the enforcement
-point on the agent-to-off-box-tool boundary, plus defense-in-depth and audit.
+How to make "financial data must not egress the box" true for a Hermes agent
+profile that reads banking data, and what that guarantee does and does not cover.
+The guarantee is primarily architectural (local-only inference); Petasos is the
+enforcement point on the agent-to-off-box-tool boundary, plus defense-in-depth
+and audit.
 
 > **Before you start:** read the [deployment hardening checklist](hardening.md)
 > for where Petasos sits in your security model (it is a detection layer, not a
@@ -11,9 +12,10 @@ point on the agent-to-off-box-tool boundary, plus defense-in-depth and audit.
 > the base install, the `petasos:` config section, and the profile config path.
 > This note adds only the banking-profile specifics on top of that baseline.
 
-**Ticket:** PET-133 (decisions D3, D4 of the Gavin Banking Observability work)  
 **Petasos version:** 0.1.2+  
-**Profile:** the active Hermes profile Gavin runs under (for example `gibson`)
+**Applies to:** any Hermes profile that pulls banking or other sensitive data
+through a local MCP and can also reach off-box tools. The examples below use a
+profile named `gibson`; substitute your own profile name.
 
 ---
 
@@ -21,7 +23,7 @@ point on the agent-to-off-box-tool boundary, plus defense-in-depth and audit.
 
 The primary guarantee is architectural, not content inspection:
 
-- **Local inference (D3).** Gavin's model runs on the box (LM Studio, llama.cpp,
+- **Local inference.** The agent's model runs on the box (LM Studio, llama.cpp,
   or a local OpenAI-compatible server), so the inference call itself never ships
   context off-box. This is the load-bearing control; sections 2 and 5 make it a
   checkable hard gate.
@@ -36,31 +38,31 @@ content pulled from the bank. But most banking *figures* (balances, amounts,
 merchant names) are not Presidio entities, so the PII-egress block alone does not
 stop them. Petasos here is defense-in-depth, audit, and the agent-to-off-box
 enforcement point; it is not a content-aware "no figure leaves" guarantee. The
-PET-134 taint wiring (section 4) narrows the gap for content relayed verbatim
-from a bank tool, but a model that paraphrases a balance into a new sentence and
-hands it to an egress tool is outside what the fence can see. The architectural
+source-taint fence (section 4) narrows the gap for content relayed verbatim from
+a bank tool, but a model that paraphrases a balance into a new sentence and hands
+it to an egress tool is outside what the fence can see. The architectural
 controls above, not Petasos content matching, are what make the box safe.
 
 ---
 
-## 2. D3: local inference is a hard gate
+## 2. Local inference is a hard gate
 
 The leak Petasos cannot intercept is the LLM inference call. The plugin registers
 `pre_tool_call` / `post_tool_call` / `on_session_start`, never `pre_llm_call`, so
-once bank data is in Gavin's context a *cloud* model would transmit it off-box on
-the next turn, a path no hook can stop. D3 closes this by configuration: Gavin's
+once bank data is in the agent's context a *cloud* model would transmit it off-box
+on the next turn, a path no hook can stop. Close this by configuration: the
 profile must point at a local inference endpoint. A cloud `model:` is a release
 blocker.
 
 That requirement is enforced by a checkable predicate so a profile edit cannot
-silently reopen it. Gavin's profile CI (and your own pre-flight check) runs:
+silently reopen it. Run it in your profile CI (and as your own pre-flight check):
 
 ```python
 from petasos.profile_lint import is_local_inference_endpoint
 
 # provider + base_url come from the profile's model: section.
 assert is_local_inference_endpoint(provider, base_url), (
-    "D3 blocker: Gavin's inference endpoint is not local"
+    "blocker: the inference endpoint is not local"
 )
 ```
 
@@ -72,15 +74,15 @@ it accepts and the ones it rejects by design.
 
 ---
 
-## 3. D4: egress-sink classification
+## 3. Egress-sink classification
 
 Petasos blocks PII findings at HIGH or worse only on tools classified as egress
-sinks; internal tools are exempt by design. For Gavin:
+sinks; internal tools are exempt by design. For a banking profile:
 
-- **Every off-box tool Gavin can reach is an egress sink.** The Vigil MCP
-  outbound / ingest tools, any `web_fetch` / `http` / `fetch`, and any messaging
-  `*_send` go in `egress_sink_tools`, by their full single-underscore wire name
-  (see the canonicalization note in `hermes-desktop.md`).
+- **Every off-box tool the agent can reach is an egress sink.** Any memory or
+  ingest MCP tool, any `web_fetch` / `http` / `fetch`, and any messaging `*_send`
+  go in `egress_sink_tools`, by their full single-underscore wire name (see the
+  canonicalization note in `hermes-desktop.md`).
 - **The `mcp_bank_*` tools are sources, never sinks.** The agent pulls data in
   through them, so they are absent from `egress_sink_tools`. Listing a bank tool
   as a sink would be a miscategorization; the regression
@@ -92,15 +94,15 @@ sinks; internal tools are exempt by design. For Gavin:
 
 This classification is operator config in the profile, not a code change. No
 banking-specific tool names ship in the Petasos library defaults; they live only
-in Gavin's profile, this note, and the test fixtures.
+in your profile, this note, and the test fixtures.
 
 ---
 
 ## 4. Source-taint wiring for `mcp_bank_`
 
-The content-agnostic provenance fence (PET-134) blocks content returned by a tool
-in a declared source namespace from leaving verbatim through an egress sink, even
-when it carries no PII span. Wire it for Gavin in the `petasos:` section:
+The content-agnostic provenance fence blocks content returned by a tool in a
+declared source namespace from leaving verbatim through an egress sink, even when
+it carries no PII span. Wire it in the `petasos:` section:
 
 ```yaml
   source_taint_namespaces: ["mcp_bank_"]
@@ -122,7 +124,7 @@ when relayed to `send_email`.
 
 ## 5. Example compliant profile
 
-A minimal Gavin-shaped `model:` plus `petasos:` block. Edit the **profile's**
+A minimal banking-shaped `model:` plus `petasos:` block. Edit the **profile's**
 `config.yaml`, not the root one (Hermes v0.16+):
 
 ```text
@@ -131,7 +133,7 @@ A minimal Gavin-shaped `model:` plus `petasos:` block. Edit the **profile's**
 ```
 
 ```yaml
-# Local inference endpoint (D3 hard gate). is_local_inference_endpoint() must
+# Local inference endpoint (hard gate). is_local_inference_endpoint() must
 # pass for this provider + base_url.
 model:
   provider: "lmstudio"
@@ -140,23 +142,23 @@ model:
 petasos:
   enabled: true
   fail_mode: "closed"
-  host_id: "gavin-banking"
+  host_id: "banking"
 
-  # D4: PII on egress is blocked or redacted.
+  # PII on egress is blocked or redacted.
   anonymize: true
   pii_entities: ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "CREDIT_CARD", "US_SSN", "US_BANK_NUMBER"]
   redaction_mode: "hash"
 
-  # D4: every off-box tool Gavin can reach is an egress sink. Bank tools are
+  # Every off-box tool the agent can reach is an egress sink. Bank tools are
   # sources (pulled in), so they are deliberately NOT listed here.
   egress_sink_tools:
     - send_email
     - send_message
     - http_request
     - send_webhook
-    - mcp_vigil_harbor_memory_ingest
+    - mcp_memory_ingest
 
-  # PET-134: content from the bank namespace may not leave verbatim.
+  # Content from the bank namespace may not leave verbatim.
   source_taint_namespaces: ["mcp_bank_"]
   taint_min_span_length: 12
 ```
@@ -201,7 +203,7 @@ The rules behind that, and the traps the predicate rejects by design:
 ## 7. Windows model-switcher caveat
 
 On Windows, the Hermes Desktop UI model switcher rewrites the `model:` section and
-has, on some builds, wiped the top-level `petasos:` section with it (PET-115). If
+has, on some builds, wiped the top-level `petasos:` section with it. If
 `petasos:` is gone, **both the egress fence and the taint fence are off**, and
 bank data can leave through any tool. Treat every model switch as suspect:
 
@@ -226,5 +228,5 @@ bank data can leave through any tool. Treat every model switch as suspect:
 
 3. **Do not resume until recovered.** If `petasos:` is absent after a switch, the
    egress fence and the `mcp_bank_` taint fence are both off; bank data can egress
-   unblocked. Re-apply the snippet and restart before letting Gavin run any
+   unblocked. Re-apply the snippet and restart before letting the agent run any
    banking task.


### PR DESCRIPTION
## What

Revises `docs/deployment/gavin-banking-egress.md` for a public audience and renames it to `docs/deployment/banking-egress.md`.

This is the banking-data egress deployment note. It was written around an internal deployment (a named persona, internal ticket/decision codes, and an internal MCP tool name). The technical guidance is generally useful, so this scrubs the internal artifacts and keeps the substance.

## Why a rename

- No file on `master` links to it by name (safe to rename).
- Sibling deployment docs (`hardening.md`, `hermes-desktop.md`) are already persona-free, so a file literally named `gavin-` was the one remaining internal leak in the public tree.
- `git` records it as a 76%-similarity rename, so history is preserved.

## Scrubbed (substance unchanged)

| Before | After |
| --- | --- |
| "Gavin" persona | "the agent" / "your banking profile" |
| `PET-133/134/115`, `D3`/`D4` codes | controls described directly, no internal IDs |
| `mcp_vigil_harbor_memory_ingest` | generic `mcp_memory_ingest` example |
| `host_id: "gavin-banking"` | `host_id: "banking"` |

**Unchanged:** the local-inference hard gate (`is_local_inference_endpoint`), egress-sink classification, `mcp_bank_` source-taint wiring, loopback-`base_url` troubleshooting, and the Windows model-switcher caveat. House style preserved (no em dashes). The example profile path keeps `gibson` to stay consistent with `hermes-desktop.md`.

## Notes

- `docs/deployment/reference_plugin/__init__.py` still has a `host_id` default of `"hermes-gavin-01"`. Left as-is (out of this doc's scope); flagging in case a follow-up wants to scrub it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated banking-data egress fencing documentation with generalized guidance and clearer threat model definitions.
  * Revised example profile configurations and removed product-specific terminology.
  * Enhanced documentation of local inference endpoints and egress sink controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->