### PR TITLE
fix(pet-152): re-mint scan-history Older head cursor after ring eviction

### DIFF
--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -3295,6 +3295,15 @@
     }
   }
 
+  // PET-152: a history fetch counts as a successful read only when it has no error AND no non-OK
+  // HTTP status. _req (:530, :550) sets `_status` on a parsed non-OK body, which for a 403/500 like
+  // `{}` carries NO `error` field — so a bare `!d.error` check would accept a failed read as an
+  // empty older page (silent "no older history" on an auth/server failure). Gate paging on this
+  // instead. `_status == null` covers OK bodies (status never stamped) and the test mocks.
+  function _historyResponseOk(d) {
+    return !!(d && !d.error && (d._status == null || d._status < 400));
+  }
+
   // PET-152: the single shared push for an older page — both the re-mint path and the paged-view
   // path call it, so the shape guard and render trigger live in one place. Module-scoped (never a
   // render-local) because it needs _container / Pet.renderDashboard. Keeps the Array.isArray shape
@@ -3336,7 +3345,8 @@
       Pet.api.getScanHistory(plan.remintLimit).then(function (rd) {
         if (gen !== _historyPagingGen) return;          // superseded by re-seed/401/unmount
         if (Pet.auth.on401(rd)) { _historyPaging = false; return; }
-        var freshCursor = (rd && !rd.error && rd.next_before) ? rd.next_before : null;
+        if (!_historyResponseOk(rd)) { _historyPaging = false; return; } // non-OK re-mint: not a miss, a failed read
+        var freshCursor = rd.next_before || null;
         if (freshCursor == null) {                      // gate said older exist, ring points nowhere
           _historyPaging = false;
           _pushOlderPage(null, { entries: [], older_truncated: true }); // honest empty (E-6)
@@ -3347,7 +3357,7 @@
           if (gen !== _historyPagingGen) return;
           _historyPaging = false;
           if (Pet.auth.on401(d)) return;
-          if (!d.error) { _pushOlderPage(freshCursor, d); }
+          if (_historyResponseOk(d)) { _pushOlderPage(freshCursor, d); }
         });
       }).catch(function () { if (gen === _historyPagingGen) _historyPaging = false; });
       return;
@@ -3358,7 +3368,7 @@
       if (gen !== _historyPagingGen) return;
       _historyPaging = false; // clear before any early return so paging can resume
       if (Pet.auth.on401(d)) return; // a 401 stops paging, never a stale page
-      if (!d.error) { _pushOlderPage(plan.cursor, d); }
+      if (_historyResponseOk(d)) { _pushOlderPage(plan.cursor, d); }
     }).catch(function () { if (gen === _historyPagingGen) _historyPaging = false; });
   };
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -332,15 +332,17 @@
     // so a profile switch reloads the same profile after save/discard.
     selectedHermesProfile: null,
     scanHistory: [],
-    // PET-148: scan-history back-page paging state. historyAtHead=true shows the live
-    // SSE-maintained scanHistory buffer (the most-recent window); when paged back,
-    // historyStack holds the fetched older pages (top = current view) and historyHeadCursor
-    // is the server `next_before` for the first "Older" click off the live head (server-minted
-    // to avoid float-repr drift). The single "of N" total stays /health.scans_total (D-RESTART);
-    // paged views never compute a competing total.
+    // PET-148/PET-152: scan-history back-page paging state. historyAtHead=true shows the live
+    // SSE-maintained scanHistory buffer (the most-recent window); when paged back, historyStack
+    // holds the fetched older pages (top = current view). PET-152 dropped the cached
+    // historyHeadCursor field: it was captured once at seed and went stale once the ring evicted
+    // past the oldest seeded row, so the first "Older" click skipped the band between the current
+    // oldest buffered row and the stale boundary. The head boundary is now re-minted via a fresh
+    // server round-trip on every head->older transition, and the "Older" affordance off the head
+    // gates on scanHistoryHasOlder(buffered, scans_total). The single "of N" total stays
+    // /health.scans_total (D-RESTART); paged views never compute a competing total.
     historyAtHead: true,
     historyStack: [],
-    historyHeadCursor: null,
     // PET-138: session_id -> cumulative count of tool calls bypassed while disarmed.
     // Dedicated, eviction-proof state (the count rides a single rate-limited
     // heartbeat row that ages out of scanHistory); fed by Pet.accrueBypass.
@@ -447,6 +449,7 @@
       if (Pet.sse) Pet.sse.disconnect(); // aborts SSE, resets _usingFallback, stops the fallback poll
       _armedSeeded = false;   // force a re-seed from server truth after re-auth (edge F-3)
       _historySeeded = false; // ditto for the scan-history buffer
+      _historyPaging = false; _historyPagingGen++; // PET-152: drop any in-flight paging re-mint; its stale .then checks gen and bails
       Pet.state.armed = null; // unknown until a verified read; bannerView keys authRequired first regardless
       if (Pet.updateConnStatus) Pet.updateConnStatus(); // F-8: don't leave the blip stuck on POLLING
       if (_container && Pet.renderDashboard) Pet.renderDashboard(_container);
@@ -478,6 +481,7 @@
       var gen = Pet.auth._gen;
       _armedSeeded = false;   // re-derive from server truth, regardless of any stray frame (edge F-3)
       _historySeeded = false;
