### PR TITLE
chore(pet-140): remove vestigial _profile_hook pass-through

### DIFF
--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -643,8 +643,11 @@ class Pipeline:
         )
         normalized_text = norm_result.normalized
 
-        # Stage 1b: Profile hook → effective scanner
-        effective_scanner = await self._profile_hook(active_profile)
+        # Stage 1b: the syntactic pre-filter always uses the base minimal
+        # scanner. Profile-driven suppression runs at Stage 4b (PET-109); no
+        # profile-based scanner selection happens here.
+        assert self._minimal_scanner is not None
+        effective_scanner = self._minimal_scanner
 
         # Stage 2: Syntactic pre-filter (raw text)
         _t0 = time.monotonic()
@@ -915,17 +918,6 @@ class Pipeline:
             self._breaker_consecutive_timeouts.pop(sname, None)
             self._breaker_open_until.pop(sname, None)
         return result
-
-    async def _profile_hook(
-        self,
-        profile: ResolvedProfile | None,
-    ) -> MinimalScanner:
-        # PET-109: profile suppression no longer happens here. The single
-        # pre-merge cross-scanner suppression stage (Stage 4b) drives it for all
-        # scanners; MinimalScanner.with_suppress_rules remains as scanner API for
-        # direct callers/tests but is no longer profile-driven.
-        assert self._minimal_scanner is not None
-        return self._minimal_scanner
 
     async def _frequency_hook(
         self, findings: tuple[ScanFinding, ...], session_id: str | None

--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -6,9 +6,17 @@ from unittest.mock import patch
 
 import pytest
 
-from petasos._types import Alert, AuditEvent, PipelineResult, Severity
+from petasos._types import (
+    Alert,
+    AuditEvent,
+    Direction,
+    PipelineResult,
+    ScanResult,
+    Severity,
+)
 from petasos.config import PetasosConfig
 from petasos.pipeline import Pipeline
+from petasos.scanners.minimal import MinimalScanner
 from petasos.session.frequency import FrequencyTracker
 from petasos.session.guard import ToolCallGuard
 from petasos.session.license import LicenseState
@@ -233,6 +241,26 @@ class TestOuterExceptionHandler:
 # ---------------------------------------------------------------------------
 
 
+class _RecordingMinimalScanner(MinimalScanner):
+    """Capture the raw Stage-1b ScanResult so the PET-140 pin can inspect it.
+
+    Subclassing keeps the object a MinimalScanner, so assigning it to
+    ``pipe._minimal_scanner`` stays mypy --strict-clean (no mock library,
+    consistent with the repo's no-mock-for-scanners convention).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.captured: list[ScanResult] = []
+
+    async def scan(
+        self, text: str, *, direction: Direction = "inbound", session_id: str | None = None
+    ) -> ScanResult:
+        result = await super().scan(text, direction=direction, session_id=session_id)
+        self.captured.append(result)
+        return result
+
+
 class TestProfilePipelineIntegration:
     async def test_pipeline_with_profile_string(self, valid_key: str) -> None:
         pipe = Pipeline(config=_cfg(), profile="admin")
@@ -270,7 +298,7 @@ class TestProfilePipelineIntegration:
         assert result.feature_status is not None
         assert result.feature_status["profiles"] == "enabled"
 
-    async def test_profile_hook_gated_by_feature_config(self, valid_key: str) -> None:
+    async def test_profile_suppression_gated_by_feature_config(self, valid_key: str) -> None:
         pipe = Pipeline(config=_cfg(), profile="research")
 
         text = "​ hello"
@@ -285,6 +313,41 @@ class TestProfilePipelineIntegration:
         assert "petasos.syntactic.encoding.invisible-chars" in inactive_rules or len(
             inactive_rules
         ) >= len(active_rules)
+
+    async def test_prefilter_uses_base_minimal_scanner_regardless_of_profile(
+        self, valid_key: str
+    ) -> None:
+        # Regression for PET-140: Stage 1b always uses the base minimal scanner;
+        # profile-driven suppression is observed only downstream at Stage 4b.
+        rule = "petasos.syntactic.encoding.invisible-chars"
+        text = "​ hello"  # triggers the invisible-chars rule
+
+        # no-profile run
+        pipe_np = Pipeline(config=_cfg())
+        pipe_np.activate(valid_key)
+        rec_np = _RecordingMinimalScanner()
+        pipe_np._minimal_scanner = rec_np
+        res_np = await pipe_np.inspect(text, session_id="s1")
+
+        # active-profile run — code_generation suppresses the invisible-chars rule
+        pipe_cg = Pipeline(config=_cfg(), profile="code_generation")
+        pipe_cg.activate(valid_key)
+        rec_cg = _RecordingMinimalScanner()
+        pipe_cg._minimal_scanner = rec_cg
+        res_cg = await pipe_cg.inspect(text, session_id="s1")
+
+        # (a) Stage 1b invoked the base scanner exactly once on each path...
+        assert len(rec_np.captured) == 1
+        assert len(rec_cg.captured) == 1
+        # ...and the profile did NOT pre-filter Stage 1b: raw findings identical.
+        stage1b_np = {f.rule_id for f in rec_np.captured[0].findings}
+        stage1b_cg = {f.rule_id for f in rec_cg.captured[0].findings}
+        assert rule in stage1b_np
+        assert stage1b_np == stage1b_cg
+
+        # (b) suppression manifests only AFTER Stage 1b (at Stage 4b):
+        assert rule in {f.rule_id for f in res_np.findings}
+        assert rule not in {f.rule_id for f in res_cg.findings}
 
     async def test_code_gen_suppresses_encoding_not_injection(self, valid_key: str) -> None:
         pipe = Pipeline(config=_cfg(), profile="code_generation")


### PR DESCRIPTION
## Summary
- Remove `Pipeline._profile_hook`, a no-op pass-through hollowed by PET-109 (which moved profile-driven suppression to the single pre-merge Stage 4b). Its body was a type-narrowing assert plus `return self._minimal_scanner`, and its `profile` parameter was never read.
- Inline `self._minimal_scanner` at the Stage-1b call site behind the retained not-None assert, and rewrite the comment to say what actually happens: Stage 1b always uses the base minimal scanner; profile tuning lives at Stage 4b.
- Reconcile a stale test name and add a behavior pin so the drift cannot silently regress. No functional change to scan output, suppression, or severity for any profile.

## Two-check interaction
The pin (`test_prefilter_uses_base_minimal_scanner_regardless_of_profile`) wraps the pipeline's minimal scanner with a recording `MinimalScanner` subclass and runs the same invisible-chars input down both a no-profile and a `code_generation` path. Assertion (a) proves Stage 1b invoked the base scanner exactly once per path with identical raw findings (profile does not pre-filter Stage 1b); assertion (b) proves the `code_generation` suppression of `petasos.syntactic.encoding.invisible-chars` manifests only in the final result (Stage 4b). Together they distinguish "base scanner at Stage 1b" from "suppression disabled entirely."

## Files changed

| File | Change |
|------|--------|
| `petasos/pipeline.py` | Removes `_profile_hook`; inlines `self._minimal_scanner` at the Stage-1b call site with a corrected comment. |
| `tests/test_session_integration.py` | Renames `test_profile_hook_gated_by_feature_config` -> `test_profile_suppression_gated_by_feature_config` (body unchanged); adds the `_RecordingMinimalScanner` helper and the D1 behavior pin. |

## Test plan
- [x] `ruff check . && ruff format --check . && mypy --strict . && pytest` (C:/python310) — ruff clean, mypy clean (148 files), **2014 passed, 42 skipped, 1 deselected, 1 xfailed** (full output: docs/specs/TODO/PET-140.test-output.txt)
- [x] The single `--deselect tests/test_console_validation.py::test_default_ignorable_rejected` is a pre-existing, environment-specific Unicode-13 skip on the local 3.10 interpreter, unrelated to this change.
- [x] Regression guards green and unchanged: `tests/test_pipeline_suppression.py` (Stage 4b semantics), `tests/test_minimal_scanner.py` + `tests/adversarial/syntactic/test_injection_evasion.py` (direct `with_suppress_rules()` callers — scanner API untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile settings incorrectly affecting early-stage syntactic pre-filtering. The initial pre-filter now operates consistently regardless of the active profile configuration.

* **Tests**
  * Added regression tests to verify consistent pre-filtering behavior across different profile configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->