### PR TITLE
fix(pet-150): scope config-hardening guidance to all profile homes

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -220,20 +220,49 @@ the guard to defend its own config file.
 
 ### The mitigation (both platforms)
 
-Place `config.yaml` and `$HERMES_HOME` outside the agent's writable filesystem
-scope:
+Place **every** resolver-reachable `config.yaml` outside the agent's writable
+filesystem scope, not only the single file `resolve_hermes_config_path()` returns
+for the active profile. That means the whole `profiles/` tree
+(`profiles/*/config.yaml`), `$HERMES_HOME`, and the legacy v0.15 root: each is a
+home the resolver can bind, so each is a config an agent must not be able to write.
 
-- **POSIX:** a read-only bind mount, or a separate uid that owns the config with
-  the agent's uid denied write.
+**Why all homes, not only the active one.** PET-146's Config Editor selector makes
+every profile home an editable surface, and the three safety levers (`fail_mode`,
+`source_taint_namespaces`, `egress_sink_tools`) live inside each profile's config.
+An agent that can write a *non-active* profile's `config.yaml` can pre-stage an
+inert relaxed or disarmed posture that arms the instant an operator equips that
+profile, or a PET-147 live swap retargets to it, with no further agent action at
+switch time. A boundary scoped to only the resolved active config leaves that
+pre-stage path open. For the Hermes-profile-home versus internal-Petasos-profile
+distinction, see `profile-resolution-model.md`.
+
+- **POSIX:** a read-only bind mount over the `profiles/` tree (and `$HERMES_HOME`),
+  or a separate uid that owns the tree with the agent's uid denied write. Scope the
+  mount or ownership to the directory, not a single file, so sibling and
+  later-created profile homes inherit the boundary.
 - **Windows:** a separate Windows user or service account owns the config