+      _historyPaging = false; _historyPagingGen++; // PET-152: supersede any in-flight paging re-mint across the re-auth resume
       return Pet.api.getArmed().then(function (d) {
         if (gen !== Pet.auth._gen) return { ok: false, stale: true }; // superseded; drop (incl. a stale 401)
         if (d && d._status === 401) return { ok: false, message: "Authentication failed. Check the token and retry." };
@@ -1292,6 +1296,19 @@
     return "showing last " + b + " of " + t;
   };
 
+  // PET-152: the honest "are there retained rows older than the live window?" predicate that
+  // gates the "Older" affordance off the live head. Reuses the SAME lifetime N already shown in
+  // scanHistorySubtitle (/health.scans_total, D-RESTART) — no competing total is minted. The
+  // b > 0 term (a deliberate divergence from scanHistorySubtitle, which is a pure label and
+  // tolerates b === 0) refuses to offer "Older" off an EMPTY live buffer: an empty window has no
+  // oldest edge to page past, and the one-shot seed (not "Older") is what populates the head.
+  // Without it, scans_total > 0 over a transiently-empty pre-seed buffer would re-mint from the
+  // Nth-newest row and CREATE a gap over rows 1..N (edges E-2/E-4). Pure (no DOM, no network).
+  Pet.scanHistoryHasOlder = function (buffered, total) {
+    var b = Number(buffered), t = Number(total);
+    return Number.isFinite(b) && Number.isFinite(t) && b > 0 && t > b;
+  };
+
   // PET-148: positional label for a paged-back history view (D-RESTART). NEVER a numeric
   // total — the only "of N" headline anywhere stays scanHistorySubtitle (scans_total from
   // /health). An empty page is retention-honest: "no older retained history" when the
@@ -1306,17 +1323,19 @@
     return "older history";
   };
 
-  // PET-148: pure paging-state transition for scan-history back-pages (testable in node:vm,
-  // like scanHistorySubtitle / mergeScanHistory). The server cursor walks only OLDER
+  // PET-148/PET-152: pure paging-state transition for scan-history back-pages (testable in
+  // node:vm, like scanHistorySubtitle / mergeScanHistory). The server cursor walks only OLDER
   // (D-PAGING); "newer" replays the client-buffered page stack back toward the live head.
   // Given the current paging state + a navigation action, returns the next-state descriptor
-  // {atHead, stack, cursor, needsFetch} — no DOM, no network. For "older" the caller fetches
-  // with `cursor` (when needsFetch) and pushes the resulting page; for "newer"/"head" the
+  // {atHead, stack, cursor, needsFetch, needsRemint, remintLimit?} — no DOM, no network. For
+  // "older" OFF THE LIVE HEAD the reducer signals needsRemint (PET-152) instead of handing back a
+  // cached head cursor that goes stale after ring eviction; the handler then re-mints the head
+  // boundary via a fresh getScanHistory(remintLimit) round-trip and pages from that. For "older"
+  // from a paged view the caller fetches with `cursor` (when needsFetch); for "newer"/"head" the
   // returned {atHead, stack} is applied directly (client-buffered, no fetch).
   Pet.historyPagingView = function (state, action) {
     state = state || {};
     var stack = Array.isArray(state.stack) ? state.stack.slice() : [];
-    var headCursor = (state.headCursor != null) ? state.headCursor : null;
     var top = stack.length ? stack[stack.length - 1] : null;
     if (action === "head") {
       return { atHead: true, stack: [], cursor: null, needsFetch: false };
@@ -1327,12 +1346,31 @@
       return { atHead: false, stack: stack, cursor: null, needsFetch: false };
     }
     if (action === "older") {
-      // Cursor: the current view's next_before, or the live head's server cursor off the head.
-      var cursor = top ? (top.nextBefore != null ? top.nextBefore : null) : headCursor;
-      var needsFetch = cursor != null;
+      if (top) {
+        // Paged view (unchanged): advance past the current page via its server next_before.
+        var cursor = (top.nextBefore != null) ? top.nextBefore : null;
+        var needsFetch = cursor != null;
+        return {
+          atHead: needsFetch ? false : (state.atHead !== false),
+          stack: stack, cursor: cursor, needsFetch: needsFetch, needsRemint: false,
+        };
+      }
+      // Off the live head: re-mint required (PET-152); never reuse a cached cursor. The head
+      // boundary is re-derived by the handler from a fetch sized to the runtime buffer length.
+      var bufferLength = (typeof state.bufferLength === "number" && state.bufferLength > 0)
+        ? state.bufferLength : 0;
+      if (bufferLength === 0) {
+        // Empty live buffer: no oldest edge to page past; the one-shot seed populates the head,
+        // not "Older". Refuse to fetch so we never page from the Nth-newest row and create a gap
+        // over rows 1..N (edges E-2/E-4).
+        return {
+          atHead: state.atHead !== false, stack: stack,
+          cursor: null, needsFetch: false, needsRemint: false,
+        };
+      }
       return {
-        atHead: needsFetch ? false : (state.atHead !== false),
-        stack: stack, cursor: cursor, needsFetch: needsFetch,
+        atHead: false, stack: stack, cursor: null,
+        needsFetch: false, needsRemint: true, remintLimit: bufferLength,
       };
     }
     // Unknown action: stay put.
@@ -1630,65 +1668,31 @@
           hist.length,
           Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
         );
-    // "Older" is offered when an older cursor exists (the paged view's next_before, or the
-    // live head's server cursor from the seed); "Newer" only when paged back.
+    // PET-152: "Older" is offered when an older cursor exists (the paged view's next_before) or,
+    // off the live head, when scanHistoryHasOlder reports retained rows older than the live window
+    // — gated on the SAME lifetime scans_total the subtitle reads (:1631), never a cached seed
+    // cursor that goes stale after ring eviction. "Newer" only when paged back.
     var histCanOlder = histPaged
       ? (histPaged.nextBefore != null)
-      : (Pet.state.historyHeadCursor != null);
+      : Pet.scanHistoryHasOlder(
+          hist.length,
+          Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
+        );
 
