### PR TITLE
feat(pet-146): Config Editor Hermes-agent-profile selector + honest per-profile posture

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -235,6 +235,16 @@ Then ensure neither the standalone console nor the embedded plugin API is
 reachable by the agent's shell or http tools (network-namespace isolation, or no
 shell/http tool in the agent's toolset). Loopback alone is insufficient.
 
+> **All profile homes, not just the active one (PET-146).** Hermes 0.16+ keeps a
+> separate `config.yaml` per persona under `profiles/<name>/`, and the Config
+> Editor's Hermes-agent-profile selector enumerates and edits **every** one of
+> them. A per-profile egress fence (`source_taint_namespaces`) or a relaxed
+> `fail_mode` can be **pre-staged in a non-equipped profile** and arm on the next
+> equip, so the read-only-mount / write-denying-ACL mitigation above must cover the
+> **whole `profiles/` tree** (plus the v0.15 root and any `$HERMES_HOME`), not only
+> the equipped profile's file. Background and the full two-axis model:
+> [`profile-resolution-model.md`](./profile-resolution-model.md).
+
 ### Optional console token (`PETASOS_CONSOLE_TOKEN`)
 
 The standalone console reads an optional bearer token from the

--- a/docs/deployment/profile-resolution-model.md
+++ b/docs/deployment/profile-resolution-model.md
@@ -1,0 +1,102 @@
+# Petasos profile-resolution model (the two profile axes)
+
+Petasos has **two independent things both called a "profile."** Conflating them
+is the single most common source of confusion when reasoning about where a
+posture setting lives and what changes it. PET-146 added the Config Editor's
+Hermes-agent-profile selector, which makes the distinction operator-visible, so
+this page pins it down.
+
+## Axis 1 — the Hermes profile home (which `config.yaml`)
+
+A *Hermes profile home* is a directory on disk that holds a `config.yaml` with a
+`petasos:` section. Hermes 0.16+ runs each persona as a separate profile home
+under `profiles/<name>/`. The effective file is resolved by
+`petasos/console/_paths.py::resolve_hermes_config_path()` with this precedence:
+
+1. **`HERMES_HOME` env** (tier `hermes_home`) — `$HERMES_HOME/config.yaml`.
+2. **active-profile pointer** (tier `profile`) — `<root>/profiles/<name>/config.yaml`,
+   where `<name>` is read from `<root>/active_profile`.
+3. **v0.15 root** (tier `root`) — `<root>/config.yaml`. If the `active_profile`
+   pointer names a missing directory, resolution falls back to root and carries a
+   **dangling-pointer warning** (surfaced in the editor as a banner labeled as the
+   *active* binding).
+
+`<root>` is the Hermes root:
+
+- **Windows:** `%LOCALAPPDATA%\hermes` (e.g. `C:\Users\<you>\AppData\Local\hermes`),
+  with profiles at `%LOCALAPPDATA%\hermes\profiles\<name>\config.yaml`.
+- **POSIX:** `~/.hermes`, with profiles at `~/.hermes/profiles/<name>/config.yaml`.
+
+`list_hermes_profiles()` enumerates `profiles/*/config.yaml` for the selector;
+`resolve_profile_config_path(name)` resolves one named member (traversal-guarded).
+
+Every `petasos:` posture field lives **inside one of these `config.yaml` files**
+and is therefore **per-Hermes-profile**. This includes the three safety levers
+that an earlier draft proposed treating as machine-global:
+
+- `fail_mode`
+- `source_taint_namespaces` (PET-134 egress fence)
+- `egress_sink_tools` (PET-112 egress PII gate)
+
+There is **no machine-global tier.** Editing any of these under profile *X*
+writes to *X*'s `config.yaml` and leaves every other profile untouched. The
+editor states this plainly ("scoped to the selected Hermes profile") and prints
+no "global" marker; the `scope` metadata key on every field is `"profile"`
+(`_config_meta.generate_config_metadata`), locking the disclosure contract.
+
+## Axis 2 — the internal `profile_name` (a runtime tuning overlay)
+
+The `petasos.profile_name` field selects an *internal* `ResolvedProfile`
+(`petasos/session/profiles/`), one of five built-ins (`general`,
+`customer_service`, `code_generation`, `research`, `admin`) or a custom dict.
+This is **not** a directory and **not** a `config.yaml`. It is a runtime overlay
+the pipeline consults field-by-field at scan time. What it contributes:
+
+- `tier_thresholds` — the **only config-shaped** runtime override; when set it
+  replaces `config.{tier1,tier2,tier3}_threshold` in `guard._state_to_tier`. This
+  is why the editor's "effective (what's enforced)" read-out overlays the
+  profile's tier thresholds onto the raw config values.
+- `confidence_floor` — a **live scan-time** override that drops findings below the
+  floor (`pipeline.py`, Stage 5b). It is *not* a `PetasosConfig` field, so it
+  never appears in `effective_config`; the editor surfaces it under
+  `active_profile_overrides` so the finding-dropping floor stays visible.
+- `suppress_rules`, `severity_overrides`, `pii_entities_extra`,
+  `tool_exempt_list`, `tool_alias_map` — non-config-shaped effects, also surfaced
+  under `active_profile_overrides`.
+
+### Effective view = config ⊕ internal-profile overrides
+
+The pipeline holds no single merged config; it consults the active
+`ResolvedProfile` at runtime. The Config Editor reconstructs an **effective
+view** that matches enforcement: `config.to_dict()` with the tier thresholds
+overlaid from the active internal profile when present. Nothing else is overlaid,
+because nothing else is a config-shaped runtime override.
+
+## The two axes do not interact
+
+The Hermes profile home decides **which file** you are reading and writing. The
+internal `profile_name` (a field *inside* that file) decides the **runtime
+overlay** applied when that file is the equipped one. Switching the selector
+changes the file (axis 1); changing `profile_name` changes the overlay (axis 2).
+
+## Equipped vs non-equipped edits
+
+- **Equipped profile** (the live binding): editing hot-applies through the
+  existing `Pipeline.reconfigure()` path (PET-126) and persists to its
+  `config.yaml`.
+- **Non-equipped profile**: editing persists to **that profile's** `config.yaml`
+  only and shows a restart banner — the change takes effect when the profile is
+  equipped (restart). PET-146 deliberately does not trigger a live equip-swap from
+  the selector; a trusted live re-bind is PET-147's `on_profile_change` signal.
+
+## Hardening consequence — all profile homes, not just the active one
+
+The selector enumerates and edits **every** `profiles/*/config.yaml`. A
+per-profile egress fence (`source_taint_namespaces`) or a relaxed `fail_mode` can
+therefore be **pre-staged in a non-equipped profile** and arm on the next equip.
+The self-disarm / self-tamper mitigation in
+[`hardening.md` §6](./hardening.md#6-protect-petasoss-own-config-self-disarm--self-tamper)
+must extend to **all** profile homes (every `profiles/*/config.yaml` plus the
+v0.15 root and any `$HERMES_HOME`), not only the active one: a read-only mount or
+write-denying ACL that covers just the equipped profile leaves the pre-stage
+vector open. Treat the whole `profiles/` tree as security-bearing.

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -872,6 +872,13 @@ def generate_config_metadata() -> list[dict[str, Any]]:
             "description": meta["description"],
             "help_plain": meta.get("help_plain") or meta["description"],
             "section": meta["section"],
+            # PET-146 D2: posture scope. Every field is per-Hermes-profile today
+            # (no machine-global tier exists) — including fail_mode /
+            # egress_sink_tools / source_taint_namespaces. Emitting "profile" on
+            # every field locks the disclosure contract so a future global tier
+            # can't silently relabel an existing field; the UI prints no "global"
+            # marker while this stays uniformly "profile".
+            "scope": "profile",
         }
 
         if f.name in _SECRET_FIELDS:

--- a/petasos/console/_paths.py
+++ b/petasos/console/_paths.py
@@ -139,6 +139,93 @@ def resolve_hermes_config_path() -> HermesConfigResolution:
     )
 
 
+def _resolved_normcase(path: Path) -> str | None:
+    """``os.path.normcase`` of the ``strict=False`` resolution, or None on OSError.
+
+    The single normalization primitive for active-vs-target identity (D4):
+    Windows case-fold, trailing-slash, and symlink collapse all happen here so a
+    selected profile is compared to the live binding as the *same file*, never as
+    a raw string or leaf name.  Returns None when the OS cannot resolve the name
+    (a malformed path or an inaccessible reparse point can raise on Windows); the
+    caller treats a None as "not the active path" — the safe persist-only branch.
+    """
+    try:
+        return os.path.normcase(str(path.resolve(strict=False)))
+    except OSError:
+        return None
+
+
+def list_hermes_profiles() -> list[dict[str, Any]]:
+    """Enumerate ``profiles/*/config.yaml`` under the Hermes root.
+
+    Returns ``[{name, path, is_active, tier}]`` — one entry per profile dir that
+    holds a ``config.yaml``, sorted by leaf name, each marked ``is_active`` by the
+    normalized-path comparison (D4) against the live binding, never a raw string
+    compare.  Fail-soft: a missing or unreadable ``profiles/`` dir (and any other
+    failure) yields ``[]`` so the caller folds in the active binding as a single
+    entry.  Never raises (D3); stays logging-free to preserve this module's
+    pure-stdlib, no-logging contract — the caller (``server.get_config``) owns the
+    diagnostic WARNING for an unreadable-but-present ``profiles/`` dir.
+    """
+    try:
+        base = hermes_root() / "profiles"
+        base_resolved = base.resolve(strict=False)
+        active_norm = _resolved_normcase(resolve_hermes_config_path().path)
+        out: list[dict[str, Any]] = []
+        for child in sorted(base.iterdir()):
+            if not child.is_dir():
+                continue
+            cfg = child / "config.yaml"
+            if not cfg.is_file():
+                continue
+            try:
+                child_resolved = child.resolve(strict=False)
+            except OSError:
+                continue
+            if not child_resolved.is_relative_to(base_resolved):
+                continue
+            cfg_norm = _resolved_normcase(cfg)
+            out.append(
+                {
+                    "name": child.name,
+                    "path": str(cfg),
+                    "is_active": active_norm is not None and cfg_norm == active_norm,
+                    "tier": "profile",
+                }
+            )
+        return out
+    except Exception:
+        return []
+
+
+def resolve_profile_config_path(name: str) -> HermesConfigResolution | None:
+    """Resolve one named profile's config path, traversal-guarded.
+
+    Returns ``HermesConfigResolution(<root>/profiles/<name>/config.yaml,
+    tier="profile", warning=None)`` when *name* is a current
+    ``list_hermes_profiles()`` member — a full resolution (not a bare ``Path``) so
+    it feeds ``read_petasos_section`` directly.  Returns None when *name* is not a
+    member (unknown or deleted) or escapes the ``profiles/`` base.  The membership
+    gate is the traversal guard: ``list_hermes_profiles`` only ever emits simple
+    leaf names from ``iterdir``, so a ``../`` or absolute *name* is never a member.
+    Never raises (D3).
+    """
+    try:
+        if name not in {p["name"] for p in list_hermes_profiles()}:
+            return None
+        base = (hermes_root() / "profiles").resolve(strict=False)
+        candidate = (hermes_root() / "profiles" / name).resolve(strict=False)
+        if not candidate.is_relative_to(base):
+            return None
+        return HermesConfigResolution(
+            path=hermes_root() / "profiles" / name / "config.yaml",
+            tier="profile",
+            warning=None,
+        )
+    except Exception:
+        return None
+
+
 def read_petasos_section(res: HermesConfigResolution) -> dict[str, Any]:
     """Read the ``petasos:`` YAML section from the resolved config path.
 

--- a/petasos/console/_paths.py
+++ b/petasos/console/_paths.py
@@ -226,25 +226,48 @@ def resolve_profile_config_path(name: str) -> HermesConfigResolution | None:
         return None
 
 
+def read_petasos_section_checked(res: HermesConfigResolution) -> tuple[dict[str, Any], bool]:
+    """Read the ``petasos:`` section AND report whether the read succeeded.
+
+    Returns ``(section, ok)``.  ``ok`` is False ONLY when the file exists but is
+    unreadable *as* a petasos section: malformed YAML, a top-level non-dict, or a
+    ``petasos:`` value that is not a dict.  A missing file, an empty file, a
+    missing ``petasos:`` key, or a ``petasos:`` with no value are all ``ok=True``
+    with ``{}`` — legitimately empty, not a failure.  This lets a caller tell
+    "intentionally empty" apart from "broken": warn on GET, reject on PUT so a
+    dirty save can't merge ``{}`` with a patch and silently persist all-defaults
+    over a malformed profile (PET-146 D4 data-loss guard).  Never raises (D3).
+    """
+    import yaml
+
+    if not res.path.is_file():
+        return {}, True
+    try:
+        with open(res.path, encoding="utf-8") as f:
+            full_config = yaml.safe_load(f)
+    except Exception:
+        return {}, False
+    if full_config is None:
+        return {}, True
+    if not isinstance(full_config, dict):
+        return {}, False
+    if "petasos" not in full_config:
+        return {}, True
+    section = full_config["petasos"]
+    if section is None:
+        return {}, True
+    if not isinstance(section, dict):
+        return {}, False
+    return section, True
+
+
 def read_petasos_section(res: HermesConfigResolution) -> dict[str, Any]:
     """Read the ``petasos:`` YAML section from the resolved config path.
 
     Returns ``{}`` on missing file, unreadable file, malformed YAML,
     YAML parsing to a non-dict, or a ``petasos:`` value that is not a