-  directory, with an ACL that denies write to the agent's account. Note that
-  `%LOCALAPPDATA%\hermes` is user-writable by default (and see the section 5
-  Windows note: on Hermes Desktop for Windows, file tools bypass the terminal
-  sandbox).
+  directory, with an inherited deny-write ACL across the entire `profiles\` tree,
+  for example `icacls "...\hermes\profiles" /deny "agent-user:(OI)(CI)W" /T`. A
+  single-file ACL would leave sibling and later-created profile homes writable.
+  Note that `%LOCALAPPDATA%\hermes` is user-writable by default (and see the
+  section 5 Windows note: on Hermes Desktop for Windows, file tools bypass the
+  terminal sandbox).
+
+Verify no home is agent-writable (the filesystem-reach check, distinct from the
+active-binding confirmation in *Profile changes require a restart* below):
+
+- **POSIX:** running as the agent's uid,
+  `find <hermes-root>/profiles -name config.yaml -writable` should print nothing.
+- **Windows:** `icacls "...\hermes\profiles\*\config.yaml"` should show no write
+  grant for the agent's account.
 
 Then ensure neither the standalone console nor the embedded plugin API is
 reachable by the agent's shell or http tools (network-namespace isolation, or no
 shell/http tool in the agent's toolset). Loopback alone is insufficient.
+
+<!-- petasos-doc-assert: multihome_config_unreachable=all-profile-homes -->
+<!-- petasos-doc-assert: multihome_prestage_threat=equip-or-live-swap -->
+<!-- petasos-doc-assert: config_boundary_mechanism=deployment-posture -->
 
 ### Optional console token (`PETASOS_CONSOLE_TOKEN`)
 

--- a/docs/security-hardening-checklist.md
+++ b/docs/security-hardening-checklist.md
@@ -69,9 +69,13 @@ Audit artifact for the 0.1.0 release. Verifies existing code against [Drawbridge
 
 | Footgun | Status | Rationale |
 |---------|--------|-----------|
-| 4c — File tool bypass | Mitigate (deployment) | Petasos does not itself dispatch file ops, shell, or subprocess calls (true). But the agent can write *Petasos's own* `config.yaml` (the `enabled` bit / posture), disarming or relaxing enforcement. Put the config out of the agent's reach (read-only mount / separate uid on POSIX, separate account + ACL deny-write on Windows) and the console out of reach (no shell/http tool, or netns). See `hardening.md` section 6. |
+| 4c — File tool bypass | Mitigate (deployment) | Petasos does not itself dispatch file ops, shell, or subprocess calls (true). But the agent can write *Petasos's own* `config.yaml` (the `enabled` bit / posture), disarming or relaxing enforcement, and this is not only the active profile: an agent that writes a non-active `profiles/<name>/config.yaml` pre-stages an inert relaxed or disarmed posture that arms on operator equip or a PET-147 live swap, with no further agent action. Put **every** profile home out of the agent's reach (the whole `profiles/` tree, `HERMES_HOME`, and the legacy root: read-only mount / separate uid on POSIX, separate account + inherited deny-write ACL across `profiles\` on Windows) and the console out of reach (no shell/http tool, or netns). The boundary is deployment posture, not guard-side write-blocklisting (PET-125 Decision 2). See `hardening.md` section 6 and `deployment/profile-resolution-model.md`. |
 | 5 — Hook shebang divergence | N/A | Petasos ships zero hook scripts, zero shell scripts, zero executables. It is a pure Python library imported by the host process. |
 | 9 — Signal handling divergence | N/A | Petasos does not register signal handlers (`signal.signal()`). Lifecycle management is the host process's responsibility (Hermes). Future work must not add signal handlers without revisiting this assessment. |
+
+<!-- petasos-doc-assert: multihome_config_unreachable=all-profile-homes -->
+<!-- petasos-doc-assert: multihome_prestage_threat=equip-or-live-swap -->
+<!-- petasos-doc-assert: config_boundary_mechanism=deployment-posture -->
 
 ---
 

--- a/tests/test_hardening_docs.py
+++ b/tests/test_hardening_docs.py
@@ -1,0 +1,151 @@
+"""Recurrence guard for the multi-home config-hardening guidance (PET-150).
+
+Both ``docs/deployment/hardening.md`` § 6 and ``docs/security-hardening-checklist.md``
+§ 7 (footgun 4c) tell the operator to put Petasos's ``config.yaml`` out of the
+agent's reach. PET-150 widened that boundary from the single resolved active
+config to *every* profile home (``profiles/*/config.yaml``, ``HERMES_HOME``, the
+legacy root), because PET-146's Config Editor selector makes every home an
+editable surface, and an agent that pre-stages a relaxed non-active config arms it
+on the next operator equip or PET-147 live swap. This file reds if either doc ever
+re-narrows that guidance, drops the pre-stage threat statement, or claims the
+boundary is guard-side write-blocklisting rather than deployment posture (PET-125
+Decision 2 preserved).
+
+The assertion keys off stable ``petasos-doc-assert`` HTML-comment markers (the
+PET-128 convention), not fragile prose substrings: markers survive prose
+rewording. This is a pure-stdlib base-lane test (no ``petasos`` import, no ML
+extras), so it runs in the default ``ci.yml`` lane (PET-106).
+
+Known limit (honest): the marker asserts the authored posture tag, not the
+surrounding prose, so a careless narrowing that left the marker intact would not
+red. The reviewer confirms prose == marker once at authoring; a light prose-anchor
+backstop is deferred (spec § Deferred).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# The marker sentinel, identical to the literal embedded in the Markdown docs and
+# to the PET-128 sibling suite (``test_docs_usage_consistency.py``). The grammar
+# is re-implemented here rather than imported to keep this doc-led guard
+# self-contained (spec Decision 1).
+_MARKER_PREFIX = "petasos-doc-assert:"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_HARDENING_DOC = _REPO_ROOT / "docs" / "deployment" / "hardening.md"
+_CHECKLIST_DOC = _REPO_ROOT / "docs" / "security-hardening-checklist.md"
+
+# Both guarded docs, parametrized by a readable id so a failure names the file.
+_GUARDED_DOCS = [
+    pytest.param(_HARDENING_DOC, id="hardening.md"),
+    pytest.param(_CHECKLIST_DOC, id="security-hardening-checklist.md"),
+]
+
+
+def _doc_assert_markers(path: Path, *, required: frozenset[str]) -> dict[str, str]:
+    """Parse ``petasos-doc-assert`` markers from one doc into ``{key: value}``.
+
+    A marker line is ``<sentinel> <pair> [<pair> ...]`` where each ``<pair>`` is
+    ``key=value``; tokens split on whitespace, then on the first ``=``. This parses
+    one doc at a time and never pools two files' markers, so a per-doc divergence
+    reds the offending doc instead of masquerading as a duplicate-key error.
+
+    Fail-loud, mirroring the PET-128 parser:
+      * a token with no ``=`` raises;
+      * an empty value, or an empty CSV element, raises;
+      * a duplicate key anywhere in the file raises;
+      * any key in ``required`` absent from the parsed markers raises, naming the
+        missing key, so a deleted marker reds with a message rather than a bare
+        ``KeyError`` at the call site.
+    """
+    parsed: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        if _MARKER_PREFIX not in raw_line:
+            continue
+        # Text after the sentinel, then drop the HTML-comment close.
+        segment = raw_line.split(_MARKER_PREFIX, 1)[1].split("-->", 1)[0].strip()
+        for token in segment.split():
+            if "=" not in token:
+                raise ValueError(
+                    f"malformed doc-assert token {token!r} in {path.name} (expected key=value)"
+                )
+            key, value = token.split("=", 1)
+            if not value:
+                raise ValueError(f"empty value for doc-assert key {key!r} in {path.name}")
+            if "," in value and any(part == "" for part in value.split(",")):
+                raise ValueError(f"empty CSV element in doc-assert key {key!r} in {path.name}")
+            if key in parsed:
+                raise ValueError(f"duplicate doc-assert key {key!r} in {path.name}")
+            parsed[key] = value
+    missing = required - parsed.keys()
+    if missing:
+        raise ValueError(f"missing required doc-assert key(s) {sorted(missing)} in {path.name}")
+    return parsed
+
+
+@pytest.mark.parametrize("doc", _GUARDED_DOCS)
+def test_hardening_doc_scopes_all_profile_homes(doc: Path) -> None:
+    # Regression for PET-150: both docs must scope the deny-write boundary to all
+    # profile homes and name the pre-stage-on-equip/swap threat. A silent
+    # re-narrowing to the active profile reds here.
+    required = frozenset({"multihome_config_unreachable", "multihome_prestage_threat"})
+    markers = _doc_assert_markers(doc, required=required)
+    assert markers["multihome_config_unreachable"] == "all-profile-homes"
+    assert markers["multihome_prestage_threat"] == "equip-or-live-swap"
+
+
+@pytest.mark.parametrize("doc", _GUARDED_DOCS)
+def test_hardening_doc_no_guard_blocklist_claim(doc: Path) -> None:
+    # Regression for PET-150 (Decision 2): the boundary is deployment posture, not
+    # guard-side write-blocklisting (PET-125 Decision 2 preserved). A positive
+    # marker locks the posture; an edit that claimed the guard enforces the
+    # boundary would have to flip this value to one the assert rejects.
+    markers = _doc_assert_markers(doc, required=frozenset({"config_boundary_mechanism"}))
+    assert markers["config_boundary_mechanism"] == "deployment-posture"
+
+
+# --- New-parser fail-loud contract ------------------------------------------
+# The sibling PET-128 tests cover a *different* parser function, so this self-
+# contained reader needs its own fail-loud coverage (spec Decision 1).
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    doc = tmp_path / "fixture.md"
+    doc.write_text(body, encoding="utf-8")
+    return doc
+
+
+def test_parser_raises_on_malformed_token(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: novalue -->\n")
+    with pytest.raises(ValueError, match="malformed doc-assert token"):
+        _doc_assert_markers(doc, required=frozenset())
+
+
+def test_parser_raises_on_empty_value(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: k= -->\n")
+    with pytest.raises(ValueError, match="empty value"):
+        _doc_assert_markers(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_empty_csv_element(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: k=a,,b -->\n")
+    with pytest.raises(ValueError, match="empty CSV element"):
+        _doc_assert_markers(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_duplicate_key(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "<!-- petasos-doc-assert: k=1 -->\n<!-- petasos-doc-assert: k=2 -->\n",
+    )
+    with pytest.raises(ValueError, match="duplicate doc-assert key"):
+        _doc_assert_markers(doc, required=frozenset({"k"}))
+
+
+def test_parser_raises_on_missing_required_key(tmp_path: Path) -> None:
+    doc = _write(tmp_path, "<!-- petasos-doc-assert: present=1 -->\n")
+    with pytest.raises(ValueError, match="missing required doc-assert key"):
+        _doc_assert_markers(doc, required=frozenset({"absent"}))


### PR DESCRIPTION
## Summary
- Extends the self-disarm / self-tamper deny-write boundary from the active profile's `config.yaml` to **every** Hermes profile home (`profiles/*/config.yaml`, `HERMES_HOME`, the legacy root), not only the file `resolve_hermes_config_path()` returns.
- Names the pre-stage threat: an inert relaxed/disarmed non-active config arms on the next operator equip or PET-147 live swap, with no further agent action at switch time.
- Adds a base-lane recurrence guard that reds if either doc ever re-narrows to active-only or drops the deployment-posture mechanism.

## Layered defense
Three `petasos-doc-assert` markers in each doc encode the posture (multi-home scope, pre-stage threat, deployment-posture mechanism). `tests/test_hardening_docs.py` asserts the marker values in both docs: a future prose narrowing that flips a marker reds CI, and one that leaves the marker intact still surfaces the prose/marker mismatch at review. No guard / classifier / `reference_plugin` code changes (PET-125 Decision 2 preserved): the boundary is deployment posture, not guard-side write-blocklisting.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/hardening.md` | Rewrites § 6 mitigation: whole-tree scope, pre-stage threat, Windows inherited-deny ACL, filesystem-reach sweep, resolution-model pointer, 3 markers |
| `docs/security-hardening-checklist.md` | Extends § 7 footgun 4c to all profile homes + pre-stage one-liner + deployment-posture mechanism + resolution-model pointer; 3 markers in § 7 |
| `tests/test_hardening_docs.py` | New base-lane recurrence guard (self-contained marker parser, 2 parametrized assertions over both docs, 5 fail-loud parser self-tests) |

## Test plan
- [x] `C:\python310\python.exe -m pytest --deselect "tests/test_console_validation.py::test_default_ignorable_rejected" -q` — 1955 passed, 41 skipped, 1 deselected, 1 xfailed (full output: docs/specs/TODO/PET-150.test-output.txt)
- [x] `ruff check .` — clean
- [x] `ruff format --check .` — 142 files already formatted
- [x] `mypy --strict .` — no issues in 142 source files
- [x] Focused `tests/test_hardening_docs.py` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced hardening documentation with expanded guidance for protecting configuration files across multiple profiles and platforms (POSIX/Windows).
  * Added detailed verification steps and platform-specific implementation instructions.
  * Updated security hardening checklist with clarified threat descriptions and protection boundaries.

* **Tests**
  * Added automated validation tests for security documentation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->