-    function pageHistoryOlder() {
-      if (_historyPaging) return; // ignore re-entrant clicks while a fetch is in flight
-      var next = Pet.historyPagingView(
-        {
-          atHead: Pet.state.historyAtHead !== false,
-          stack: Pet.state.historyStack || [],
-          headCursor: Pet.state.historyHeadCursor,
-        },
-        "older"
-      );
-      if (!next.needsFetch) return; // at the retained bottom; no older cursor (flag stays clear)
-      _historyPaging = true;
-      Pet.api.getScanHistory(100, next.cursor).then(function (d) {
-        _historyPaging = false; // clear before any early return so paging can resume
-        if (Pet.auth.on401(d)) return; // a 401 stops paging, never a stale page
-        if (!d.error) {
-          Pet.state.historyAtHead = false;
-          var st = Pet.state.historyStack || (Pet.state.historyStack = []);
-          st.push({
-            entries: (d.entries && Array.isArray(d.entries)) ? d.entries : [],
-            cursor: next.cursor,
-            nextBefore: d.next_before || null,
-            olderTruncated: !!d.older_truncated,
-          });
-          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
-        }
-      });
-    }
-    function pageHistoryNewer() {
-      // Same in-flight guard as pageHistoryOlder: while an "Older" fetch is pending, a
-      // synchronous stack pop here would invalidate the cursor that pending .then is about
-      // to push from, appending a non-contiguous page and breaking Older/Newer adjacency.
-      if (_historyPaging) return;
-      var next = Pet.historyPagingView(
-        { atHead: Pet.state.historyAtHead !== false, stack: Pet.state.historyStack || [] },
-        "newer"
-      );
-      Pet.state.historyAtHead = next.atHead;
-      Pet.state.historyStack = next.stack;
-      if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
-    }
-
+    // PET-152: the "Older"/"Newer" handlers are now module-scoped (Pet.pageHistoryOlder /
+    // Pet.pageHistoryNewer), defined once rather than rebuilt per render so they provably share
+    // the one _historyPaging in-flight binding and are unit-testable end-to-end.
     var histControls = Pet.h("div", { style: { display: "flex", gap: "8px", marginTop: "10px", alignItems: "center" } });
     if (histCanOlder) {
       histControls.appendChild(Pet.h("button", {
         className: "btn btn-ghost btn-sm", type: "button",
-        ariaLabel: "Show older scan history", onClick: pageHistoryOlder,
+        ariaLabel: "Show older scan history", onClick: Pet.pageHistoryOlder,
       }, "Older"));
     }
     if (!histAtHead) {
       histControls.appendChild(Pet.h("button", {
         className: "btn btn-ghost btn-sm", type: "button",
-        ariaLabel: "Show newer scan history", onClick: pageHistoryNewer,
+        ariaLabel: "Show newer scan history", onClick: Pet.pageHistoryNewer,
       }, "Newer"));
     }
     // Body: rows for the active view, or the retention-honest empty state when a paged-back