-    dict.  Never raises (D3).
+    dict.  Never raises (D3).  Use ``read_petasos_section_checked`` when the
+    empty-vs-unreadable distinction matters.
     """
-    import yaml
-
-    if not res.path.is_file():
-        return {}
-    try:
-        with open(res.path, encoding="utf-8") as f:
-            full_config = yaml.safe_load(f)
-    except Exception:
-        return {}
-    if not isinstance(full_config, dict):
-        return {}
-    section = full_config.get("petasos", {})
-    if not isinstance(section, dict):
-        return {}
+    section, _ = read_petasos_section_checked(res)
     return section

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -179,9 +179,14 @@ def _require_handlers() -> Any:
 
 
 @router.get("/config")
-async def get_config() -> Any:
+async def get_config(profile: str | None = None) -> Any:
+    # PET-146 (edge F-1): the embedded Hermes-desktop bridge MUST forward the
+    # ?profile=<name> selector — this is the primary operator surface; without it
+    # the selector silently no-ops there. The PUT bridge below already forwards the
+    # body unchanged (the selector rides as a top-level body key, popped in the
+    # shared handler), so only this GET needs the explicit query param.
     h = _require_handlers()
-    return await h.get_config()
+    return await h.get_config(profile=profile)
 
 
 @router.put("/config")

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -185,8 +185,20 @@ async def get_config(profile: str | None = None) -> Any:
     # the selector silently no-ops there. The PUT bridge below already forwards the
     # body unchanged (the selector rides as a top-level body key, popped in the
     # shared handler), so only this GET needs the explicit query param.
+    from fastapi.responses import JSONResponse
+
+    from petasos.console.server import ProfileNotFoundError
+
     h = _require_handlers()
-    return await h.get_config(profile=profile)
+    # CodeRabbit PR #135: an unresolved selector is a structured 422, not a silent
+    # fallback to the equipped view (mirrors the standalone route + the PUT contract).
+    try:
+        return await h.get_config(profile=profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
 
 
 @router.put("/config")

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -24,7 +24,7 @@ from petasos.console._paths import (
     _resolved_normcase,
     hermes_root,
     list_hermes_profiles,
-    read_petasos_section,
+    read_petasos_section_checked,
     resolve_hermes_config_path,
     resolve_profile_config_path,
 )
@@ -330,6 +330,16 @@ def _persist_config(validated_config: Any, *, target_path: "Path | None" = None)
     except Exception as exc:
         _logger.error("Failed to persist config: %s", exc)
         return False
+
+
+class ProfileNotFoundError(Exception):
+    """A named profile selector did not resolve (deleted / unknown).
+
+    Raised by ``get_config`` so the route boundary can surface a structured 422,
+    mirroring ``update_config``'s contract (PET-146 edge F-6 / CodeRabbit PR #135).
+    A plain ``Exception`` (not ``ValueError``) so it is never swallowed by the
+    ``from_dict`` ``(ValueError, TypeError)`` handlers downstream.
+    """
 
 
 def _hermes_profile_label(res: "HermesConfigResolution") -> str:
@@ -690,10 +700,16 @@ class ConsoleHandlers:
 
         # PET-146 D4: a selected profile is "the equipped one" iff its resolved
         # config path is the SAME FILE as the live binding (normalized-path compare,
-        # not a leaf-name/raw-string compare). An unresolvable selector (deleted,
-        # unknown) or a resolution OSError degrades to the active view.
+        # not a leaf-name/raw-string compare).
         target_res = resolve_profile_config_path(profile) if profile is not None else None
+        # PET-146 (CodeRabbit PR #135): a NAMED selector that does not resolve
+        # (deleted/unknown) is rejected, mirroring update_config — never silently
+        # shown as the equipped view, which would risk the operator editing the
+        # wrong profile. Surfaced as a 422 at the route/bridge boundary.
+        if profile is not None and target_res is None:
+            raise ProfileNotFoundError(f"Profile {profile!r} not found")
         target_norm = _resolved_normcase(target_res.path) if target_res is not None else None
+        # A resolution OSError (target_norm None) degrades to the active view.
         viewing_active = (
             target_res is None
             or target_norm is None
@@ -715,8 +731,18 @@ class ConsoleHandlers:
             assert target_res is not None
             from petasos.config import PetasosConfig
 
+            # CodeRabbit PR #135: distinguish a read FAILURE (malformed YAML / non-dict
+            # section) from a legitimately-empty section. read_ok=False means the
+            # `{}` is a broken read, not an intentional default — warn rather than
+            # present silent defaults.
+            section, read_ok = read_petasos_section_checked(target_res)
+            if not read_ok:
+                profile_warning = (
+                    "This profile's config could not be read (malformed YAML) and is shown "
+                    "as defaults."
+                )
             try:
-                cfg = PetasosConfig.from_dict(read_petasos_section(target_res))
+                cfg = PetasosConfig.from_dict(section)
             except (ValueError, TypeError) as exc:
                 # The selected profile's config holds values PetasosConfig rejects
                 # (e.g. a bad fail_mode or unordered tiers). The console must never
@@ -727,9 +753,11 @@ class ConsoleHandlers:
                 _logger.warning("selected profile %r config rejected: %s", profile, exc)
                 cfg = PetasosConfig()
                 view_profile = None
-                profile_warning = (
-                    f"This profile's config could not be loaded and is shown as defaults: {exc}"
-                )
+                if profile_warning is None:
+                    profile_warning = (
+                        "This profile's config could not be loaded and is shown as "
+                        f"defaults: {exc}"
+                    )
             else:
                 view_profile = None
                 if cfg.profile_name:
@@ -848,7 +876,22 @@ class ConsoleHandlers:
         # all-defaults and silently reset the profile's posture (edge round-2 F-6).
         # (is_active is False only when target_res resolved — narrow for mypy.)
         assert target_res is not None
-        merged = {**read_petasos_section(target_res), **body}
+        # CodeRabbit PR #135: if the target's config is UNREADABLE (malformed YAML /
+        # non-dict section), reject rather than merge `{}` + body and silently persist
+        # all-defaults over the broken file. A legitimately-empty section (read_ok
+        # True) still saves normally (the dirty-only merge preserves on-disk posture).
+        section, read_ok = read_petasos_section_checked(target_res)
+        if not read_ok:
+            return None, [
+                {
+                    "field": "profile",
+                    "message": (
+                        "This profile's config is unreadable (malformed YAML); repair it on "
+                        "disk before saving."
+                    ),
+                }
+            ]
+        merged = {**section, **body}
         try:
             validated = PetasosConfig.from_dict(merged)
         except (ValueError, TypeError) as exc:
@@ -1129,10 +1172,18 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
         return HTMLResponse(html_path.read_text(encoding="utf-8"))
 
     @app.get("/api/config")
-    async def api_get_config(profile: str | None = None) -> dict[str, Any]:
+    async def api_get_config(profile: str | None = None) -> Any:
         # PET-146: optional ?profile=<name> selector loads a non-equipped profile's
         # effective view; absent -> the equipped binding (byte-identical to today).
-        return await handlers.get_config(profile=profile)
+        # A named selector that no longer resolves is a structured 422 (CodeRabbit
+        # PR #135), mirroring the PUT contract — not a silent fallback to active.
+        try:
+            return await handlers.get_config(profile=profile)
+        except ProfileNotFoundError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
 
     @app.put("/api/config")
     async def api_update_config(request: Request) -> Any:

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -701,6 +701,10 @@ class ConsoleHandlers:
             or target_norm == active_norm
         )
 
+        # Non-None only when the SELECTED non-equipped profile's config.yaml holds
+        # values PetasosConfig rejects (hand-edited / corrupt). Distinct from
+        # `config_warning`, which always reflects the ACTIVE binding (edge F-5).
+        profile_warning: str | None = None
         if viewing_active:
             cfg = self.pipeline.config
             view_profile = self.pipeline._default_profile
@@ -711,11 +715,26 @@ class ConsoleHandlers:
             assert target_res is not None
             from petasos.config import PetasosConfig
 
-            cfg = PetasosConfig.from_dict(read_petasos_section(target_res))
-            view_profile = None
-            if cfg.profile_name:
-                with contextlib.suppress(KeyError):
-                    view_profile = self.pipeline._profile_resolver.resolve(cfg.profile_name)
+            try:
+                cfg = PetasosConfig.from_dict(read_petasos_section(target_res))
+            except (ValueError, TypeError) as exc:
+                # The selected profile's config holds values PetasosConfig rejects
+                # (e.g. a bad fail_mode or unordered tiers). The console must never
+                # 500 on a browse — degrade to defaults for the view and surface the
+                # parse error so the operator can fix it. (A subsequent save of a
+                # dirty field that does NOT cover the bad value still 422s via the
+                # update_config merge, pinpointing the offending field.)
+                _logger.warning("selected profile %r config rejected: %s", profile, exc)
+                cfg = PetasosConfig()
+                view_profile = None
+                profile_warning = (
+                    f"This profile's config could not be loaded and is shown as defaults: {exc}"
+                )
+            else:
+                view_profile = None
+                if cfg.profile_name:
+                    with contextlib.suppress(KeyError):
+                        view_profile = self.pipeline._profile_resolver.resolve(cfg.profile_name)
 
         return {
             "config": cfg.to_dict(redact_secrets=True),
@@ -731,6 +750,7 @@ class ConsoleHandlers:
             "profile_home": str(active_res.path.parent),
             "config_tier": active_res.tier,
             "config_warning": active_res.warning,
+            "profile_warning": profile_warning,
             "effective_config": _compute_effective_config(cfg, view_profile),
             "active_profile_overrides": _active_profile_overrides(view_profile),
             "hermes_profiles": profiles,

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -20,7 +20,14 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from petasos.console._config_meta import generate_config_metadata, generate_section_metadata
-from petasos.console._paths import resolve_hermes_config_path
+from petasos.console._paths import (
+    _resolved_normcase,
+    hermes_root,
+    list_hermes_profiles,
+    read_petasos_section,
+    resolve_hermes_config_path,
+    resolve_profile_config_path,
+)
 from petasos.console._presets import generate_preset_metadata, resolve_active_preset
 from petasos.console._ring_buffer import RingBuffer
 from petasos.console._sse import SSEBroadcaster
@@ -28,9 +35,14 @@ from petasos.console._validation import SessionIdError, sanitize_session_id
 from petasos.normalize import normalize
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from fastapi import FastAPI
 
+    from petasos.config import PetasosConfig
+    from petasos.console._paths import HermesConfigResolution
     from petasos.pipeline import Pipeline
+    from petasos.session.profiles import ResolvedProfile
 
 _logger = logging.getLogger(__name__)
 
@@ -244,8 +256,18 @@ def _enforcement_summary(ev: dict[str, Any], *, provenance: str = "unattested") 
     }
 
 
-def _persist_config(validated_config: Any) -> bool:
-    """Write the petasos: section back to Hermes config.yaml.
+def _persist_config(validated_config: Any, *, target_path: "Path | None" = None) -> bool:
+    """Write the petasos: section back to a Hermes config.yaml.
+
+    ``target_path is None`` resolves the active binding via
+    ``resolve_hermes_config_path()`` (today's behavior, byte-identical) — the
+    standalone/equipped path.  An explicit ``target_path`` writes to that file
+    instead (PET-146 D4, a non-equipped profile's ``config.yaml``).  Either way
+    the write is the same atomic temp+rename; ``hash_key``/``session_secret`` are
+    popped so NO secret is ever written to any ``config.yaml`` (parity
+    active/non-active), and ``enabled``/``host_id`` are merge-preserved from the
+    written file.  Last-writer-wins across the dashboard / gateway / model-switcher
+    writers is accepted (edge F-7).
 
     Returns True on success, False on failure.
     """
@@ -254,10 +276,13 @@ def _persist_config(validated_config: Any) -> bool:
 
     import yaml
 
-    res = resolve_hermes_config_path()
-    if res.warning is not None:
-        _logger.warning("Hermes profile resolution: %s", res.warning)
-    config_path = res.path
+    if target_path is None:
+        res = resolve_hermes_config_path()
+        if res.warning is not None:
+            _logger.warning("Hermes profile resolution: %s", res.warning)
+        config_path = res.path
+    else:
+        config_path = target_path
     if not config_path.exists():
         _logger.warning("Cannot persist config — %s not found", config_path)
         return False
@@ -305,6 +330,58 @@ def _persist_config(validated_config: Any) -> bool:
     except Exception as exc:
         _logger.error("Failed to persist config: %s", exc)
         return False
+
+
+def _hermes_profile_label(res: "HermesConfigResolution") -> str:
+    """PET-146 D1 human label for a binding resolution.
+
+    The ``profiles/<name>`` leaf for ``tier == "profile"``, ``"HERMES_HOME"`` for
+    ``tier == "hermes_home"``, ``"root"`` for ``tier == "root"``.
+    """
+    if res.tier == "profile":
+        return res.path.parent.name
+    if res.tier == "hermes_home":
+        return "HERMES_HOME"
+    return "root"
+
+
+def _compute_effective_config(
+    config: "PetasosConfig", view_profile: "ResolvedProfile | None"
+) -> dict[str, Any]:
+    """PET-146 D-EFFECTIVE: the synthetic view that matches enforcement.
+
+    Starts from ``config.to_dict(redact_secrets=True)`` and overlays ONLY the tier
+    thresholds when the governing internal profile sets ``tier_thresholds`` — the
+    single config-shaped runtime override (``guard._state_to_tier`` consults
+    ``profile.tier_thresholds`` over ``config.{tier1,2,3}_threshold``).  No other
+    field is overlaid, because no other config-shaped field is overridden at
+    runtime.  ``confidence_floor`` is a live finding-dropping override but is NOT a
+    ``PetasosConfig`` field, so it cannot appear here — it surfaces in
+    ``active_profile_overrides`` instead (corr F-1).
+    """
+    eff = config.to_dict(redact_secrets=True)
+    if view_profile is not None and view_profile.tier_thresholds is not None:
+        tt = view_profile.tier_thresholds
+        eff["tier1_threshold"] = tt.tier1
+        eff["tier2_threshold"] = tt.tier2
+        eff["tier3_threshold"] = tt.tier3
+    return eff
+
+
+def _active_profile_overrides(view_profile: "ResolvedProfile | None") -> dict[str, Any] | None:
+    """PET-146 D-EFFECTIVE: the internal profile's non-config-shaped runtime effects.
+
+    ``None`` when no internal profile governs the viewed config; else
+    ``ResolvedProfile.to_dict()`` verbatim (it emits fresh copies — frozen-exports
+    safe).  Surfaces ``confidence_floor`` (the live finding-dropping floor that is
+    not a ``PetasosConfig`` field), ``suppress_rules``, ``severity_overrides``,
+    ``pii_entities_extra``, ``tier_thresholds``, ``tool_exempt_list``,
+    ``tool_alias_map`` — what the internal profile adds, without pretending they
+    are config fields.
+    """
+    if view_profile is None:
+        return None
+    return view_profile.to_dict()
 
 
 class ConsoleHandlers:
@@ -581,64 +658,224 @@ class ConsoleHandlers:
         except Exception:
             _logger.debug("Console alert broadcast failed", exc_info=True)
 
-    async def get_config(self) -> dict[str, Any]:
-        config_dict = self.pipeline.config.to_dict(redact_secrets=True)
-        fields = generate_config_metadata()
-        sections = generate_section_metadata()
-        # PET-124: the strength-preset registry and the derived active level. The
-        # comparator is passed the PetasosConfig object (not the redacted payload
-        # dict) — no preset-owned field is a secret, so redaction cannot perturb it.
+    async def get_config(self, profile: str | None = None) -> dict[str, Any]:
+        # PET-146 D1: the active binding identity + its (possibly dangling-pointer)
+        # warning. resolve_hermes_config_path() is the same resolver _persist_config
+        # uses. The active binding's config_warning is carried in EVERY payload,
+        # regardless of the selected profile (edge F-5), so the dangling-pointer
+        # signal never vanishes while the operator browses a non-active profile.
+        active_res = resolve_hermes_config_path()
+        active_norm = _resolved_normcase(active_res.path)
+
+        # PET-146 D1: the profile list (fail-soft active-only on []).
+        profiles = list_hermes_profiles()
+        if not profiles:
+            # Caller-owned diagnostic (keeps _paths.py logging-free): WARN only when
+            # the profiles/ dir is present but enumerated empty — a benign
+            # double-log on a legitimately-empty dir is acceptable (edge F-8).
+            with contextlib.suppress(Exception):
+                if (hermes_root() / "profiles").exists():
+                    _logger.warning(
+                        "profiles/ is present but enumerated empty — selector falls back to "
+                        "the active binding only"
+                    )
+            profiles = [
+                {
+                    "name": _hermes_profile_label(active_res),
+                    "path": str(active_res.path),
+                    "is_active": True,
+                    "tier": active_res.tier,
+                }
+            ]
+
+        # PET-146 D4: a selected profile is "the equipped one" iff its resolved
+        # config path is the SAME FILE as the live binding (normalized-path compare,
+        # not a leaf-name/raw-string compare). An unresolvable selector (deleted,
+        # unknown) or a resolution OSError degrades to the active view.
+        target_res = resolve_profile_config_path(profile) if profile is not None else None
+        target_norm = _resolved_normcase(target_res.path) if target_res is not None else None
+        viewing_active = (
+            target_res is None
+            or target_norm is None
+            or active_norm is None
+            or target_norm == active_norm
+        )
+
+        if viewing_active:
+            cfg = self.pipeline.config
+            view_profile = self.pipeline._default_profile
+        else:
+            # PET-146 D4 load: read the target file's on-disk section, build a config
+            # from it, and resolve ITS internal profile via the pipeline's resolver.
+            # (viewing_active is False only when target_res resolved — narrow for mypy.)
+            assert target_res is not None
+            from petasos.config import PetasosConfig
+
+            cfg = PetasosConfig.from_dict(read_petasos_section(target_res))
+            view_profile = None
+            if cfg.profile_name:
+                with contextlib.suppress(KeyError):
+                    view_profile = self.pipeline._profile_resolver.resolve(cfg.profile_name)
+
         return {
-            "config": config_dict,
-            "fields": fields,
-            "sections": sections,
+            "config": cfg.to_dict(redact_secrets=True),
+            "fields": generate_config_metadata(),
+            "sections": generate_section_metadata(),
+            # PET-124: the strength-preset registry and the derived active level. The
+            # comparator is passed the PetasosConfig object (not the redacted payload
+            # dict) — no preset-owned field is a secret, so redaction cannot perturb it.
             "presets": generate_preset_metadata(),
-            "active_preset": resolve_active_preset(self.pipeline.config),
+            "active_preset": resolve_active_preset(cfg),
+            # PET-146 D1: the binding identity, effective view, and profile list.
+            "hermes_profile": _hermes_profile_label(active_res),
+            "profile_home": str(active_res.path.parent),
+            "config_tier": active_res.tier,
+            "config_warning": active_res.warning,
+            "effective_config": _compute_effective_config(cfg, view_profile),
+            "active_profile_overrides": _active_profile_overrides(view_profile),
+            "hermes_profiles": profiles,
+            "is_active": viewing_active,
         }
 
     async def update_config(
-        self, body: dict[str, Any]
+        self, body: dict[str, Any], profile: str | None = None
     ) -> tuple[dict[str, Any] | None, list[dict[str, str]] | None]:
-        current = self.pipeline.config.to_dict()
-        current.pop("session_secret", None)
-        merged = {**current, **body}
-        try:
-            from petasos.config import PetasosConfig
+        from petasos.config import PetasosConfig
 
+        # PET-146: the selector rides as a top-level body key on PUT (the bridge
+        # forwards the body unchanged) and falls back to the handler arg (the GET
+        # query path). Pop it BEFORE any merge so it never reaches
+        # PetasosConfig.from_dict, mirroring the session_secret pop precedent.
+        body = dict(body)
+        selector = body.pop("profile", None)
+        if selector is None:
+            selector = profile
+
+        active_res = resolve_hermes_config_path()
+        active_norm = _resolved_normcase(active_res.path)
+        target_res = resolve_profile_config_path(selector) if selector is not None else None
+
+        # PET-146 D4 / edge F-6: a named selector that no longer resolves (deleted
+        # between load and save) is rejected explicitly — never silently routed to
+        # the active file nor folded into the generic persist warning.
+        if selector is not None and target_res is None:
+            return None, [{"field": "profile", "message": f"Profile {selector!r} not found"}]
+
+        target_norm = _resolved_normcase(target_res.path) if target_res is not None else None
+        # No selector -> the equipped binding (D3, byte-identical to today). A
+        # selector that resolves to the same file as the live binding is ALSO the
+        # equipped path (D4 normalized-path compare; closes case-fold / symlink /
+        # HERMES_HOME-aliasing). A resolution OSError -> treated as NOT active (the
+        # safe persist-only branch, edge round-2 F-2).
+        is_active = target_res is None or (
+            target_norm is not None and active_norm is not None and target_norm == active_norm
+        )
+
+        if is_active:
+            # ── Equipped path (D3): unchanged validate -> reconfigure -> persist ──
+            current = self.pipeline.config.to_dict()
+            current.pop("session_secret", None)
+            merged = {**current, **body}
+            try:
+                validated = PetasosConfig.from_dict(merged)
+            except (ValueError, TypeError) as exc:
+                msg = str(exc)
+                field = _extract_field_from_error(msg, body)
+                return None, [{"field": field, "message": msg}]
+            # PET-126: route through reconfigure so the change takes effect on the
+            # running pipeline (frequency, escalation, audit verbosity, alerting, and
+            # decode_encoded_payloads all live-update), not just on a new session.
+            try:
+                self.pipeline.reconfigure(validated)
+            except KeyError as exc:
+                # PET-146 D-NONACTIVE-VALIDATION (active-path parity): an unknown
+                # profile_name surfaces from ProfileResolver.resolve inside
+                # reconfigure as a KeyError — a pre-existing 500 the selector makes
+                # reachable for arbitrary profiles. Map it to a structured 422.
+                return None, [{"field": "profile_name", "message": str(exc)}]
+            except (ValueError, TypeError) as exc:
+                # from_dict validates structure, but frequency_weights content (glob
+                # position, non-negative/finite values) is validated inside
+                # FrequencyTracker.apply_config during reconfigure. Surface that as a
+                # structured field error (422), not an unhandled 500. reconfigure is
+                # atomic (Decision 5), so the live config is unchanged on failure and
+                # we do not persist a config that could not be applied.
+                msg = str(exc)
+                field = _extract_field_from_error(msg, body)
+                return None, [{"field": field, "message": msg}]
+            persisted = _persist_config(validated)
+            result = {
+                "config": validated.to_dict(redact_secrets=True),
+                "fields": generate_config_metadata(),
+                "sections": generate_section_metadata(),
+                # PET-124: recompute the dial level from the freshly validated config
+                # so the editor re-render reflects the just-applied preset (or Custom).
+                "presets": generate_preset_metadata(),
+                "active_preset": resolve_active_preset(validated),
+                # PET-146 D3: the equipped save hot-applied; UI keeps no banner.
+                "applied": True,
+            }
+            if not persisted:
+                result["warning"] = "Config applied in memory but failed to persist to disk"
+            return result, None
+
+        # ── Non-equipped path (D4): merge on-disk section, validate, dry-run gate,
+        # persist-only (never reconfigure — the live pipeline is bound elsewhere) ──
+        # Merge base is the TARGET FILE's on-disk section, NOT the redacted client
+        # payload (edge F-2): a redacted hash_key "[REDACTED]" would pass the
+        # non-empty check and mask a real error. body is the operator's dirty-field
+        # subset only — a full-form save against an empty on-disk section would write
+        # all-defaults and silently reset the profile's posture (edge round-2 F-6).
+        # (is_active is False only when target_res resolved — narrow for mypy.)
+        assert target_res is not None
+        merged = {**read_petasos_section(target_res), **body}
+        try:
             validated = PetasosConfig.from_dict(merged)
         except (ValueError, TypeError) as exc:
             msg = str(exc)
             field = _extract_field_from_error(msg, body)
             return None, [{"field": field, "message": msg}]
-        # PET-126: route through reconfigure so the change takes effect on the
-        # running pipeline (frequency, escalation, audit verbosity, alerting, and
-        # decode_encoded_payloads all live-update), not just on a new session. A
-        # bare ``self.pipeline._config = validated`` only updated the fields read
-        # directly off _config at scan time.
+
+        # PET-146 D-NONACTIVE-VALIDATION: a non-active save skips reconfigure, so it
+        # would skip the validations that only run there. Replicate the two
+        # fail-prone ones in dry-run BEFORE any write, so an unappliable config can't
+        # be pre-staged into a profile that later becomes live.
         try:
-            self.pipeline.reconfigure(validated)
+            from petasos.session.frequency import FrequencyTracker
+
+            # The constructor validates frequency_weights content (glob position,
+            # finite, non-negative). Discard the instance; bind no callbacks.
+            FrequencyTracker(validated)
+            if validated.profile_name:
+                # KeyError on an unknown internal profile name (parity with
+                # reconfigure's ProfileResolver.resolve). Discard the result.
+                self.pipeline._profile_resolver.resolve(validated.profile_name)
         except (ValueError, TypeError) as exc:
-            # from_dict validates structure, but frequency_weights content (glob
-            # position, non-negative/finite values) is validated inside
-            # FrequencyTracker.apply_config during reconfigure. Surface that as a
-            # structured field error (422), not an unhandled 500. reconfigure is
-            # atomic (Decision 5), so the live config is unchanged on failure and
-            # we do not persist a config that could not be applied.
-            msg = str(exc)
-            field = _extract_field_from_error(msg, body)
-            return None, [{"field": field, "message": msg}]
-        persisted = _persist_config(validated)
+            return None, [{"field": "frequency_weights", "message": str(exc)}]
+        except KeyError as exc:
+            return None, [{"field": "profile_name", "message": str(exc)}]
+
+        # PET-146 D4 tripwire: a mis-determined is_active is a silent split-brain
+        # (dashboard skips reconfigure while the gateway hot-applies the file, or the
+        # reverse). Log target/active/is_active at INFO so a mis-route is visible.
+        _logger.info(
+            "Petasos non-equipped profile save: target_path=%s active_path=%s is_active=%s",
+            target_res.path,
+            active_res.path,
+            is_active,
+        )
+        persisted = _persist_config(validated, target_path=target_res.path)
         result = {
             "config": validated.to_dict(redact_secrets=True),
             "fields": generate_config_metadata(),
             "sections": generate_section_metadata(),
-            # PET-124: recompute the dial level from the freshly validated config so
-            # the editor re-render reflects the just-applied preset (or Custom).
             "presets": generate_preset_metadata(),
             "active_preset": resolve_active_preset(validated),
+            # PET-146 D5: persisted but NOT hot-applied -> UI shows the restart banner.
+            "applied": False,
         }
         if not persisted:
