### PR TITLE
fix(pet-141): collapse stale version fallbacks to a single authority

### DIFF
--- a/petasos/console/hermes/README.md
+++ b/petasos/console/hermes/README.md
@@ -1,0 +1,7 @@
+# Petasos Hermes plugin bundle
+
+`manifest.json` `version` is the **plugin-bundle** version, deliberately
+**independent** of the `petasos` Python package version (`petasos.__version__`).
+The bundle ships on its own cadence; do not sync it to the package version.
+(`manifest.json` is strict JSON and cannot carry an inline comment; this note
+records the choice. PET-141.)

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -723,7 +723,9 @@ class ConsoleHandlers:
         import petasos
 
         return {
-            "version": getattr(petasos, "__version__", "0.1.0"),
+            # PET-141: source the version from the package single-source; no
+            # hardcoded fallback (a literal can only mask a real packaging defect).
+            "version": petasos.__version__,
             "repo_url": "https://github.com/Vigil-Harbor/Petasos",
             "license": "MIT",
             "description": (
@@ -799,6 +801,12 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
     from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
     from fastapi.staticfiles import StaticFiles
 
+    import petasos
+
+    # PET-141: bind the package version once so both FastAPI constructions (and the
+    # package) can never drift — D3 single source for the OpenAPI version field.
+    _version = petasos.__version__
+
     # PET-125: normalize the token once, centrally, so the env path (serve) and a
     # programmatic auth_token= argument agree. Single WARNING site for set-but-blank.
     resolved_token: str | None
@@ -811,7 +819,7 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
         resolved_token = auth_token
 
     if resolved_token is None:
-        app = _FastAPI(title="Petasos Console", version="0.1.0")
+        app = _FastAPI(title="Petasos Console", version=_version)
     else:
         token: str = resolved_token  # non-Optional capture for the closure below
 
@@ -838,7 +846,7 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
 
         app = _FastAPI(
             title="Petasos Console",
-            version="0.1.0",
+            version=_version,
             dependencies=[Depends(_require_console_token)],
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,16 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.version]
+# PET-141: single version authority. Hatch reads __version__ from this file at
+# build time, so petasos/__init__.py is the sole version literal in the repo.
+path = "petasos/__init__.py"
+
 [project]
 name = "petasos"
-version = "0.1.2"
+# PET-141: version is derived from petasos/__init__.py via Hatch (see
+# [tool.hatch.version]); no static literal here.
+dynamic = ["version"]
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Vigil Harbor", email = "support@vigilharbor.com" }]

--- a/tests/test_console_auth.py
+++ b/tests/test_console_auth.py
@@ -21,6 +21,7 @@ import pytest
 
 pytest.importorskip("fastapi")
 
+import petasos  # noqa: E402
 from petasos.config import PetasosConfig  # noqa: E402
 from petasos.console.server import build_app  # noqa: E402
 from petasos.pipeline import Pipeline  # noqa: E402
@@ -194,3 +195,11 @@ def test_token_with_surrounding_whitespace_is_compared_verbatim(
     # A trimmed credential does not match.
     trimmed = tc.get("/api/health", headers={"Authorization": "Bearer tok"})
     assert trimmed.status_code == 401
+
+
+def test_openapi_version_matches_package() -> None:
+    # Regression for PET-141: the OpenAPI version tracks petasos.__version__ on
+    # BOTH construction paths (untokened and PET-125 tokened), so the single
+    # _version local (D3) keeps the two branches and the package from drifting.
+    assert build_app(_make_pipeline()).version == petasos.__version__
+    assert build_app(_make_pipeline(), auth_token="t").version == petasos.__version__

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -8,6 +8,7 @@ import pytest
 
 pytest.importorskip("fastapi")
 
+import petasos  # noqa: E402
 import petasos.console._paths as paths_mod  # noqa: E402
 from petasos._types import ScanResult  # noqa: E402
 from petasos.config import PetasosConfig  # noqa: E402
@@ -214,11 +215,20 @@ async def test_profile_metadata_surfaced(handlers: ConsoleHandlers) -> None:
 
 async def test_get_about(handlers: ConsoleHandlers) -> None:
     result = await handlers.get_about()
-    assert result["version"] == "0.1.2"
+    # Regression for PET-141: version pins to the package single-source, not a
+    # hand-bumped "0.1.2" literal — the payload-shape smoke check stays.
+    assert result["version"] == petasos.__version__
     assert result["license"] == "MIT"
     assert "donation" in result
     assert "url" in result["donation"]
     assert "credits" in result
+
+
+async def test_about_version_matches_package(handlers: ConsoleHandlers) -> None:
+    # Regression for PET-141: the /about version is sourced from
+    # petasos.__version__ with no hardcoded fallback (D2).
+    result = await handlers.get_about()
+    assert result["version"] == petasos.__version__
 
 
 async def test_scan_history_limit(handlers: ConsoleHandlers) -> None:

--- a/tests/test_version_sourcing.py
+++ b/tests/test_version_sourcing.py
@@ -1,0 +1,71 @@
+"""PET-141: version-sourcing drift guards.
+
+Single-source invariant: the repo holds exactly one package-version literal
+(``petasos/__init__.py:__version__``); the console reads it at runtime and the
+build derives it via Hatch. These guards run in the default (fastapi-free) CI
+lane, so a reintroduced hardcoded literal fails the gate where it has teeth.
+
+There is NO ``importorskip("fastapi")`` here on purpose (spec D6): every console
+test file skips entirely in the default CI lane (no fastapi installed), so the
+drift tripwire must live in this module, which imports only the stdlib plus
+``petasos``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+from pathlib import Path
+
+import pytest
+
+import petasos
+
+# A quoted three-segment integer literal: "0.1.0" / '2.3.4'. The pattern requires
+# the surrounding quotes and exactly three dotted integer segments, so it matches
+# a reintroduced Python version literal (always a quoted string) while it does
+# NOT match a bare or quoted dotted-quad such as ``127.0.0.1`` / ``"127.0.0.1"``
+# (the closing quote does not sit after the third segment), nor a two-segment
+# numeric (``1.0``), nor a version-shaped number in prose. See spec § Test
+# details — this is the one authoritative regex for the guard.
+_VERSION_LITERAL = re.compile(r"""['\"]\d+\.\d+\.\d+['\"]""")
+
+_SERVER_PY = Path(petasos.__file__).resolve().parent / "console" / "server.py"
+
+
+def _literal_hits(text: str) -> list[str]:
+    # Line-wise scan mirroring tests/test_ci_extras_lanes.py: skip comment lines
+    # (``lstrip`` starts with ``#``), return every non-comment line that bears a
+    # quoted version literal.
+    hits: list[str] = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if _VERSION_LITERAL.search(line):
+            hits.append(line.strip())
+    return hits
+
+
+def test_no_hardcoded_version_literal_in_console() -> None:
+    # Regression for PET-141: no quoted version literal may re-enter the console
+    # server source; the version must be sourced from ``petasos.__version__``.
+    source = _SERVER_PY.read_text(encoding="utf-8")
+    hits = _literal_hits(source)
+    assert hits == [], f"hardcoded version literal(s) in console/server.py: {hits}"
+
+    # Synthetic negative case pinning the dotted-quad exclusion (mirrors the
+    # test_ci_extras_lanes.py synthetic suite): the guard must NOT fire on a host
+    # literal, so a future widening of the pattern cannot silently regress it.
+    assert _literal_hits('    host = "127.0.0.1"') == []
+
+
+def test_package_version_single_source() -> None:
+    # Regression for PET-141: build/dist metadata cannot diverge from the single
+    # source ``__version__``. Skips on a source-only checkout where no dist
+    # metadata exists (D7); runs in CI where ``pip install -e .`` provides
+    # editable dist metadata, exactly where the build-derived invariant must hold.
+    try:
+        dist_version = importlib.metadata.version("petasos")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("petasos has no dist metadata (source-only checkout); D7")
+    assert dist_version == petasos.__version__


### PR DESCRIPTION
## Summary
- Collapse the version-drift class: `petasos/__init__.py:__version__` becomes the **sole** package-version literal in the repo; `pyproject.toml` derives it via Hatch (`dynamic = ["version"]` + `[tool.hatch.version]`).
- The console reports `petasos.__version__` everywhere (about payload + both FastAPI/OpenAPI constructions) with **no** hardcoded `"0.1.0"` fallback.
- The Hermes `manifest.json` version is declared a deliberately independent plugin-bundle line (D4); its value and JSON contract are unchanged.
- A new non-fastapi-gated regression module fails the **default CI lane** if any hardcoded version literal is reintroduced into the console source, and proves build metadata cannot diverge from `__version__`.

No version *number* changes — this is a sourcing/drift fix, not a release. Isolated wheel build confirms Hatch derives `petasos-0.1.2-py3-none-any.whl` from `__init__.py`.

## Layered defense
The drift could previously enter at four independent surfaces (manifest, `get_about`, two `_FastAPI` constructions, pyproject literal). Now:
1. **Build** — pyproject has no literal; Hatch reads `__init__.py` (`test_package_version_single_source`).
2. **Runtime** — `build_app` binds one `_version` local, passed to both the untokened and PET-125 tokened `_FastAPI(...)` calls, so the branches and the package can't drift (`test_openapi_version_matches_package`).
3. **Source tripwire** — `test_no_hardcoded_version_literal_in_console` runs in the fastapi-free default lane and rejects any re-typed quoted version literal (with a synthetic `127.0.0.1` negative case pinning the dotted-quad exclusion).

## Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Static `version` → `dynamic = ["version"]` + `[tool.hatch.version] path` |
| `petasos/console/server.py` | `get_about` drops the literal fallback; `build_app` binds one `_version` for both constructions |
| `petasos/console/hermes/README.md` | New — records the manifest version's deliberate independence (D4) |
| `tests/test_version_sourcing.py` | New — non-fastapi-gated CI guards (no-literal + single-source) |
| `tests/test_console_handlers.py` | `test_get_about` pins to `petasos.__version__`; adds `test_about_version_matches_package` |
| `tests/test_console_auth.py` | Adds `test_openapi_version_matches_package` (both construction paths) |

## Test plan
- [x] `C:\python310\python.exe -m pytest tests/test_version_sourcing.py tests/test_console_handlers.py tests/test_console_auth.py` — 69 passed, 1 skipped (`test_package_version_single_source` skips on the source-only checkout per D7)
- [x] Full suite — 1949 passed, 42 skipped, 1 deselected (pre-existing Unicode-13 `test_default_ignorable_rejected`), 1 xfailed
- [x] `ruff check .` clean · `ruff format --check .` clean · `mypy --strict .` — no issues in 142 files
- [x] Isolated `python -m build --wheel` → `petasos-0.1.2-py3-none-any.whl` (Hatch derives the version from `__init__.py`)

> CI complement: `test_version_sourcing.py` runs in full in the `[dev]` lane (editable dist metadata present); the fastapi-gated console tests run on any interpreter with fastapi. Every new assertion is exercised in at least one environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Hermes plugin bundle README clarifying that `manifest.json` version is bundle-scoped and intentionally independent of the main package version.

* **Bug Fixes**
  * Updated the console “about” response and OpenAPI version to always reflect the package’s current version consistently.

* **Tests**
  * Added/updated regression tests to assert API/OpenAPI “version” matches the package version for all configurations.
  * Added drift-guard tests preventing reintroduction of hardcoded version strings.

* **Chores**
  * Switched project versioning to derive dynamically from the package source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->