@@ -1779,10 +1783,12 @@
         // _req never rejects on HTTP error (it resolves an error envelope), and a
         // 200 {} body lacking .entries would make the merge throw on .scan_id.
         if (!d.error && d.entries && Array.isArray(d.entries)) {
-          // PET-148: the server's next_before on the seed (limit 500) is the cursor at the
-          // oldest seeded row — the boundary the first "Older" click pages past, server-minted
-          // so the client never mints a float-repr-fragile token (edge F-4).
-          Pet.state.historyHeadCursor = d.next_before || null;
+          // PET-148/PET-152: the seed merges the live-head window but no longer captures a head
+          // cursor. PET-152 dropped that cached cursor: it went stale once the ring evicted past
+          // the oldest seeded row, so the first "Older" click skipped the band between the current
+          // oldest buffered row and the stale boundary. The head boundary is now re-minted per
+          // head->older transition (Pet.pageHistoryOlder), never cached across evictions (edge F-4
+          // still holds: that re-mint is a server round-trip, never a client-derived token).
           // PET-99 D6/D9: shape-guarded seed-merge (skips non-object entries on
           // both sides before reading .scan_id) — replaces the inline dedup loops.
           Pet.mergeScanHistory(Pet.state.scanHistory, d.entries);
@@ -3252,11 +3258,125 @@
   // scan-history ring buffer exactly once per mount (not on every SSE re-render).
   // Reset in Pet.unmount AND at the top of Pet.mount (double-mount hardening).
   var _historySeeded = false;
-  // PET-148: in-flight guard for "Older" paging. The pageHistoryOlder handler closure is
-  // rebuilt on every renderDashboard, so a local flag can't survive between clicks — this
-  // module-scoped flag ignores re-entrant clicks while a getScanHistory fetch is pending,
-  // so two quick clicks can't fetch the same cursor twice and push a duplicate page.
+  // PET-148/PET-152: in-flight guard for scan-history paging. PET-152 extracted the
+  // pageHistoryOlder/pageHistoryNewer handlers to module scope (Pet.pageHistoryOlder /
+  // Pet.pageHistoryNewer), so they are now defined ONCE and provably share this one binding
+  // rather than being rebuilt per renderDashboard. It ignores re-entrant clicks while a
+  // getScanHistory fetch is pending — including across the PET-152 two-fetch re-mint chain —
+  // so two quick clicks can't fetch the same cursor twice, and an in-flight "Older" re-mint
+  // blocks a "Newer" click that would otherwise pop the cursor that pending .then is about to
+  // push from (the :1667-style non-contiguous-page hazard).
   var _historyPaging = false;
+  // PET-152: paging generation. Bumped at every paging-context teardown (_enterAuthRequired,
+  // _resume, Pet.mount, Pet.unmount — beside each _historySeeded = false) and captured by each
+  // handler at entry; every fetch .then/.catch checks it before mutating, so a two-fetch re-mint
+  // chain that outlives a re-seed / 401 / unmount / profile-switch cannot push a stale older page
+  // onto a freshly-reset stack or flip historyAtHead. Mirrors the Pet.auth._gen stale-read guard.
+  var _historyPagingGen = 0;
+  // PET-152: one-shot tripwire flag for the re-mint divergence (the gate offered "Older" because
+  // scans_total > buffered, yet the head re-mint returned no cursor). Set once per console-JS load
+  // and intentionally NOT reset at teardown — it is a structural-defect signal, not a per-session
+  // one (matches the server one-shot WARNING _ring_overflow_warned at server.py:609).
+  var _remintMissWarned = false;
+
+  // PET-152: one-shot console.warn naming the re-mint divergence. The "Older" gate keyed on the
+  // lifetime scans_total promised older rows exist, but the head re-mint came back with no cursor
+  // (ring empty / error, or everything beyond the ring already rotated out). Surfacing it once
+  // turns a would-be silent dead click into an operator-visible signal.
+  function _warnRemintMiss() {
+    if (_remintMissWarned) return;
+    _remintMissWarned = true;
+    if (typeof console !== "undefined" && console && console.warn) {
+      console.warn(
+        "[petasos] scan-history: re-mint returned no cursor while scans_total exceeded the " +
+        "buffered window; landing on the retention-honest empty state. Rows older than the live " +
+        "window are unreachable (aged out of retention, or the live ring is empty)."
+      );
+    }
+  }
+
+  // PET-152: the single shared push for an older page — both the re-mint path and the paged-view
+  // path call it, so the shape guard and render trigger live in one place. Module-scoped (never a
+  // render-local) because it needs _container / Pet.renderDashboard. Keeps the Array.isArray shape
+  // guard so a 200 {} / { entries: null } body lands on the honest empty state instead of throwing
+  // on .scan_id (carried from the seed-merge hazard at :1778-1780).
+  function _pushOlderPage(cursor, d) {
+    Pet.state.historyAtHead = false;
+    var st = Pet.state.historyStack || (Pet.state.historyStack = []);
+    st.push({
+      entries: (d && Array.isArray(d.entries)) ? d.entries : [],
+      cursor: cursor,
+      nextBefore: (d && d.next_before) || null,
+      olderTruncated: !!(d && d.older_truncated),
+    });
+    if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+  }
+
+  // PET-152: "Older" handler. Reads Pet.state fresh at click time, captures the paging
+  // generation, asks the reducer for a plan, and runs the two-fetch re-mint off the live head:
+  // fetch-1 (limit = runtime buffer length, `before` absent) re-mints the head boundary off the
+  // in-memory ring; fetch-2 (`before` = freshCursor) pages into the on-disk sink. The two fetches
+  // read two different stores (server.py:1219-1235), so ring-then-sink is the only shape that can
+  // mint a current head boundary AND then reach the sink. The _historyPaging guard stays set
+  // across BOTH fetches and is cleared on every terminal path; each .then/.catch first checks the
+  // captured generation so a chain that outlives a re-seed / 401 / unmount drops without mutating.
+  Pet.pageHistoryOlder = function () {
+    if (_historyPaging) return; // ignore re-entrant clicks while a fetch is in flight
+    var gen = _historyPagingGen; // F-2: capture; teardown bumps this
+    var plan = Pet.historyPagingView(
+      {
+        atHead: Pet.state.historyAtHead !== false,
+        stack: Pet.state.historyStack || [],
+        bufferLength: (Pet.state.scanHistory || []).length,
+      },
+      "older"
+    );
+    if (plan.needsRemint) {
+      _historyPaging = true;
+      Pet.api.getScanHistory(plan.remintLimit).then(function (rd) {
+        if (gen !== _historyPagingGen) return;          // superseded by re-seed/401/unmount
+        if (Pet.auth.on401(rd)) { _historyPaging = false; return; }
+        var freshCursor = (rd && !rd.error && rd.next_before) ? rd.next_before : null;
+        if (freshCursor == null) {                      // gate said older exist, ring points nowhere
+          _historyPaging = false;
+          _pushOlderPage(null, { entries: [], older_truncated: true }); // honest empty (E-6)
+          _warnRemintMiss();                            // one-shot tripwire (E-6)
+          return;
+        }
+        return Pet.api.getScanHistory(100, freshCursor).then(function (d) {
+          if (gen !== _historyPagingGen) return;
+          _historyPaging = false;
+          if (Pet.auth.on401(d)) return;
+          if (!d.error) { _pushOlderPage(freshCursor, d); }
+        });
+      }).catch(function () { if (gen === _historyPagingGen) _historyPaging = false; });
+      return;
+    }
+    if (!plan.needsFetch) return; // paged view at the retained bottom (flag stays clear)
+    _historyPaging = true;
+    Pet.api.getScanHistory(100, plan.cursor).then(function (d) {
+      if (gen !== _historyPagingGen) return;
+      _historyPaging = false; // clear before any early return so paging can resume
+      if (Pet.auth.on401(d)) return; // a 401 stops paging, never a stale page
+      if (!d.error) { _pushOlderPage(plan.cursor, d); }
+    }).catch(function () { if (gen === _historyPagingGen) _historyPaging = false; });
+  };
+
+  // PET-152: "Newer" handler — relocated to module scope, behavior byte-identical to the former
+  // render-local closure (D-PAGING: client-buffered stack pop, no fetch), so it provably shares
+  // the one _historyPaging binding with pageHistoryOlder. Same in-flight guard: while an "Older"
+  // fetch is pending, a synchronous stack pop here would invalidate the cursor that pending .then
+  // is about to push from, appending a non-contiguous page and breaking Older/Newer adjacency.
+  Pet.pageHistoryNewer = function () {
+    if (_historyPaging) return;
+    var next = Pet.historyPagingView(
+      { atHead: Pet.state.historyAtHead !== false, stack: Pet.state.historyStack || [] },
+      "newer"
+    );
+    Pet.state.historyAtHead = next.atHead;
+    Pet.state.historyStack = next.stack;
+    if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+  };
   // PET-127: gate the scanner-health skeleton. renderDashboard re-runs on every
   // SSE/poll frame, so an unconditional skeleton would re-flash; this flips true
   // at every /health settle (in-render success+error arms AND the 10s poll), never
@@ -3311,6 +3431,7 @@
   Pet.mount = function (el) {
     el.innerHTML = "";
     _historySeeded = false;  // PET-102: re-seed on a re-mount that skipped unmount (plugin hot-reload)
+    _historyPaging = false; _historyPagingGen++;  // PET-152: cancel any in-flight paging from a skipped unmount
     _healthLoaded = false;   // PET-127: re-show the scanner-health skeleton on (re-)mount
     _armedSeeded = false;    // PET-111: re-fetch the armed bit on (re-)mount
     clearArmedConfirm();     // drop any stale disarm-confirm + timer from a skipped unmount
@@ -3405,6 +3526,7 @@
     _connStatus = null;      // PET-13: drop the stale header-blip node
     _liveRegion = null;      // PET-13: drop the stale live-region node
     _historySeeded = false;  // PET-102: next mount re-seeds the history buffer
+    _historyPaging = false; _historyPagingGen++;  // PET-152: cancel any in-flight paging re-mint on teardown
     _healthLoaded = false;   // PET-127: next mount re-shows the scanner-health skeleton
     _armedSeeded = false;    // PET-111: next mount re-fetches the armed bit
     clearArmedConfirm();     // clear the pending-disarm confirm + its 4s timer on teardown

--- a/tests/js/scan-history-paging.test.mjs
+++ b/tests/js/scan-history-paging.test.mjs
@@ -40,17 +40,57 @@ const sandbox = { window: {}, document };
 vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
+// ── PET-152 handler-integration helpers ──────────────────────────────────────
+// Pet.pageHistoryOlder is the async two-fetch re-mint handler; these drive it over the real
+// shipped petasos.js. The handler's in-flight guard (_historyPaging) and paging generation
+// (_historyPagingGen) are module-private, so each handler test calls resetPagingState() first
+// to clear the guard via the real exposed teardown (Pet.auth._enterAuthRequired) and
+// re-establish a clean live-head context — making every test independent of what a prior test
+// left in flight (e.g. the never-resolving fetch in the cross-guard test).
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+function makeRows(n, prefix) {
+  const rows = [];
+  for (let i = 0; i < n; i++) rows.push({ scan_id: (prefix || "s") + "-" + i });
+  return rows;
+}
+function resetPagingState() {
+  // The real, already-exposed teardown bumps _historyPagingGen and resets _historyPaging without
+  // needing DOM (renderDashboard is gated on the null _container in this headless harness).
+  Pet.renderDashboard = function () {};
+  Pet.auth._enterAuthRequired();
+  Pet.state.authRequired = false;
+  Pet.state.armed = true;
+  Pet.state.historyAtHead = true;
+  Pet.state.historyStack = [];
+  Pet.state.scanHistory = [];
+  Pet.state.pipelineHealth = null;
+  Pet.state.tab = "obs";
+}
+
 test("loader: petasos.js exposes the paging seams", () => {
   assert.equal(typeof Pet, "object");
   assert.equal(typeof Pet.historyPagingView, "function");
   assert.equal(typeof Pet.historyPageLabel, "function");
+  // PET-152: the new seams + extracted handlers are on the namespace.
+  assert.equal(typeof Pet.scanHistoryHasOlder, "function");
+  assert.equal(typeof Pet.pageHistoryOlder, "function");
+  assert.equal(typeof Pet.pageHistoryNewer, "function");
 });
 
-test("Older off the live head fetches with the head's server cursor", () => {
-  const next = Pet.historyPagingView({ atHead: true, stack: [], headCursor: "1700.5~s-abc" }, "older");
-  assert.equal(next.needsFetch, true);
-  assert.equal(next.cursor, "1700.5~s-abc");
-  assert.equal(next.atHead, false); // a successful older fetch leaves the live head
+test("Older off the live head signals a re-mint, never a cached cursor (PET-152)", () => {
+  // PET-152: off the head the reducer signals needsRemint instead of returning a (now-removed)
+  // cached seed cursor — that cursor went stale after ring eviction and skipped a band of rows.
+  const next = Pet.historyPagingView({ atHead: true, stack: [], bufferLength: 437 }, "older");
+  assert.equal(next.needsRemint, true);
+  assert.equal(next.cursor, null);      // no cursor is derivable; the reducer cannot hand back a stale one
+  assert.equal(next.remintLimit, 437);  // the handler re-mints sized to the runtime buffer length
+  assert.equal(next.needsFetch, false); // the re-mint is the handler's own fetch, not this plan's cursor fetch
+  assert.equal(next.atHead, false);     // a re-mint leaves the live head
 });
 
 test("Older from a paged view advances to that page's next_before cursor", () => {
@@ -60,14 +100,16 @@ test("Older from a paged view advances to that page's next_before cursor", () =>
   assert.equal(next.cursor, "1600.0~s-def"); // advances past the current page
 });
 
-test("Older at the retained bottom (null cursor) does not fetch", () => {
-  // head with no server cursor (empty sink / seed not done):
-  const atHead = Pet.historyPagingView({ atHead: true, stack: [], headCursor: null }, "older");
+test("Older at the retained bottom does not fetch (empty head; paged-view null cursor)", () => {
+  // PET-152: empty live head (no buffered rows) — re-mint refused, no fetch (edges E-2/E-4).
+  const atHead = Pet.historyPagingView({ atHead: true, stack: [], bufferLength: 0 }, "older");
+  assert.equal(atHead.needsRemint, false);
   assert.equal(atHead.needsFetch, false);
   assert.equal(atHead.cursor, null);
-  // paged view whose next_before is null (true bottom):
+  // paged view whose next_before is null (true bottom) — unchanged:
   const paged = Pet.historyPagingView({ atHead: false, stack: [{ nextBefore: null }] }, "older");
   assert.equal(paged.needsFetch, false);
+  assert.equal(paged.needsRemint, false);
 });
 
 test("Newer at the boundary restores the live head", () => {
@@ -117,4 +159,194 @@ test("empty paged response is retention-honest (D-ROTATION / edge F-2)", () => {
 test("the head subtitle stays scanHistorySubtitle (the only 'of N' total)", () => {
   // The live head keeps the PET-144 honest subtitle; paged views never compute a total.
   assert.equal(Pet.scanHistorySubtitle(500, 1200), "showing last 500 of 1200");
+});
+
+// ── PET-152: re-mint reducer, gate predicate, and two-fetch handler ───────────
+
+test("older off the live head re-mints, never reuses a stale seed cursor (PET-152 gap closure)", () => {
+  // Even handed a (now-removed) cached cursor field, the reducer ignores it: off the head it
+  // returns NO cursor and signals a re-mint, so no stale seed cursor can ever be handed back.
+  const next = Pet.historyPagingView(
+    { atHead: true, stack: [], bufferLength: 200, headCursor: "1700.5~stale" },
+    "older"
+  );
+  assert.equal(next.needsRemint, true);
+  assert.equal(next.cursor, null);
+  assert.equal(next.remintLimit, 200);
+});
+
+test("re-mint sizes the head fetch from runtime buffer length, not the literal 500 (D-DRIFT)", () => {
+  assert.equal(
+    Pet.historyPagingView({ atHead: true, stack: [], bufferLength: 312 }, "older").remintLimit,
+    312
+  );
+});
+
+test("scanHistoryHasOlder truth table (PET-152 gate)", () => {
+  assert.equal(Pet.scanHistoryHasOlder(500, 1200), true);   // evicting: older rows exist
+  assert.equal(Pet.scanHistoryHasOlder(500, 501), true);    // one evicted row (E-7 boundary)
+  assert.equal(Pet.scanHistoryHasOlder(300, 300), false);   // the window holds everything
+  assert.equal(Pet.scanHistoryHasOlder(500, 3), false);     // restart stale-low total (E-7)
+  assert.equal(Pet.scanHistoryHasOlder(0, 5), false);       // empty live buffer (E-2)
+  assert.equal(Pet.scanHistoryHasOlder(500, null), false);  // /health not loaded yet (E-5)
+  assert.equal(Pet.scanHistoryHasOlder(500, undefined), false);
+  assert.equal(Pet.scanHistoryHasOlder(500, NaN), false);
+});
+
+test("pageHistoryOlder re-mints then pages from the fresh boundary (post-eviction, seed -> evict -> older)", async () => {
+  resetPagingState();
+  const L = 500;
+  Pet.state.scanHistory = makeRows(L, "live");          // a full, post-eviction live window
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  const calls = [];
+  Pet.api.getScanHistory = function (limit, before) {
+    calls.push({ limit: limit, before: before });
+    if (before === undefined) {
+      // fetch-1: the head re-mint off the in-memory ring. Entries are discarded; only next_before read.
+      return Promise.resolve({ entries: makeRows(limit, "head"), next_before: "FRESH" });
+    }
+    // fetch-2: the older page from the on-disk sink, keyed on the RE-MINTED cursor.
+    return Promise.resolve({ entries: makeRows(100, "older"), next_before: "OLDER" });
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].limit, L);            // fetch-1 sized to the runtime buffer length
+  assert.equal(calls[0].before, undefined);   // fetch-1 is `before`-absent (reads the ring)
+  assert.equal(calls[1].before, "FRESH");     // fetch-2 pages from the re-minted boundary, not a seed value
+  const top = Pet.state.historyStack[Pet.state.historyStack.length - 1];
+  assert.equal(top.cursor, "FRESH");
+  assert.equal(top.nextBefore, "OLDER");
+  assert.equal(top.entries.length, 100);
+  assert.equal(Pet.state.historyAtHead, false);
+});
+
+test("pageHistoryOlder clears the in-flight guard on a rejected re-mint fetch (E-3)", async () => {
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  let calls = 0;
+  let mode = "reject";
+  Pet.api.getScanHistory = function (limit, before) {
+    calls++;
+    if (mode === "reject") return Promise.reject(new Error("transport down"));
+    if (before === undefined) return Promise.resolve({ entries: [], next_before: "FRESH" });
+    return Promise.resolve({ entries: makeRows(100, "older"), next_before: null });
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls, 1); // the rejected re-mint
+  // The .catch must have cleared the guard — a subsequent click must be able to fetch again.
+  mode = "ok";
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.ok(calls >= 3, "in-flight guard wedged after a rejected re-mint (calls=" + calls + ")");
+});
+
+test("pageHistoryOlder shows the honest empty state when the re-mint yields no cursor (E-6)", async () => {
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };          // gate-true: older rows "exist"
+  const calls = [];
+  Pet.api.getScanHistory = function (limit, before) {
+    calls.push({ limit: limit, before: before });
+    return Promise.resolve({ entries: makeRows(limit, "head"), next_before: null }); // ring points nowhere
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls.length, 1); // no fetch-2 (no cursor to page with)
+  const top = Pet.state.historyStack[Pet.state.historyStack.length - 1];
+  assert.equal(Pet.historyPageLabel(top), "no older retained history");
+  assert.equal(Pet.state.historyAtHead, false);
+  assert.equal(top.nextBefore, null); // self-disables further "Older" (no re-click loop, bounded stack)
+  // _historyPaging must be cleared: re-establish a live head and confirm a fresh re-mint fetches.
+  Pet.state.historyAtHead = true;
+  Pet.state.historyStack = [];
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.ok(calls.length >= 2, "in-flight guard not cleared after the E-6 empty push");
+});
+
+test("a sink rotation between the two fetches lands on the honest empty state (E-8)", async () => {
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  const calls = [];
+  Pet.api.getScanHistory = function (limit, before) {
+    calls.push({ limit: limit, before: before });
+    if (before === undefined) return Promise.resolve({ entries: makeRows(limit, "head"), next_before: "FRESH" });
+    // fetch-2: the segment just older than FRESH was unlinked by a rotation between the fetches.
+    return Promise.resolve({ entries: [], older_truncated: true });
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].before, "FRESH");
+  const top = Pet.state.historyStack[Pet.state.historyStack.length - 1];
+  assert.equal(top.entries.length, 0);
+  assert.equal(top.olderTruncated, true);
+  assert.equal(Pet.historyPageLabel(top), "no older retained history"); // never a contiguous-looking page
+  assert.equal(Pet.state.historyAtHead, false);
+});
+
+test("an in-flight Older blocks a Newer click (E-9 cross-guard, shared _historyPaging)", () => {
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  // A paged-back context with one page, so a (wrongly) allowed Newer would pop back toward the head.
+  Pet.state.historyAtHead = false;
+  Pet.state.historyStack = [{ entries: makeRows(3, "p"), cursor: "C", nextBefore: "N" }];
+  const pending = deferred(); // fetch never resolves -> _historyPaging stays set
+  let calls = 0;
+  Pet.api.getScanHistory = function () { calls++; return pending.promise; };
+  Pet.pageHistoryOlder(); // advances the paged view; sets the shared in-flight guard
+  assert.equal(calls, 1);
+  Pet.pageHistoryNewer(); // must be ignored while the Older fetch is pending
+  assert.equal(Pet.state.historyStack.length, 1); // NOT popped
+  assert.equal(Pet.state.historyAtHead, false);   // still paged back
+});
+
+test("a re-mint that resolves after teardown does not push onto the reset stack (E-9 generation)", async () => {
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  const d1 = deferred();
+  let calls = 0;
+  Pet.api.getScanHistory = function (limit, before) {
+    calls++;
+    if (before === undefined) return d1.promise; // fetch-1: controllable
+    return Promise.resolve({ entries: makeRows(100, "older"), next_before: "OLDER" });
+  };
+  Pet.pageHistoryOlder(); // captures gen; fetch-1 pending
+  assert.equal(calls, 1);
+  // The real, already-exposed teardown (the :449 site) bumps the generation and resets the guard.
+  Pet.auth._enterAuthRequired();
+  Pet.state.authRequired = false;
+  // Simulate the re-seed straight back to the live head that follows teardown.
+  Pet.state.historyStack = [];
+  Pet.state.historyAtHead = true;
+  // Now let the stale fetch-1 resolve; its .then must see gen !== _historyPagingGen and bail.
+  d1.resolve({ entries: makeRows(500, "head"), next_before: "FRESH" });
+  await flush();
+  assert.equal(Pet.state.historyStack.length, 0); // stale continuation dropped, nothing pushed
+  assert.equal(Pet.state.historyAtHead, true);    // not flipped back to a paged view
+  assert.equal(calls, 1);                          // fetch-2 never issued under the dead generation
+});
+
+test("_pushOlderPage tolerates a malformed older-page body (F-5)", async () => {
+  for (const bad of [{}, { entries: null }]) {
+    resetPagingState();
+    Pet.state.scanHistory = makeRows(500, "live");
+    Pet.state.pipelineHealth = { scans_total: 1200 };
+    Pet.api.getScanHistory = function (limit, before) {
+      if (before === undefined) return Promise.resolve({ entries: [], next_before: "FRESH" });
+      return Promise.resolve(bad); // fetch-2: malformed
+    };
+    Pet.pageHistoryOlder();
+    await flush();
+    const top = Pet.state.historyStack[Pet.state.historyStack.length - 1];
+    assert.equal(top.entries.length, 0);
+    assert.equal(top.nextBefore, null);
+    assert.match(Pet.historyPageLabel(top), /no older/); // honest empty state, no throw
+  }
 });

--- a/tests/js/scan-history-paging.test.mjs
+++ b/tests/js/scan-history-paging.test.mjs
@@ -350,3 +350,54 @@ test("_pushOlderPage tolerates a malformed older-page body (F-5)", async () => {
     assert.match(Pet.historyPageLabel(top), /no older/); // honest empty state, no throw
   }
 });
+
+test("a non-OK sink fetch is a failed read, never an empty older page (F-6, _status gate)", async () => {
+  // _req stamps `_status` on a parsed non-OK body; a 403/500 like {} carries NO `error`. The push
+  // must NOT treat it as an empty older page (that would render a silent "no older history" on an
+  // auth/server failure). Nothing is pushed and the in-flight guard clears so a retry can fetch.
+  resetPagingState();
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  let calls = 0;
+  Pet.api.getScanHistory = function (limit, before) {
+    calls++;
+    if (before === undefined) return Promise.resolve({ entries: makeRows(limit, "head"), next_before: "FRESH" });
+    return Promise.resolve({ _status: 500 }); // fetch-2: server error, no `error` field, no entries
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls, 2);
+  assert.equal(Pet.state.historyStack.length, 0); // failed read NOT pushed as an empty page
+  assert.equal(Pet.state.historyAtHead, true);    // never left the live head (only _pushOlderPage flips it)
+  // guard cleared: a fresh re-mint must be able to fetch again
+  Pet.api.getScanHistory = function (limit, before) {
+    calls++;
+    if (before === undefined) return Promise.resolve({ entries: makeRows(limit, "head"), next_before: "FRESH" });
+    return Promise.resolve({ entries: makeRows(100, "older"), next_before: "OLDER" });
+  };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.ok(calls >= 4, "in-flight guard wedged after a non-OK sink fetch (calls=" + calls + ")");
+  assert.equal(Pet.state.historyStack.length, 1); // the retry pages cleanly
+});
+
+test("a non-OK paged-view fetch is a failed read, never an empty older page (F-6, _status gate)", async () => {
+  resetPagingState();
+  // Paged-back one level so the reducer takes the needsFetch (non-remint) branch.
+  Pet.state.scanHistory = makeRows(500, "live");
+  Pet.state.pipelineHealth = { scans_total: 1200 };
+  Pet.state.historyAtHead = false;
+  Pet.state.historyStack = [{ entries: makeRows(3, "p"), cursor: "C0", nextBefore: "C1" }];
+  let calls = 0;
+  Pet.api.getScanHistory = function () { calls++; return Promise.resolve({ _status: 403 }); };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls, 1);
+  assert.equal(Pet.state.historyStack.length, 1); // unchanged: the 403 is not pushed as a new page
+  // guard cleared: a subsequent click fetches again
+  Pet.api.getScanHistory = function () { calls++; return Promise.resolve({ entries: makeRows(2, "q"), next_before: null }); };
+  Pet.pageHistoryOlder();
+  await flush();
+  assert.equal(calls, 2);
+  assert.equal(Pet.state.historyStack.length, 2);
+});


### PR DESCRIPTION
## Summary
- Closes the in-session audit-history navigation gap: `Pet.state.historyHeadCursor` was captured once at mount-seed and never refreshed, so after a single mount took on >500 scans the ring evicted past it and clicking "Older" from the live head skipped the contiguous band between the current oldest buffered row and the stale seed boundary.
- Drops the cached cursor entirely and re-mints the head boundary via a fresh server round-trip (sized to the **runtime** buffer length) on every head→older transition; gates "Older" off the head on the same lifetime `/health.scans_total` the subtitle already shows.
- Client-side reachability fix only: no change to `server.py`, the `getScanHistory` wire shape, `next_before`/`older_truncated` minting, or D-RESTART's single total. The on-disk rows were never lost (PET-148 sink).

## Two-fetch interaction (ring then sink)
Off the live head the reducer signals `needsRemint`; `Pet.pageHistoryOlder` then does **fetch-1** `getScanHistory(bufferLength)` (`before` absent → reverse-reads the ≤500 in-memory ring, re-minting a current head boundary) and **fetch-2** `getScanHistory(100, freshCursor)` (`before` present → reverse-reads the on-disk sink under `_history_lock`). A `before`-absent call can never reach sink rows, so ring-then-sink is the only shape that can mint a fresh boundary *and* page into the sink. The re-minted cursor is never older than the current oldest buffered row, so paging is gap-free down to retention; a rotation between the two fetches degrades honestly to the retention-empty state, never a silently-skipped band.

## Layered defense
- **In-flight guard** (`_historyPaging`, shared by both module-scoped handlers): an "Older" re-mint in flight blocks a "Newer" pop that would invalidate the cursor it is about to push from.
- **Generation guard** (`_historyPagingGen`, bumped at all four teardown sites, checked in both `.then` bodies + `.catch`): a two-fetch chain that outlives a re-seed / 401 / unmount cannot push a stale page onto the reset stack or flip `historyAtHead`.
- **Tripwire** (`_warnRemintMiss`, one-shot): a `scans_total > buffered` vs `next_before == null` divergence lands on the retention-honest empty state and warns once, never a silent dead click.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/static/petasos.js` | Drops `historyHeadCursor` (state + seed); reducer signals re-mint off the head; new `Pet.scanHistoryHasOlder` gate; extracts/exposes `Pet.pageHistoryOlder`/`pageHistoryNewer` to module scope with the two-fetch re-mint, shared `_pushOlderPage`, `_historyPagingGen`, and `_warnRemintMiss` |
| `tests/js/scan-history-paging.test.mjs` | Re-points the test that pinned the buggy reducer; adds reducer/gate/handler-integration coverage (post-eviction re-mint, E-3/E-6/E-8/E-9, F-5) |

## Test plan
- [x] `node --test tests/js/scan-history-paging.test.mjs` — 20/20 pass (full output: `docs/specs/TODO/PET-152.test-output.txt`)
- [x] `pytest tests/test_console_scan_history.py tests/test_console_handlers.py -q` (regression guard: server read path + `next_before` minting unchanged) — 71 passed
- [x] `pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 2013 passed, 42 skipped, 1 deselected (pre-existing local Unicode 13/14 failure), 1 xfailed
- [x] `ruff check .` / `ruff format --check .` / `mypy --strict .` — clean (no Python source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked “Older” scan-history pagination to re-establish the live window boundary before loading older retained records.
  * “Older” navigation is now enabled only when the live window has additional history to page.

* **Bug Fixes**
  * Prevents stale or late results from affecting the scan-history view after teardown/resume and during rapid Older/Newer navigation.
  * Handles empty or no-cursor outcomes as honest empty states.

* **Tests**
  * Expanded headless integration coverage for Older/Newer paging, re-establishment (“remint”) behavior, concurrency protection, and non-OK fetch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->