-            result["warning"] = "Config applied in memory but failed to persist to disk"
+            result["warning"] = "Config failed to persist to disk"
         return result, None
 
     async def run_scan(
@@ -872,8 +1109,10 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
         return HTMLResponse(html_path.read_text(encoding="utf-8"))
 
     @app.get("/api/config")
-    async def api_get_config() -> dict[str, Any]:
-        return await handlers.get_config()
+    async def api_get_config(profile: str | None = None) -> dict[str, Any]:
+        # PET-146: optional ?profile=<name> selector loads a non-equipped profile's
+        # effective view; absent -> the equipped binding (byte-identical to today).
+        return await handlers.get_config(profile=profile)
 
     @app.put("/api/config")
     async def api_update_config(request: Request) -> Any:

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -238,6 +238,20 @@
 .pet .pet-dial-rec { font-size: 11px; color: var(--tx-faint); font-family: var(--font-mono); }
 .pet .pet-dial-rec b { color: var(--amber); font-weight: 600; }
 
+/* PET-146: Hermes-agent-profile selector — sits above the Strength dial. The
+   read-out/note/banner reuse .notice for the alert strips; these style the
+   selector chrome, the binding line, the scoped note, and the effective block. */
+.pet .pet-hermes-profile-host { flex: 0 0 auto; display: flex; flex-direction: column; gap: 6px; padding: 4px 0 12px; margin-bottom: 8px; border-bottom: 1px solid var(--border-soft); }
+.pet .pet-hermes-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.pet .pet-hermes-label { flex: 0 0 auto; font-size: 13px; font-weight: 600; color: var(--tx-bright); }
+.pet .pet-hermes-select { height: 32px; min-width: 200px; }
+.pet .pet-hermes-binding { font-size: 10px; color: var(--tx-faint); font-family: var(--font-mono); }
+.pet .pet-hermes-note { font-size: 11px; color: var(--tx-faint); font-family: var(--font-mono); }
+.pet .pet-hermes-effective { display: flex; flex-direction: column; gap: 2px; padding: 8px 10px; margin-top: 4px; background: var(--bg-raised); border: 1px solid var(--border-soft); border-radius: var(--r-card); }
+.pet .pet-hermes-effective-head { font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--tx-faint); }
+.pet .pet-hermes-effective-row { font-size: 11px; color: var(--tx-mut); }
+.pet .pet-hermes-effective-faint { color: var(--tx-faint); font-style: italic; }
+
 /* flex: none, not a fixed basis — inside the column .pet-ctrl-wrap (petasos.js, PET-81)
    a 38px flex-basis becomes the *height* (column main axis beats the height property),
    rendering the pill as a 38x38 rounded square (PET-89). min/max-height + 999px radius

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -326,6 +326,11 @@
     // authoritatively on every fetch and update response.
     configPresets: null,
     configActivePreset: null,
+    // PET-146: the non-equipped Hermes profile currently being viewed/edited in the
+    // Config Editor, or null for the equipped binding (the default, byte-identical
+    // to the pre-PET-146 active-only view). Persists across renderConfig re-renders
+    // so a profile switch reloads the same profile after save/discard.
+    selectedHermesProfile: null,
     scanHistory: [],
     // PET-138: session_id -> cumulative count of tool calls bypassed while disarmed.
     // Dedicated, eviction-proof state (the count rides a single rate-limited
@@ -387,7 +392,7 @@
     _put: function (path, body) {
       return this._req(path, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
     },
-    getConfig: function () { return this._get("/config"); },
+    getConfig: function (profile) { return this._get("/config" + (profile ? ("?profile=" + encodeURIComponent(profile)) : "")); },
     putConfig: function (patch) { return this._put("/config", patch); },
     postScan: function (text, dir, sid) { return this._post("/scan", { text: text, direction: dir, session_id: sid }); },
     getHealth: function () { return this._get("/health"); },
@@ -2020,6 +2025,177 @@
     return seg;
   };
 
+  // PET-146: pure ordered option list for the Hermes-agent-profile selector,
+  // derived from a /config payload's `hermes_profiles`. First-wins dedup by name;
+  // blank / non-string names skipped; options keyed by `name` (not the display
+  // label) so a profile dir literally named "root"/"HERMES_HOME" is harmless to
+  // selection (edge F-10). Fail-soft to [] on any malformed payload; never throws.
+  Pet.hermesProfileOptions = function (d) {
+    var list = (d && Array.isArray(d.hermes_profiles)) ? d.hermes_profiles : [];
+    var out = [];
+    var seen = {};
+    list.forEach(function (p) {
+      if (!p || typeof p !== "object") return;
+      var name = p.name;
+      if (typeof name !== "string" || !name.trim()) return;
+      if (Object.prototype.hasOwnProperty.call(seen, name)) return;
+      seen[name] = true;
+      out.push({
+        name: name,
+        path: typeof p.path === "string" ? p.path : "",
+        is_active: p.is_active === true,
+        tier: typeof p.tier === "string" ? p.tier : "profile",
+      });
+    });
+    return out;
+  };
+
+  // PET-146 D5: pinned non-equipped restart-banner copy (no em dash, house style).
+  // Exported so the JS test and the impl can't drift.
+  Pet.HERMES_RESTART_BANNER =
+    "This isn't the equipped profile; changes take effect when it's equipped (restart).";
+
+  // PET-146: the Hermes-agent-profile selector. Mounts a <select> over the payload's
+  // profiles (defaulting to the equipped/active entry, or `opts.selected` when a
+  // non-equipped profile is being viewed), the binding read-out, the dangling-pointer
+  // warning strip (labeled as the ACTIVE binding so it is not misread as a property
+  // of a browsed non-active profile, edge round-2 F-7), the "scoped to the selected
+  // Hermes profile" note (no per-field "global" badge — D2), an effective
+  // (what's-enforced) read-out, and the non-equipped restart banner (D5).
+  //
+  // `opts.selected` is the name of the non-equipped profile currently viewed (or
+  // null/absent when viewing the equipped one). `opts.onSwitch(target)` is invoked
+  // with the chosen target — null for the equipped entry, else the profile name —
+  // AFTER the selector clears Pet.state.configDirty, so a subsequent save sends only
+  // the freshly-loaded profile's values (edge round-2 F-4). A switch away from a
+  // dirty form is gated behind a two-step confirm (the preset-apply idiom) so pending
+  // edits are not silently discarded (edge round-3 F-1). Never throws.
+  Pet.renderHermesProfileSelector = function (host, d, opts) {
+    opts = opts || {};
+    var onSwitch = typeof opts.onSwitch === "function" ? opts.onSwitch : function () {};
+    var options = Pet.hermesProfileOptions(d);
+    var isActiveView = !d || d.is_active !== false;
+
+    var optionByName = function (nm) {
+      for (var i = 0; i < options.length; i++) if (options[i].name === nm) return options[i];
+      return null;
+    };
+    var activeName = null;
+    options.forEach(function (o) { if (o.is_active) activeName = o.name; });
+    // The currently-selected option name: the viewed non-equipped profile when
+    // given, else the equipped entry.
+    var currentName = (!isActiveView && opts.selected) ? opts.selected : activeName;
+
+    // ── selector row ──
+    var select = Pet.h("select", { className: "pet-hermes-select input mono", ariaLabel: "Hermes agent profile" });
+    options.forEach(function (o) {
+      var label = o.name + (o.is_active ? " (equipped)" : "");
+      select.appendChild(Pet.h("option", { value: o.name }, label));
+    });
+    if (currentName != null) select.value = currentName;
+
+    var pendingTarget;   // a target awaiting a confirming second change (dirty form)
+    var removeStrip = function () {
+      var n = host.querySelector ? host.querySelector(".pet-hermes-switch-confirm") : null;
+      if (n && n.remove) n.remove();
+    };
+    var proceed = function (target) {
+      pendingTarget = undefined;
+      removeStrip();
+      // Clear pending edits + any weaken-confirm intent so the previously-viewed
+      // profile's edits neither leak into the next save (F-4) nor linger.
+      Pet.state.configDirty = {};
+      onSwitch(target);
+    };
+    select.addEventListener("change", function () {
+      var name = select.value;
+      if (name === currentName) { pendingTarget = undefined; removeStrip(); return; }   // no real change
+      var opt = optionByName(name);
+      var target = (opt && opt.is_active) ? null : name;      // equipped -> null
+      var dirtyCount = Object.keys(Pet.state.configDirty || {}).length;
+      if (dirtyCount > 0 && pendingTarget !== name) {
+        // Gate the switch: stash the intent, revert the visible value, and show the
+        // confirm strip. A second change to the same option confirms. (removeStrip
+        // only drops the DOM node — it must NOT reset pendingTarget, or the confirm
+        // could never latch.)
+        pendingTarget = name;
+        select.value = currentName != null ? currentName : "";
+        removeStrip();   // drop any stale strip before re-adding (idempotent)
+        host.appendChild(Pet.h("div", { role: "alert", className: "notice pet-hermes-switch-confirm", style: { marginTop: "8px" } },
+          Pet.Icon("warn"),
+          Pet.h("span", {}, "Switching profiles discards your " + dirtyCount + " unsaved edit" + (dirtyCount === 1 ? "" : "s") + ". Choose ", Pet.h("b", {}, name), " again to confirm.")
+        ));
+        return;
+      }
+      proceed(target);
+    });
+
+    var row = Pet.h("div", { className: "pet-hermes-row" },
+      Pet.h("label", { className: "pet-hermes-label" }, "Hermes agent profile"),
+      select
+    );
+    host.appendChild(row);
+
+    // ── binding read-out: which config.yaml, which tier ──
+    var tier = d && d.config_tier ? String(d.config_tier) : "root";
+    var home = d && d.profile_home ? String(d.profile_home) : "";
+    host.appendChild(Pet.h("div", { className: "pet-hermes-binding mono" },
+      "binding: " + (d && d.hermes_profile ? String(d.hermes_profile) : "root") + " · tier " + tier + (home ? (" · " + home) : "")));
+
+    // ── dangling-pointer warning, labeled as the ACTIVE binding (edge round-2 F-7) ──
+    if (d && d.config_warning) {
+      host.appendChild(Pet.h("div", { role: "alert", className: "notice pet-hermes-warn", style: { marginTop: "8px" } },
+        Pet.Icon("warn"),
+        Pet.h("span", {}, "Active binding: ", Pet.h("b", {}, d.hermes_profile ? String(d.hermes_profile) : "root"),
+          " has a dangling pointer. " + String(d.config_warning))));
+    }
+
+    // ── "scoped to the selected Hermes profile" note (replaces any global marker) ──
+    host.appendChild(Pet.h("div", { className: "pet-hermes-note" },
+      "Settings here are scoped to the selected Hermes profile. No machine-wide tier exists."));
+
+    // ── non-equipped restart banner (D5, pinned copy) ──
+    if (!isActiveView) {
+      host.appendChild(Pet.h("div", { role: "status", className: "notice pet-hermes-banner", style: { marginTop: "8px" } },
+        Pet.Icon("warn"), Pet.h("span", {}, Pet.HERMES_RESTART_BANNER)));
+    }
+
+    // ── effective (what's enforced) read-out ──
+    host.appendChild(Pet.hermesEffectiveReadout(d));
+    return host;
+  };
+
+  // PET-146: compact, read-only "effective (what's enforced)" block — the resolved
+  // tier thresholds (config ⊕ the internal profile's tier_thresholds) plus the
+  // internal profile's added suppressions / severity / pii / confidence floor, so
+  // the operator sees what the active internal profile adds without it masquerading
+  // as a config field. Pure builder; never throws.
+  Pet.hermesEffectiveReadout = function (d) {
+    var eff = (d && d.effective_config && typeof d.effective_config === "object") ? d.effective_config : {};
+    var ov = (d && d.active_profile_overrides && typeof d.active_profile_overrides === "object") ? d.active_profile_overrides : null;
+    var box = Pet.h("div", { className: "pet-hermes-effective" });
+    box.appendChild(Pet.h("div", { className: "pet-hermes-effective-head" }, "effective (what's enforced)"));
+    var t1 = eff.tier1_threshold, t2 = eff.tier2_threshold, t3 = eff.tier3_threshold;
+    box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" },
+      "tier thresholds: " + (t1 != null ? t1 : "?") + " / " + (t2 != null ? t2 : "?") + " / " + (t3 != null ? t3 : "?")));
+    if (ov) {
+      box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" },
+        "internal profile: " + (ov.name != null ? String(ov.name) : "(unnamed)")));
+      if (ov.confidence_floor != null) {
+        box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" }, "confidence floor: " + ov.confidence_floor));
+      }
+      var sr = Array.isArray(ov.suppress_rules) ? ov.suppress_rules : [];
+      if (sr.length) box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" }, "suppressed rules: " + sr.join(", ")));
+      var so = (ov.severity_overrides && typeof ov.severity_overrides === "object") ? Object.keys(ov.severity_overrides) : [];
+      if (so.length) box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" }, "severity overrides: " + so.length));
+      var pe = Array.isArray(ov.pii_entities_extra) ? ov.pii_entities_extra : [];
+      if (pe.length) box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row" }, "extra PII entities: " + pe.join(", ")));
+    } else {
+      box.appendChild(Pet.h("div", { className: "mono pet-hermes-effective-row pet-hermes-effective-faint" }, "no internal profile active"));
+    }
+    return box;
+  };
+
   Pet.renderConfig = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "16px", height: "100%" } });
@@ -2048,7 +2224,7 @@
       function () { return []; }
     );
 
-    Pet.api.getConfig().then(function (d) {
+    Pet.api.getConfig(Pet.state.selectedHermesProfile).then(function (d) {
       if (d.error || !d.config || !d.fields) {
         formArea.innerHTML = "";
         formArea.appendChild(Pet.h("div", { style: { padding: "20px", color: "var(--err)", fontSize: "12px", fontFamily: "var(--font-mono)" } },
@@ -2073,6 +2249,25 @@
       });
       var dialHost = Pet.h("div", { className: "pet-dial-host" });
       formArea.appendChild(dialHost);
+
+      // PET-146: the Hermes-agent-profile selector sits at the very TOP of the
+      // editor (above the Strength dial). dialHost is already appended, so
+      // insertBefore positions the selector host visually above it. `viewingActive`
+      // gates the save routing: a non-equipped view tags the PUT with the selected
+      // profile so update_config persists-only (D4) instead of hot-applying.
+      var viewingActive = d.is_active !== false;
+      var hermesHost = Pet.h("div", { className: "pet-hermes-profile-host" });
+      formArea.insertBefore(hermesHost, dialHost);
+      Pet.renderHermesProfileSelector(hermesHost, d, {
+        selected: Pet.state.selectedHermesProfile,
+        onSwitch: function (target) {
+          // target: null for the equipped entry, else the chosen profile name.
+          // configDirty was already cleared by the selector before this fires.
+          Pet.state.selectedHermesProfile = target;
+          Pet.renderConfig(container);
+        },
+      });
+
       var dialApplyInFlight = false;
       var currentConfigValues = function () {
         // Persisted config overlaid with in-memory edits, restricted to owned fields.
@@ -2104,7 +2299,12 @@
         }
         clearPresetConfirm();
         dialApplyInFlight = true;  // in-flight guard, mirrors the Apply button
-        Pet.api.putConfig(preset.overrides).then(function (resp) {
+        // PET-146: tag the PUT with the selected profile when a non-equipped profile
+        // is being viewed, so a preset apply persists to THAT profile (D4) rather
+        // than hot-applying to the equipped pipeline behind the operator's back.
+        var presetPatch = Object.assign({}, preset.overrides);
+        if (!viewingActive && Pet.state.selectedHermesProfile) presetPatch.profile = Pet.state.selectedHermesProfile;
+        Pet.api.putConfig(presetPatch).then(function (resp) {
           var failMsg = null;
           if (resp && resp._status && resp.detail) {
             var raw = Array.isArray(resp.detail) ? resp.detail : [resp.detail];
@@ -2327,8 +2527,12 @@
       };
       var saveBar = Pet.h("div", { className: "pet-save-bar", style: { position: "sticky", bottom: "0", background: "var(--bg-app)", borderTop: "1px solid var(--border-soft)", marginTop: "6px", padding: "8px 0", display: "flex", flexDirection: "column", gap: "8px" } },
         // PET-13: subtle hot-swap disclosure (PET-126), bottom-anchored, not a top warning.
+        // PET-146: honest per-view copy — the equipped profile hot-applies; a
+        // non-equipped profile persists to its config.yaml and waits for equip/restart.
         Pet.h("div", { style: { fontSize: "11px", color: "var(--tx-faint)", fontFamily: "var(--font-mono)", lineHeight: "1.5" } },
-          "Saved to config.yaml and applied to the running pipeline immediately. No restart needed; frequency counters and escalation state are preserved."),
+          viewingActive
+            ? "Saved to config.yaml and applied to the running pipeline immediately. No restart needed; frequency counters and escalation state are preserved."
+            : "Saved to the selected profile's config.yaml. Takes effect when that profile is equipped (restart); the running pipeline is not changed."),
         Pet.h("div", { style: { display: "flex", gap: "10px", justifyContent: "flex-end", alignItems: "center" } },
         Pet.h("button", { className: "btn btn-ghost", onClick: function () {
           if (applyBtn && applyBtn.disabled) return;  // PET-13: Apply in flight; don't tear down formArea mid-PUT
@@ -2348,7 +2552,14 @@
             clearWeakenConfirm();
             formArea.querySelectorAll(".pet-field-err").forEach(function (el) { el.remove(); });
             applyBtn.disabled = true;
-            Pet.api.putConfig(Pet.state.configDirty).then(function (d) {
+            // PET-146: send the dirty-field subset (never the full form — a full-form
+            // save against an empty on-disk section would reset a profile's posture,
+            // edge round-2 F-6) and, when a non-equipped profile is in view, tag it
+            // with `profile` so update_config persists-only (D4).
+            var savePatch = {};
+            Object.keys(Pet.state.configDirty).forEach(function (k) { savePatch[k] = Pet.state.configDirty[k]; });
+            if (!viewingActive && Pet.state.selectedHermesProfile) savePatch.profile = Pet.state.selectedHermesProfile;
+            Pet.api.putConfig(savePatch).then(function (d) {
               if (d._status && d.detail) {
                 var raw = Array.isArray(d.detail) ? d.detail : [d.detail];
                 var details = raw.map(function (el) {
@@ -2397,11 +2608,17 @@
               }
               Pet.state.config = d.config || Pet.state.config;
               Pet.state.configDirty = {};
+              // PET-146 D5: a non-equipped save persisted-only (applied === false) —
+              // say so honestly (takes effect on equip/restart) rather than claiming
+              // it hit the running pipeline. The re-render below re-shows the banner.
+              var savedTail = (d.applied === false)
+                ? " Saved to the selected profile; takes effect when it's equipped (restart)."
+                : " Applied to the running pipeline.";
               formArea.insertBefore(Pet.h("div", {
                 role: "status",
                 className: "notice",
                 style: { background: "var(--ok-soft)", borderColor: "rgba(63,185,80,.3)", color: "var(--ok)", marginBottom: "8px" }
-              }, Pet.Icon("check"), Pet.h("span", {}, Pet.h("b", {}, "Configuration saved."), " Applied to the running pipeline.")), formArea.firstChild);
+              }, Pet.Icon("check"), Pet.h("span", {}, Pet.h("b", {}, "Configuration saved."), savedTail)), formArea.firstChild);
               setTimeout(function () { if (Pet.state.tab === "cfg") Pet.renderConfig(container); }, 1500);
             }).then(function () { applyBtn.disabled = false; }, function () { applyBtn.disabled = false; });
           } }, Pet.Icon("check"), applyLabel);

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -2246,6 +2246,18 @@
     );
 
     Pet.api.getConfig(Pet.state.selectedHermesProfile).then(function (d) {
+      // PET-146 (CodeRabbit PR #135): a selected profile that no longer resolves
+      // (deleted out-of-band) is rejected by the backend with a 422 naming the
+      // `profile` field. Reset to the equipped view and reload, rather than bricking
+      // the editor on a stale selection (getConfig(null) won't 422, so no loop).
+      if (d && d._status === 422 && Array.isArray(d.detail) &&
+          d.detail.some(function (e) { return e && e.field === "profile"; }) &&
+          Pet.state.selectedHermesProfile) {
+        Pet.state.selectedHermesProfile = null;
+        Pet.state.configDirty = {};
+        Pet.renderConfig(container);
+        return;
+      }
       if (d.error || !d.config || !d.fields) {
         formArea.innerHTML = "";
         formArea.appendChild(Pet.h("div", { style: { padding: "20px", color: "var(--err)", fontSize: "12px", fontFamily: "var(--font-mono)" } },

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -2055,6 +2055,19 @@
   Pet.HERMES_RESTART_BANNER =
     "This isn't the equipped profile; changes take effect when it's equipped (restart).";
 
+  // PET-146: build the PUT /config payload for a save. Copies the source map (the
+  // dirty-field subset, or a preset's overrides) and tags it with `profile` ONLY
+  // when a non-equipped profile is in view, so update_config persists-only to that
+  // profile (D4); the equipped view omits `profile` and hot-applies (D3,
+  // byte-identical to pre-PET-146). Pure; never mutates the source.
+  Pet.buildSavePatch = function (source, viewingActive, selectedProfile) {
+    var patch = {};
+    var src = (source && typeof source === "object") ? source : {};
+    Object.keys(src).forEach(function (k) { patch[k] = src[k]; });
+    if (!viewingActive && selectedProfile) patch.profile = selectedProfile;
+    return patch;
+  };
+
   // PET-146: the Hermes-agent-profile selector. Mounts a <select> over the payload's
   // profiles (defaulting to the equipped/active entry, or `opts.selected` when a
   // non-equipped profile is being viewed), the binding read-out, the dangling-pointer
@@ -2148,6 +2161,14 @@
         Pet.Icon("warn"),
         Pet.h("span", {}, "Active binding: ", Pet.h("b", {}, d.hermes_profile ? String(d.hermes_profile) : "root"),
           " has a dangling pointer. " + String(d.config_warning))));
+    }
+
+    // ── selected-profile parse warning (its config.yaml holds invalid values) ──
+    // Labeled as the SELECTED profile, distinct from the active-binding warning above.
+    if (d && d.profile_warning) {
+      host.appendChild(Pet.h("div", { role: "alert", className: "notice pet-hermes-profile-warn", style: { marginTop: "8px" } },
+        Pet.Icon("warn"),
+        Pet.h("span", {}, "Selected profile: " + String(d.profile_warning))));
     }
 
     // ── "scoped to the selected Hermes profile" note (replaces any global marker) ──
@@ -2302,8 +2323,7 @@
         // PET-146: tag the PUT with the selected profile when a non-equipped profile
         // is being viewed, so a preset apply persists to THAT profile (D4) rather
         // than hot-applying to the equipped pipeline behind the operator's back.
-        var presetPatch = Object.assign({}, preset.overrides);
-        if (!viewingActive && Pet.state.selectedHermesProfile) presetPatch.profile = Pet.state.selectedHermesProfile;
+        var presetPatch = Pet.buildSavePatch(preset.overrides, viewingActive, Pet.state.selectedHermesProfile);
         Pet.api.putConfig(presetPatch).then(function (resp) {
           var failMsg = null;
           if (resp && resp._status && resp.detail) {
@@ -2556,9 +2576,7 @@
             // save against an empty on-disk section would reset a profile's posture,
             // edge round-2 F-6) and, when a non-equipped profile is in view, tag it
             // with `profile` so update_config persists-only (D4).
-            var savePatch = {};
-            Object.keys(Pet.state.configDirty).forEach(function (k) { savePatch[k] = Pet.state.configDirty[k]; });
-            if (!viewingActive && Pet.state.selectedHermesProfile) savePatch.profile = Pet.state.selectedHermesProfile;
+            var savePatch = Pet.buildSavePatch(Pet.state.configDirty, viewingActive, Pet.state.selectedHermesProfile);
             Pet.api.putConfig(savePatch).then(function (d) {
               if (d._status && d.detail) {
                 var raw = Array.isArray(d.detail) ? d.detail : [d.detail];

--- a/tests/js/hermes-profile-selector.test.mjs
+++ b/tests/js/hermes-profile-selector.test.mjs
@@ -185,7 +185,34 @@ test("loader: petasos.js exports the PET-146 surfaces", () => {
   assert.equal(typeof Pet.hermesProfileOptions, "function");
   assert.equal(typeof Pet.renderHermesProfileSelector, "function");
   assert.equal(typeof Pet.hermesEffectiveReadout, "function");
+  assert.equal(typeof Pet.buildSavePatch, "function");
   assert.equal(typeof Pet.HERMES_RESTART_BANNER, "string");
+});
+
+// ── save-routing contract: buildSavePatch tags `profile` only when non-equipped ─
+test("buildSavePatch: equipped view omits `profile`; non-equipped includes it", () => {
+  // Equipped (viewingActive true): no profile key -> update_config hot-applies (D3).
+  const equipped = Pet.buildSavePatch({ fail_mode: "open" }, true, "beta");
+  assert.equal(equipped.fail_mode, "open");
+  assert.equal("profile" in equipped, false, "equipped save must NOT carry profile");
+
+  // Non-equipped: profile tagged -> update_config persists-only (D4).
+  const nonEquipped = Pet.buildSavePatch({ fail_mode: "open" }, false, "beta");
+  assert.equal(nonEquipped.fail_mode, "open");
+  assert.equal(nonEquipped.profile, "beta", "non-equipped save tags the selected profile");
+
+  // No selected profile (defensive) -> never tags, even when not viewing active.
+  const noSel = Pet.buildSavePatch({ fail_mode: "open" }, false, null);
+  assert.equal("profile" in noSel, false);
+
+  // Pure: the source map is never mutated.
+  const src = { a: 1 };
+  Pet.buildSavePatch(src, false, "beta");
+  assert.equal("profile" in src, false, "source map left untouched");
+
+  // Degrade: a non-object source yields a bare (or profile-only) patch, never throws.
+  assert.doesNotThrow(() => Pet.buildSavePatch(null, true, null));
+  assertLoose.deepEqual(Pet.buildSavePatch(null, false, "beta"), { profile: "beta" });
 });
 
 // ── 2. hermesProfileOptions: order, dedup, skip-blank, degrade ──────────────

--- a/tests/js/hermes-profile-selector.test.mjs
+++ b/tests/js/hermes-profile-selector.test.mjs
@@ -1,0 +1,344 @@
+// Unit tests for PET-146 — the Config Editor Hermes-agent-profile selector.
+//
+// Covers the JS surfaces added to petasos/console/static/petasos.js:
+//   1. Pet.hermesProfileOptions(d) — pure ordered/deduped option list from a
+//      /config payload; fail-soft to [] on any malformed payload; never-throw.
+//   2. Pet.renderHermesProfileSelector(host, d, opts) — the render seam: a <select>
+//      over the profiles, the "scoped to the selected Hermes profile" note (no
+//      "global" badge), the binding read-out, the non-equipped restart banner, the
+//      effective read-out, and the dirty-form switch confirm gating that clears
+//      Pet.state.configDirty before invoking opts.onSwitch (edge round-2 F-4 /
+//      round-3 F-1).
+//   3. Pet.hermesEffectiveReadout(d) — the read-only effective (what's enforced)
+//      block (tier thresholds + active_profile_overrides).
+//
+// Like profile-picker.test.mjs this ships its OWN DOM shim, extended with
+// parentNode tracking, node.remove(), and a minimal class-based querySelector —
+// the only capabilities the selector needs beyond that file's shim.
+//
+// Zero npm dependencies: Node's built-in test runner + assert + node:vm, evaluating
+// the real shipped petasos.js. Run with:
+//   node --test tests/js/hermes-profile-selector.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+// Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
+// returned from the node:vm sandbox carry the sandbox realm's Object/Array
+// prototypes, so assert/strict's deepStrictEqual rejects them even when
+// structurally identical (profile-picker.test.mjs:24-29). Structural comparisons
+// of sandbox-origin values use this; primitive comparisons keep strict `assert`.
+import assertLoose from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── Extended interactive DOM shim ──────────────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType, // 1 = element, 3 = text, 11 = fragment
+    childNodes: [],
+    style: {},
+    dataset: {},
+    attributes: {},
+    handlers: {},
+    className: "",
+    title: "",
+    value: undefined,
+    parentNode: null,
+    tabIndex: undefined,
+    appendChild(child) {
+      child.parentNode = this;
+      this.childNodes.push(child);
+      return child;
+    },
+    removeChild(child) {
+      const i = this.childNodes.indexOf(child);
+      if (i !== -1) this.childNodes.splice(i, 1);
+      child.parentNode = null;
+      return child;
+    },
+    remove() {
+      if (this.parentNode) this.parentNode.removeChild(this);
+    },
+    setAttribute(k, v) {
+      this.attributes[k] = String(v);
+    },
+    getAttribute(k) {
+      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
+    },
+    addEventListener(type, fn) {
+      (this.handlers[type] = this.handlers[type] || []).push(fn);
+    },
+    // Minimal descendant ".class" matcher (the only selector the seam uses).
+    querySelector(sel) {
+      const cls = sel.startsWith(".") ? sel.slice(1) : sel;
+      const hit = (node) => {
+        for (const c of node.childNodes) {
+          if (c.nodeType === 1) {
+            if ((c.className || "").split(/\s+/).includes(cls)) return c;
+            const deep = hit(c);
+            if (deep) return deep;
+          }
+        }
+        return null;
+      };
+      return hit(this);
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("");
+    },
+    set textContent(v) {
+      const t = makeNode(3);
+      t.nodeValue = String(v);
+      t.parentNode = this;
+      this.childNodes = [t];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createElementNS(ns, tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    el.namespaceURI = ns;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+// ── Load the real petasos.js under a sandbox ───────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const src = readFileSync(petasosJsPath, "utf8");
+const sandbox = { window: {}, document };
+vm.runInNewContext(src, sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const hasClass = (el, c) => (el.className || "").split(/\s+/).includes(c);
+function findByClass(root, cls) {
+  for (const c of root.childNodes) {
+    if (c.nodeType === 1) {
+      if (hasClass(c, cls)) return c;
+      const deep = findByClass(c, cls);
+      if (deep) return deep;
+    }
+  }
+  return null;
+}
+function findByTag(root, tag) {
+  for (const c of root.childNodes) {
+    if (c.nodeType === 1) {
+      if (c.tagName === tag) return c;
+      const deep = findByTag(c, tag);
+      if (deep) return deep;
+    }
+  }
+  return null;
+}
+function optionLabels(select) {
+  return (select.childNodes || []).filter((n) => n.tagName === "OPTION").map((o) => o.textContent);
+}
+
+function payload(over) {
+  over = over || {};
+  return Object.assign(
+    {
+      is_active: true,
+      hermes_profile: "alpha",
+      config_tier: "profile",
+      profile_home: "/root/profiles/alpha",
+      config_warning: null,
+      effective_config: { tier1_threshold: 15, tier2_threshold: 30, tier3_threshold: 50 },
+      active_profile_overrides: null,
+      hermes_profiles: [
+        { name: "alpha", path: "/r/alpha", is_active: true, tier: "profile" },
+        { name: "beta", path: "/r/beta", is_active: false, tier: "profile" },
+      ],
+    },
+    over,
+  );
+}
+
+function host() {
+  return makeNode(1);
+}
+
+// ── 1. Loader guard ──────────────────────────────────────────────────────────
+test("loader: petasos.js exports the PET-146 surfaces", () => {
+  assert.equal(typeof Pet.hermesProfileOptions, "function");
+  assert.equal(typeof Pet.renderHermesProfileSelector, "function");
+  assert.equal(typeof Pet.hermesEffectiveReadout, "function");
+  assert.equal(typeof Pet.HERMES_RESTART_BANNER, "string");
+});
+
+// ── 2. hermesProfileOptions: order, dedup, skip-blank, degrade ──────────────
+test("hermesProfileOptions: ordered, first-wins deduped, blank/garbage skipped", () => {
+  const d = payload({
+    hermes_profiles: [
+      { name: "alpha", path: "/r/alpha", is_active: true, tier: "profile" },
+      { name: "beta", path: "/r/beta", is_active: false, tier: "profile" },
+      { name: "alpha", path: "/dup", is_active: false }, // dedup, first wins
+      { name: "  ", path: "/blank" }, // blank name -> skipped
+      { description: "noname" }, // no name -> skipped
+    ],
+  });
+  const opts = Pet.hermesProfileOptions(d);
+  assertLoose.deepEqual(opts.map((o) => o.name), ["alpha", "beta"]);
+  assert.equal(opts[0].is_active, true);
+  assert.equal(opts[1].is_active, false);
+
+  for (const bad of [null, undefined, {}, { hermes_profiles: "nope" }, { hermes_profiles: 7 }]) {
+    let out;
+    assert.doesNotThrow(() => { out = Pet.hermesProfileOptions(bad); });
+    assert.ok(Array.isArray(out));
+    assert.equal(out.length, 0);
+  }
+});
+
+// ── 3. selector renders: <select>, options, scoped note, no "global" badge ──
+test("renderHermesProfileSelector: select + options + scoped note, no global marker", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  Pet.renderHermesProfileSelector(h, payload(), { selected: null, onSwitch() {} });
+
+  const select = findByTag(h, "SELECT");
+  assert.ok(select, "a <select> is rendered");
+  const labels = optionLabels(select);
+  assert.equal(labels.length, 2);
+  assert.ok(labels.some((l) => l.includes("alpha") && l.includes("(equipped)")), "equipped option labeled");
+  assert.ok(labels.some((l) => l.includes("beta")), "non-equipped option present");
+
+  const note = findByClass(h, "pet-hermes-note");
+  assert.ok(note, "scoped note present");
+  assert.ok(note.textContent.includes("scoped to the selected Hermes profile"));
+  // No per-field "global" badge anywhere in the selector subtree.
+  assert.ok(!h.textContent.toLowerCase().includes("global"), "no 'global' marker rendered");
+
+  // Default selection is the equipped entry when viewing active.
+  assert.equal(select.value, "alpha");
+});
+
+// ── 4. non-equipped view shows the pinned restart banner ────────────────────
+test("renderHermesProfileSelector: is_active false renders the pinned restart banner", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  Pet.renderHermesProfileSelector(h, payload({ is_active: false }), { selected: "beta", onSwitch() {} });
+
+  const banner = findByClass(h, "pet-hermes-banner");
+  assert.ok(banner, "restart banner present when non-equipped");
+  assert.ok(banner.textContent.includes(Pet.HERMES_RESTART_BANNER));
+  // The pinned copy is exact (JS test and impl cannot drift) and em-dash-free.
+  assert.equal(
+    Pet.HERMES_RESTART_BANNER,
+    "This isn't the equipped profile; changes take effect when it's equipped (restart).",
+  );
+  assert.ok(!Pet.HERMES_RESTART_BANNER.includes("—"), "no em dash (house style)");
+});
+
+test("renderHermesProfileSelector: equipped view renders NO restart banner", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  Pet.renderHermesProfileSelector(h, payload({ is_active: true }), { selected: null, onSwitch() {} });
+  assert.equal(findByClass(h, "pet-hermes-banner"), null);
+});
+
+// ── 5. effective read-out reflects tier thresholds + overrides ──────────────
+test("hermesEffectiveReadout: renders tier thresholds and active_profile_overrides", () => {
+  const d = payload({
+    effective_config: { tier1_threshold: 25, tier2_threshold: 45, tier3_threshold: 70 },
+    active_profile_overrides: {
+      name: "research",
+      confidence_floor: 0.7,
+      suppress_rules: ["petasos.syntactic.encoding.base64-in-text"],
+      severity_overrides: {},
+      pii_entities_extra: [],
+    },
+  });
+  const box = Pet.hermesEffectiveReadout(d);
+  const txt = box.textContent;
+  assert.ok(txt.includes("effective (what's enforced)"));
+  assert.ok(txt.includes("25") && txt.includes("45") && txt.includes("70"), "profile tier thresholds shown");
+  assert.ok(txt.includes("research"), "internal profile named");
+  assert.ok(txt.includes("0.7"), "confidence floor surfaced (it is NOT a config field)");
+});
+
+// ── 6. clean-form switch invokes onSwitch immediately ───────────────────────
+test("switch on a clean form: change invokes onSwitch with the target name", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  let got = "UNSET";
+  Pet.renderHermesProfileSelector(h, payload(), { selected: null, onSwitch(t) { got = t; } });
+  const select = findByTag(h, "SELECT");
+
+  select.value = "beta";
+  select.handlers.change[0]();
+  assert.equal(got, "beta", "non-equipped target passed through");
+});
+
+test("switch to the equipped entry passes null (loads the live config)", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  let got = "UNSET";
+  Pet.renderHermesProfileSelector(h, payload({ is_active: false }), { selected: "beta", onSwitch(t) { got = t; } });
+  const select = findByTag(h, "SELECT");
+
+  select.value = "alpha"; // alpha is the equipped option
+  select.handlers.change[0]();
+  assert.equal(got, null, "equipped entry -> null target");
+});
+
+// ── 7. dirty-form switch is gated, then confirmed (round-2 F-4 / round-3 F-1) ─
+test("dirty-form switch: first change prompts confirm + keeps configDirty; second confirms + clears it", () => {
+  Pet.state.configDirty = { fail_mode: "open" }; // an unsaved edit under profile A
+  const h = host();
+  const calls = [];
+  Pet.renderHermesProfileSelector(h, payload(), { selected: null, onSwitch(t) { calls.push(t); } });
+  const select = findByTag(h, "SELECT");
+
+  // First change toward beta: gated. onSwitch NOT called; configDirty intact;
+  // a confirm strip appears; the visible value reverts to the current (alpha).
+  select.value = "beta";
+  select.handlers.change[0]();
+  assert.equal(calls.length, 0, "switch not committed on first change");
+  assertLoose.deepEqual(Pet.state.configDirty, { fail_mode: "open" }, "edits preserved, not discarded");
+  assert.ok(findByClass(h, "pet-hermes-switch-confirm"), "confirm strip shown");
+  assert.equal(select.value, "alpha", "visible selection reverted pending confirm");
+
+  // Second change to the SAME target confirms: onSwitch fires with beta and
+  // configDirty is cleared so a subsequent save sends only B's values.
+  select.value = "beta";
+  select.handlers.change[0]();
+  assertLoose.deepEqual(calls, ["beta"], "switch committed on confirm");
+  assertLoose.deepEqual(Pet.state.configDirty, {}, "configDirty cleared before onSwitch");
+});
+
+// ── 8. dangling-pointer warning labeled as the ACTIVE binding (round-2 F-7) ──
+test("renderHermesProfileSelector: config_warning renders labeled as the active binding", () => {
+  Pet.state.configDirty = {};
+  const h = host();
+  Pet.renderHermesProfileSelector(
+    h,
+    payload({ is_active: false, selected: "beta", config_warning: "active_profile points to a missing dir" }),
+    { selected: "beta", onSwitch() {} },
+  );
+  const warn = findByClass(h, "pet-hermes-warn");
+  assert.ok(warn, "warning strip present");
+  assert.ok(warn.textContent.includes("Active binding"), "labeled as the ACTIVE binding, not the browsed profile");
+});

--- a/tests/test_console_hermes_profile.py
+++ b/tests/test_console_hermes_profile.py
@@ -25,7 +25,7 @@ pytest.importorskip("fastapi")
 
 from petasos.config import PetasosConfig  # noqa: E402
 from petasos.console.hermes import plugin_api  # noqa: E402
-from petasos.console.server import ConsoleHandlers  # noqa: E402
+from petasos.console.server import ConsoleHandlers, ProfileNotFoundError  # noqa: E402
 from petasos.pipeline import Pipeline  # noqa: E402
 from petasos.scanners.minimal import MinimalScanner  # noqa: E402
 
@@ -396,6 +396,66 @@ async def test_get_config_malformed_profile_degrades_without_500(
     # The valid-profile path leaves profile_warning None.
     ok = await handlers.get_config()
     assert ok["profile_warning"] is None
+
+
+def _write_unreadable_profile(root: Path, name: str) -> Path:
+    # A member profile (config.yaml exists) whose petasos: section is a non-dict —
+    # read_petasos_section_checked() reports ok=False (a real read failure).
+    pdir = root / "profiles" / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    cfg = pdir / "config.yaml"
+    cfg.write_text("petasos:\n  - not\n  - a dict\n", encoding="utf-8")
+    return cfg
+
+
+async def test_get_config_unreadable_profile_warns_not_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # CodeRabbit PR #135 (read-failure provenance): a malformed-YAML profile must
+    # not silently present defaults — read_ok=False surfaces a profile_warning.
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    _write_unreadable_profile(root, "beta")
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    payload = await handlers.get_config(profile="beta")
+    assert payload["is_active"] is False
+    assert payload["profile_warning"] is not None  # not a silent default
+
+
+async def test_nonactive_save_rejects_unreadable_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # CodeRabbit PR #135: a dirty save against an UNREADABLE profile is rejected, so
+    # it cannot merge {} + body and silently persist all-defaults over the broken file.
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    beta = _write_unreadable_profile(root, "beta")
+    before = beta.read_bytes()
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    result, errors = await handlers.update_config({"fail_mode": "open"}, profile="beta")
+    assert result is None and errors is not None
+    assert errors[0]["field"] == "profile"
+    assert beta.read_bytes() == before  # the broken file is left untouched
+
+
+async def test_get_config_unresolved_selector_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # CodeRabbit PR #135 (outside-diff): a named selector that does not resolve is
+    # rejected (ProfileNotFoundError -> route 422), never a silent fallback to the
+    # equipped view (which would risk editing the wrong profile).
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    with pytest.raises(ProfileNotFoundError):
+        await handlers.get_config(profile="ghost")
+    # The bridge maps it to a 422 (not a 500 / silent active view).
+    monkeypatch.setattr(plugin_api, "_handlers", handlers)
+    resp = await plugin_api.get_config(profile="ghost")
+    assert getattr(resp, "status_code", None) == 422
 
 
 # ── edge F-1: the embedded plugin bridge forwards the selector ──────────────

--- a/tests/test_console_hermes_profile.py
+++ b/tests/test_console_hermes_profile.py
@@ -32,6 +32,8 @@ from petasos.scanners.minimal import MinimalScanner  # noqa: E402
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from fastapi import Request
+
 pytestmark = pytest.mark.anyio
 
 
@@ -497,8 +499,13 @@ async def test_bridge_forwards_profile_selector(
         async def json(self) -> dict[str, Any]:
             return self._d
 
-    # _Req is a minimal stand-in for fastapi.Request (only .json() is used).
-    out = await plugin_api.update_config(_Req({"fail_mode": "open", "profile": "beta"}))  # type: ignore[arg-type]
+    # _Req is a minimal stand-in for fastapi.Request (only .json() is used). The
+    # cast keeps mypy --strict green across environments that disagree on whether
+    # `Request` resolves to a concrete type or to Any (the bare arg-type ignore was
+    # flagged unused under the CI stubs).
+    out = await plugin_api.update_config(
+        cast("Request", _Req({"fail_mode": "open", "profile": "beta"}))
+    )
     assert isinstance(out, dict)
     assert out["applied"] is False
     assert _section_of(beta)["fail_mode"] == "open"

--- a/tests/test_console_hermes_profile.py
+++ b/tests/test_console_hermes_profile.py
@@ -1,0 +1,406 @@
+"""PET-146: Config Editor Hermes-agent-profile selector — backend tests.
+
+Covers the ``get_config``/``update_config`` payload extension and routing:
+the binding identity + effective view (D1/D-EFFECTIVE), the equipped vs
+non-equipped save split (D3/D4), the non-active dry-run validation gate
+(D-NONACTIVE-VALIDATION), secret omission parity (edge round-2 F-1), normalized
+is_active determination (edge F-3), and the embedded plugin bridge forwarding the
+selector (edge F-1).
+
+The handlers resolve the active Hermes binding from the environment at call time
+(``resolve_hermes_config_path``), so each test redirects the platform-appropriate
+root env var to a ``tmp_path`` sandbox with real ``profiles/<name>/config.yaml``
+fixtures — the same shape the live resolver reads.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+pytest.importorskip("fastapi")
+
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console.hermes import plugin_api  # noqa: E402
+from petasos.console.server import ConsoleHandlers  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.anyio
+
+
+# ── env-driven Hermes-root sandbox ──────────────────────────────────────────
+def _point_root_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    from petasos.console._paths import hermes_root
+
+    root = hermes_root()
+    (root / "profiles").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_profile(
+    root: Path, name: str, section: dict[str, Any] | None = None, *, active: bool = False
+) -> Path:
+    pdir = root / "profiles" / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    cfg_path = pdir / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"petasos": section or {}}), encoding="utf-8")
+    if active:
+        (root / "active_profile").write_text(name, encoding="utf-8")
+    return cfg_path
+
+
+def _handlers(config: PetasosConfig | None = None) -> ConsoleHandlers:
+    return ConsoleHandlers(
+        Pipeline(scanners=[MinimalScanner()], config=config or PetasosConfig(fail_mode="degraded"))
+    )
+
+
+def _section_of(cfg_path: Path) -> dict[str, Any]:
+    return yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["petasos"]
+
+
+# ── D1: binding identity for each tier ──────────────────────────────────────
+async def test_get_config_surfaces_binding_profile_tier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    active = _write_profile(root, "gibson", {"fail_mode": "open"}, active=True)
+    payload = await _handlers().get_config()
+
+    assert payload["config_tier"] == "profile"
+    assert payload["hermes_profile"] == "gibson"
+    assert payload["profile_home"] == str(active.parent)
+    assert payload["config_warning"] is None
+    assert payload["is_active"] is True
+    names = {p["name"] for p in payload["hermes_profiles"]}
+    assert "gibson" in names
+
+
+async def test_get_config_surfaces_binding_hermes_home_tier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_root_at(tmp_path, monkeypatch)
+    hh = tmp_path / "hh"
+    hh.mkdir()
+    (hh / "config.yaml").write_text(yaml.safe_dump({"petasos": {}}), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hh))
+
+    payload = await _handlers().get_config()
+    assert payload["config_tier"] == "hermes_home"
+    assert payload["hermes_profile"] == "HERMES_HOME"
+
+
+async def test_get_config_surfaces_binding_root_tier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_root_at(tmp_path, monkeypatch)  # no active_profile pointer, no HERMES_HOME
+    payload = await _handlers().get_config()
+    assert payload["config_tier"] == "root"
+    assert payload["hermes_profile"] == "root"
+
+
+# ── D-EFFECTIVE: effective view reflects the internal profile overlay ────────
+async def test_get_config_effective_settings_reflect_internal_profile_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_root_at(tmp_path, monkeypatch)
+    # 'research' sets tier_thresholds {25,45,70} and confidence_floor 0.7.
+    handlers = _handlers(PetasosConfig(fail_mode="degraded", profile_name="research"))
+    payload = await handlers.get_config()
+
+    eff = payload["effective_config"]
+    # Positive: effective tier thresholds reflect the PROFILE, not the raw config.
+    assert eff["tier1_threshold"] == 25
+    assert eff["tier2_threshold"] == 45
+    assert eff["tier3_threshold"] == 70
+
+    ov = payload["active_profile_overrides"]
+    assert ov is not None
+    assert ov["name"] == "research"
+    # Negative (corr F-1): confidence_floor is NOT a PetasosConfig field, so it is
+    # ABSENT from effective_config but PRESENT in active_profile_overrides.
+    assert "confidence_floor" not in eff
+    assert ov["confidence_floor"] == 0.7
+
+
+async def test_get_config_no_internal_profile_overrides_is_null(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _point_root_at(tmp_path, monkeypatch)
+    payload = await _handlers(PetasosConfig(fail_mode="degraded")).get_config()
+    assert payload["active_profile_overrides"] is None
+    # No overlay -> effective tier thresholds equal the raw config defaults.
+    assert payload["effective_config"]["tier1_threshold"] == payload["config"]["tier1_threshold"]
+
+
+# ── D2: scope metadata is uniformly "profile" ───────────────────────────────
+async def test_field_scope_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _point_root_at(tmp_path, monkeypatch)
+    payload = await _handlers().get_config()
+    fields = {f["name"]: f for f in payload["fields"]}
+    assert fields  # non-empty
+    assert all(f["scope"] == "profile" for f in fields.values())
+    # The three reversed levers are explicitly per-profile, none "global".
+    for lever in ("fail_mode", "egress_sink_tools", "source_taint_namespaces"):
+        assert fields[lever]["scope"] == "profile"
+    assert not any(f["scope"] == "global" for f in fields.values())
+
+
+# ── D3: equipped edit hot-applies (PET-126 regression) ──────────────────────
+async def test_edit_active_profile_hotapplies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    active = _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    calls = {"n": 0}
+    orig = handlers.pipeline.reconfigure
+
+    def _spy(cfg: PetasosConfig) -> None:
+        calls["n"] += 1
+        orig(cfg)
+
+    monkeypatch.setattr(handlers.pipeline, "reconfigure", _spy)
+
+    result, errors = await handlers.update_config({"fail_mode": "closed"})
+    assert errors is None
+    assert result is not None
+    assert result["applied"] is True
+    assert calls["n"] == 1  # reconfigure ran (hot-apply)
+    assert handlers.pipeline.config.fail_mode == "closed"
+    assert _section_of(active)["fail_mode"] == "closed"  # persisted to the active file
+
+
+# ── D4: non-equipped edit persists without hot-apply ────────────────────────
+async def test_edit_nonactive_profile_persists_without_hotapply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    beta = _write_profile(root, "beta", {"fail_mode": "degraded"})
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    before_cfg = handlers.pipeline.config
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        handlers.pipeline,
+        "reconfigure",
+        lambda cfg: calls.__setitem__("n", calls["n"] + 1),
+    )
+
+    result, errors = await handlers.update_config({"fail_mode": "open"}, profile="beta")
+    assert errors is None
+    assert result is not None
+    assert result["applied"] is False
+    assert calls["n"] == 0  # no reconfigure on the non-equipped path
+    assert handlers.pipeline.config is before_cfg  # live config untouched
+    assert _section_of(beta)["fail_mode"] == "open"  # target file written
+
+
+async def test_safety_levers_persist_per_hermes_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    # X carries an on-disk posture field NOT in the save body, to prove dirty-only
+    # saves preserve (not reset) untouched posture (edge round-2 F-6).
+    x = _write_profile(root, "x", {"fail_mode": "degraded", "tool_guard_enabled": False})
+    y = _write_profile(root, "y", {"fail_mode": "closed"})
+    y_before = y.read_bytes()
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    body = {
+        "fail_mode": "open",
+        "source_taint_namespaces": ["vault"],
+        "egress_sink_tools": ["mcp.send"],
+    }
+    result, errors = await handlers.update_config(body, profile="x")
+    assert errors is None and result is not None
+
+    sec = _section_of(x)
+    assert sec["fail_mode"] == "open"
+    assert sec["source_taint_namespaces"] == ["vault"]
+    assert sec["egress_sink_tools"] == ["mcp.send"]
+    # The on-disk lever not in the body survived (merge base = on-disk section).
+    assert sec["tool_guard_enabled"] is False
+    # A sibling profile is byte-for-byte untouched.
+    assert y.read_bytes() == y_before
+
+
+async def test_nonactive_save_omits_secrets_from_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    beta = _write_profile(root, "beta", {"fail_mode": "degraded"})
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    # A client payload carrying a redacted hash_key must not land on disk: the
+    # secret is popped on every write (parity with the active path).
+    result, errors = await handlers.update_config(
+        {"fail_mode": "open", "hash_key": "[REDACTED]"}, profile="beta"
+    )
+    assert errors is None and result is not None and result["applied"] is False
+
+    raw = beta.read_text(encoding="utf-8")
+    assert "hash_key" not in raw
+    assert "session_secret" not in raw
+    assert "[REDACTED]" not in raw
+
+
+# ── edge F-3: is_active is a normalized-path equality, not a leaf compare ────
+async def test_is_active_path_normalization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    alpha = _write_profile(root, "alpha", {"fail_mode": "degraded"})
+    # Alias case (cross-platform): HERMES_HOME points AT profiles/alpha, so the
+    # active binding file IS alpha's config.yaml. A save targeting "alpha" must be
+    # recognized as the equipped path (reconfigure), never mis-routed to persist-only.
+    monkeypatch.setenv("HERMES_HOME", str(alpha.parent))
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    calls = {"n": 0}
+    orig = handlers.pipeline.reconfigure
+    monkeypatch.setattr(
+        handlers.pipeline,
+        "reconfigure",
+        lambda cfg: (calls.__setitem__("n", calls["n"] + 1), orig(cfg))[1],
+    )
+    result, errors = await handlers.update_config({"fail_mode": "closed"}, profile="alpha")
+    assert errors is None and result is not None
+    assert result["applied"] is True  # equipped path
+    assert calls["n"] == 1
+
+    # And the read side agrees: get_config(profile="alpha") reports is_active True.
+    payload = await handlers.get_config(profile="alpha")
+    assert payload["is_active"] is True
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="case-fold is Windows-only")
+async def test_is_active_path_normalization_casefold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    alpha = _write_profile(root, "alpha", {"fail_mode": "degraded"})
+    # HERMES_HOME with a case-variant of the same path: on Windows os.path.normcase
+    # folds them equal, so the equipped edit is still recognized.
+    monkeypatch.setenv("HERMES_HOME", str(alpha.parent).upper())
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+    payload = await handlers.get_config(profile="alpha")
+    assert payload["is_active"] is True
+
+
+# ── D-NONACTIVE-VALIDATION: dry-run gate rejects unappliable configs ─────────
+async def test_nonactive_save_validation_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    beta = _write_profile(root, "beta", {"fail_mode": "degraded"})
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    # (a) malformed frequency_weights (negative weight) -> 422, byte-unchanged.
+    before = beta.read_bytes()
+    result, errors = await handlers.update_config(
+        {"frequency_weights": {"some_tool": -1.0}}, profile="beta"
+    )
+    assert result is None and errors is not None
+    assert errors[0]["field"] == "frequency_weights"
+    assert beta.read_bytes() == before  # nothing pre-staged
+
+    # (b) unresolvable profile_name -> 422 {field: profile_name}, byte-unchanged.
+    result, errors = await handlers.update_config(
+        {"profile_name": "no_such_profile_xyz"}, profile="beta"
+    )
+    assert result is None and errors is not None
+    assert errors[0]["field"] == "profile_name"
+    assert beta.read_bytes() == before
+
+
+async def test_active_save_bad_profile_name_maps_to_422(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Active-path parity: an unknown profile_name surfaces as a structured 422, not
+    # an unhandled 500 from reconfigure's ProfileResolver.resolve KeyError.
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    result, errors = await handlers.update_config({"profile_name": "no_such_profile_xyz"})
+    assert result is None and errors is not None
+    assert errors[0]["field"] == "profile_name"
+
+
+async def test_save_nonexistent_profile_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # edge F-6: a selector that no longer resolves (deleted between load and save)
+    # is rejected explicitly, never silently routed to the active file.
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    result, errors = await handlers.update_config({"fail_mode": "open"}, profile="ghost")
+    assert result is None and errors is not None
+    assert errors[0]["field"] == "profile"
+
+
+# ── D4 load + edge F-5: non-active view carries the active binding's warning ─
+async def test_get_config_nonactive_view_loads_target_and_carries_active_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    # A DANGLING active_profile pointer -> tier root + warning on the active binding.
+    (root / "active_profile").write_text("missing_profile", encoding="utf-8")
+    _write_profile(root, "beta", {"fail_mode": "open"})
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    payload = await handlers.get_config(profile="beta")
+    assert payload["is_active"] is False
+    assert payload["config"]["fail_mode"] == "open"  # loaded from beta's file
+    # The dangling-pointer signal is the ACTIVE binding's, carried regardless of the
+    # browsed profile (edge F-5).
+    assert payload["config_warning"] is not None
+
+
+# ── edge F-1: the embedded plugin bridge forwards the selector ──────────────
+async def test_bridge_forwards_profile_selector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    beta = _write_profile(root, "beta", {"fail_mode": "degraded"})
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+    monkeypatch.setattr(plugin_api, "_handlers", handlers)
+
+    # GET bridge forwards ?profile= -> the non-active view of beta.
+    got = await plugin_api.get_config(profile="beta")
+    assert got["is_active"] is False
+
+    # PUT bridge forwards the body (selector rides as a top-level key) -> persists
+    # to beta without hot-applying.
+    class _Req:
+        def __init__(self, data: dict[str, Any]) -> None:
+            self._d = data
+
+        async def json(self) -> dict[str, Any]:
+            return self._d
+
+    out = await plugin_api.update_config(_Req({"fail_mode": "open", "profile": "beta"}))
+    assert isinstance(out, dict)
+    assert out["applied"] is False
+    assert _section_of(beta)["fail_mode"] == "open"

--- a/tests/test_console_hermes_profile.py
+++ b/tests/test_console_hermes_profile.py
@@ -16,7 +16,7 @@ fixtures — the same shape the live resolver reads.
 from __future__ import annotations
 
 import platform
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 import yaml
@@ -68,7 +68,8 @@ def _handlers(config: PetasosConfig | None = None) -> ConsoleHandlers:
 
 
 def _section_of(cfg_path: Path) -> dict[str, Any]:
-    return yaml.safe_load(cfg_path.read_text(encoding="utf-8"))["petasos"]
+    full = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", full["petasos"])
 
 
 # ── D1: binding identity for each tier ──────────────────────────────────────
@@ -195,11 +196,11 @@ async def test_edit_nonactive_profile_persists_without_hotapply(
 
     before_cfg = handlers.pipeline.config
     calls = {"n": 0}
-    monkeypatch.setattr(
-        handlers.pipeline,
-        "reconfigure",
-        lambda cfg: calls.__setitem__("n", calls["n"] + 1),
-    )
+
+    def _count(cfg: PetasosConfig) -> None:
+        calls["n"] += 1
+
+    monkeypatch.setattr(handlers.pipeline, "reconfigure", _count)
 
     result, errors = await handlers.update_config({"fail_mode": "open"}, profile="beta")
     assert errors is None
@@ -275,11 +276,12 @@ async def test_is_active_path_normalization(
 
     calls = {"n": 0}
     orig = handlers.pipeline.reconfigure
-    monkeypatch.setattr(
-        handlers.pipeline,
-        "reconfigure",
-        lambda cfg: (calls.__setitem__("n", calls["n"] + 1), orig(cfg))[1],
-    )
+
+    def _spy(cfg: PetasosConfig) -> None:
+        calls["n"] += 1
+        orig(cfg)
+
+    monkeypatch.setattr(handlers.pipeline, "reconfigure", _spy)
     result, errors = await handlers.update_config({"fail_mode": "closed"}, profile="alpha")
     assert errors is None and result is not None
     assert result["applied"] is True  # equipped path
@@ -398,24 +400,37 @@ async def test_get_config_malformed_profile_degrades_without_500(
     assert ok["profile_warning"] is None
 
 
-def _write_unreadable_profile(root: Path, name: str) -> Path:
-    # A member profile (config.yaml exists) whose petasos: section is a non-dict —
+# Two distinct read-failure shapes read_petasos_section_checked() must catch:
+# (1) valid YAML whose petasos: value is a non-dict (shape failure), and
+# (2) genuinely malformed YAML syntax that makes yaml.safe_load raise (the
+# except branch) — CodeRabbit PR #135 review #2 nit.
+_UNREADABLE_PROFILE_CASES = (
+    "petasos:\n  - not\n  - a dict\n",  # non-dict section (shape branch)
+    "petasos: [\n",  # unclosed flow sequence -> yaml.safe_load raises (except branch)
+)
+
+
+def _write_unreadable_profile(
+    root: Path, name: str, contents: str = _UNREADABLE_PROFILE_CASES[0]
+) -> Path:
+    # A member profile (config.yaml exists) whose petasos: section cannot be read —
     # read_petasos_section_checked() reports ok=False (a real read failure).
     pdir = root / "profiles" / name
     pdir.mkdir(parents=True, exist_ok=True)
     cfg = pdir / "config.yaml"
-    cfg.write_text("petasos:\n  - not\n  - a dict\n", encoding="utf-8")
+    cfg.write_text(contents, encoding="utf-8")
     return cfg
 
 
+@pytest.mark.parametrize("contents", _UNREADABLE_PROFILE_CASES)
 async def test_get_config_unreadable_profile_warns_not_silent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, contents: str
 ) -> None:
     # CodeRabbit PR #135 (read-failure provenance): a malformed-YAML profile must
     # not silently present defaults — read_ok=False surfaces a profile_warning.
     root = _point_root_at(tmp_path, monkeypatch)
     _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
-    _write_unreadable_profile(root, "beta")
+    _write_unreadable_profile(root, "beta", contents)
     handlers = _handlers(PetasosConfig(fail_mode="degraded"))
 
     payload = await handlers.get_config(profile="beta")
@@ -423,14 +438,15 @@ async def test_get_config_unreadable_profile_warns_not_silent(
     assert payload["profile_warning"] is not None  # not a silent default
 
 
+@pytest.mark.parametrize("contents", _UNREADABLE_PROFILE_CASES)
 async def test_nonactive_save_rejects_unreadable_profile(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, contents: str
 ) -> None:
     # CodeRabbit PR #135: a dirty save against an UNREADABLE profile is rejected, so
     # it cannot merge {} + body and silently persist all-defaults over the broken file.
     root = _point_root_at(tmp_path, monkeypatch)
     _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
-    beta = _write_unreadable_profile(root, "beta")
+    beta = _write_unreadable_profile(root, "beta", contents)
     before = beta.read_bytes()
     handlers = _handlers(PetasosConfig(fail_mode="degraded"))
 
@@ -481,7 +497,8 @@ async def test_bridge_forwards_profile_selector(
         async def json(self) -> dict[str, Any]:
             return self._d
 
-    out = await plugin_api.update_config(_Req({"fail_mode": "open", "profile": "beta"}))
+    # _Req is a minimal stand-in for fastapi.Request (only .json() is used).
+    out = await plugin_api.update_config(_Req({"fail_mode": "open", "profile": "beta"}))  # type: ignore[arg-type]
     assert isinstance(out, dict)
     assert out["applied"] is False
     assert _section_of(beta)["fail_mode"] == "open"

--- a/tests/test_console_hermes_profile.py
+++ b/tests/test_console_hermes_profile.py
@@ -377,6 +377,27 @@ async def test_get_config_nonactive_view_loads_target_and_carries_active_warning
     assert payload["config_warning"] is not None
 
 
+async def test_get_config_malformed_profile_degrades_without_500(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A hand-edited / corrupt non-equipped config.yaml (valid YAML dict, but a value
+    # PetasosConfig rejects) must never 500 the browse: get_config degrades to
+    # defaults and surfaces a profile_warning (CodeRabbit PR #135).
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "degraded"}, active=True)
+    _write_profile(root, "beta", {"fail_mode": "bogus"})  # invalid enum -> from_dict raises
+    handlers = _handlers(PetasosConfig(fail_mode="degraded"))
+
+    payload = await handlers.get_config(profile="beta")
+    assert payload["is_active"] is False
+    assert payload["profile_warning"] is not None
+    # Shown as defaults (a valid PetasosConfig), not the rejected value.
+    assert payload["config"]["fail_mode"] == "degraded"
+    # The valid-profile path leaves profile_warning None.
+    ok = await handlers.get_config()
+    assert ok["profile_warning"] is None
+
+
 # ── edge F-1: the embedded plugin bridge forwards the selector ──────────────
 async def test_bridge_forwards_profile_selector(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -49,7 +49,7 @@ def _point_root_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _write_profile(
-    root: Path, name: str, section: dict | None = None, *, active: bool = False
+    root: Path, name: str, section: dict[str, Any] | None = None, *, active: bool = False
 ) -> Path:
     pdir = root / "profiles" / name
     pdir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,111 @@
+"""PET-146: tests for the Hermes-profile enumeration helpers in
+``petasos.console._paths``.
+
+``list_hermes_profiles`` enumerates ``profiles/*/config.yaml`` under the Hermes
+root, marking the active binding by a normalized-path compare; it is fail-soft
+(``[]`` on a missing/unreadable ``profiles/`` dir) and never raises.
+``resolve_profile_config_path`` resolves one named member, traversal-guarded,
+returning ``None`` for a non-member.
+
+The helpers read the Hermes root from the environment at call time
+(``hermes_root()``: ``%LOCALAPPDATA%\\hermes`` on Windows, ``~/.hermes`` on
+POSIX), so these tests redirect the platform-appropriate env var to a ``tmp_path``
+sandbox rather than monkeypatching internals.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from petasos.console._paths import (
+    hermes_root,
+    list_hermes_profiles,
+    resolve_hermes_config_path,
+    resolve_profile_config_path,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _point_root_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``hermes_root()`` into *tmp_path* for the current platform.
+
+    Returns the resolved root dir (``<tmp>/hermes`` on Windows, ``<tmp>/.hermes``
+    on POSIX), with ``HERMES_HOME`` cleared so the active-profile pointer governs.
+    """
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    root = hermes_root()
+    (root / "profiles").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_profile(
+    root: Path, name: str, section: dict | None = None, *, active: bool = False
+) -> Path:
+    pdir = root / "profiles" / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    cfg_path = pdir / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"petasos": section or {}}), encoding="utf-8")
+    if active:
+        (root / "active_profile").write_text(name, encoding="utf-8")
+    return cfg_path
+
+
+def test_list_hermes_profiles_enumerates_and_marks_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "open"}, active=True)
+    _write_profile(root, "beta", {"fail_mode": "closed"})
+    # A bare dir with no config.yaml must be skipped (not every dir is a profile).
+    (root / "profiles" / "not_a_profile").mkdir()
+
+    profiles = list_hermes_profiles()
+    by_name = {p["name"]: p for p in profiles}
+    assert set(by_name) == {"alpha", "beta"}
+    assert all(p["tier"] == "profile" for p in profiles)
+    # Active marked by normalized-path equality against the live binding, not a
+    # leaf-name compare.
+    assert by_name["alpha"]["is_active"] is True
+    assert by_name["beta"]["is_active"] is False
+    assert Path(by_name["alpha"]["path"]) == resolve_hermes_config_path().path
+
+
+def test_list_hermes_profiles_failsoft_missing_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Point the root somewhere with no profiles/ dir at all.
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "empty"))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path / "empty"))
+    # Never raises; yields [] so the caller folds in active-only.
+    assert list_hermes_profiles() == []
+
+
+def test_resolve_profile_config_path_member_and_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _point_root_at(tmp_path, monkeypatch)
+    _write_profile(root, "alpha", {"fail_mode": "open"}, active=True)
+
+    res = resolve_profile_config_path("alpha")
+    assert res is not None
+    assert res.tier == "profile"
+    assert res.warning is None
+    assert res.path == root / "profiles" / "alpha" / "config.yaml"
+
+    # Non-member names are rejected (no traversal): unknown leaf and a ../ escape.
+    assert resolve_profile_config_path("does_not_exist") is None
+    assert resolve_profile_config_path("../../etc") is None
+    assert resolve_profile_config_path("..") is None


### PR DESCRIPTION
## Summary
- Adds a Hermes-agent-profile selector at the top of the Config Editor (above the Strength dial) that names the equipped profile and lets the operator view/edit any of their Hermes profiles.
- The picked profile's **effective** settings (resolved config ⊕ the internal `profile_name`'s runtime overrides) render and edit; editing the **equipped** profile hot-applies (PET-126), editing a **non-equipped** profile persists to that profile's `config.yaml` only with a restart banner.
- All posture fields — including `fail_mode` / `egress_sink_tools` / `source_taint_namespaces` — are stated plainly as per-Hermes-profile (D2 reversal; no false "global" claim), and a `scope` metadata key (`"profile"` on every field) locks the disclosure contract.

## Layered defense
- **`is_active` is a normalized-path equality** (`_resolved_normcase`: `os.path.normcase` of `resolve(strict=False)`), not a leaf/raw-string compare — closes the Windows case-fold, trailing-slash, symlink, and `HERMES_HOME == profiles/<name>` aliasing cases that would mis-route a save. A resolution `OSError` degrades to the safe persist-only branch; every non-equipped save logs an INFO tripwire.
- **Non-equipped saves run a dry-run gate** before any write: `FrequencyTracker(validated)` (validates `frequency_weights`) + `ProfileResolver.resolve` (validates `profile_name`), so an unappliable config can't be pre-staged. The active path now maps a bad `profile_name` `KeyError` to 422 (was 500).
- **Secrets never hit disk**: `_persist_config` pops `hash_key`/`session_secret` on every write (parity active/non-equipped); the non-equipped merge base is the on-disk section, not the redacted payload.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_paths.py` | Adds `list_hermes_profiles`, `resolve_profile_config_path`, `_resolved_normcase` (fail-soft, logging-free) |
| `petasos/console/server.py` | `get_config(profile=)` binding identity + effective view + profile list; `update_config(profile=)` equipped vs non-equipped routing; `_persist_config(target_path=)`; effective-view helpers; 422 parity |
| `petasos/console/hermes/plugin_api.py` | Embedded Hermes bridge forwards the `profile` selector (edge F-1) |
| `petasos/console/_config_meta.py` | Emits `scope="profile"` on every field (D2) |
| `petasos/console/static/petasos.js` | Selector above the dial, effective read-out, restart banner, dirty-switch confirm, profile-tagged saves |
| `petasos/console/static/petasos.css` | Selector / note / banner / effective read-out styles |
| `docs/deployment/profile-resolution-model.md` | New: the two profile axes, per-profile levers, Windows layout, all-profile-homes hardening note |
| `docs/deployment/hardening.md` | Back-link + extends §6 mitigation to all profile homes (D-HARDENING) |
| `tests/test_console_hermes_profile.py` | New backend tests (anyio) |
| `tests/test_paths.py` | New `_paths` enumeration tests |
| `tests/js/hermes-profile-selector.test.mjs` | New selector JS tests |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/test_console_hermes_profile.py tests/test_paths.py tests/test_console_handlers.py --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 73/73 pass (full output: docs/specs/TODO/PET-146.test-output.txt)
- [x] `C:/python310/python.exe -m mypy --strict petasos` — clean
- [x] `ruff check . && ruff format --check .` — clean
- [x] `node --test tests/js/` — 155/155 pass (run as `tests/js/*.mjs`; the trailing-slash directory form is a Node v25 path-resolution quirk, not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hermes profile selector to browse and edit different agent profiles in the console editor
  * Non-equipped profile edits now persist separately and take effect upon restart/re-equip
  * Added "effective configuration" readout displaying runtime-enforced settings and active overrides

* **Documentation**
  * Added comprehensive profile-resolution model documentation clarifying profile scoping and behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->