### PR TITLE
feat(pet-157): self-diagnosing integrity-key state for Observability provenance

### DIFF
--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -133,6 +133,26 @@ def verify_event(ev: object, key: bytes | None) -> bool:
         return False
 
 
+def classify_integrity_failure(record: object) -> str:
+    """Name the failure class of a record that failed verification (PET-157 D3).
+
+    The single source of truth for the ``sig-missing`` / ``sig-mismatch`` split, consumed by
+    the live drain's log tripwire (``_log_integrity_failure``), the ``get_health`` integrity
+    field, and the boot preflight, so the three can never drift. Pure and total, mirroring
+    ``verify_event``'s posture: a non-dict input or a missing/non-string ``sig`` is
+    ``"sig-missing"``; a present string ``sig`` that nonetheless failed verification is
+    ``"sig-mismatch"``. The *caller* owns the trust decision — this only names the class
+    once verification has already failed.
+
+    Empty-string ``sig`` corner (preserved, not refined): ``sig == ""`` classifies as
+    ``"sig-mismatch"`` (``isinstance("", str)`` is ``True``), byte-identical to the
+    pre-PET-157 inline expression it replaces.
+    """
+    if not isinstance(record, dict) or not isinstance(record.get("sig"), str):
+        return "sig-missing"
+    return "sig-mismatch"
+
+
 def emit_enforcement_event(event: dict[str, Any]) -> bool:
     """Append one enforcement event as a JSONL line. O(1), fail-open.
 

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -17,6 +17,7 @@ import json
 import logging
 import time
 import uuid
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from petasos.console import _history
@@ -62,6 +63,36 @@ _ENFORCEMENT_TAIL_INTERVAL_S = 1.0
 # PET-139: rate-limit window for the integrity-failure tripwire (D9), mirroring the
 # reference plugin's `_DISARM_LOG_EVERY_S` cadence so a forging loop cannot spam the log.
 _INTEGRITY_LOG_EVERY_S = 30.0
+# PET-157 (D8): bound on the recent-verdict window the `get_health` integrity field samples.
+# A bounded deque sample, NOT the durable record: a forged/mismatched row older than this many
+# newer events ages out of the live `counts`, but the durable record of a failure this run is
+# the one-shot PETASOS_INTEGRITY_PREFLIGHT WARNING (D7) plus the per-row
+# PETASOS_INTEGRITY_UNVERIFIABLE log (PET-139), neither of which the window can evict.
+_INTEGRITY_WINDOW = 256
+# PET-157 (D9): remediation copy for the integrity diagnostic, backend-emitted so a health-level
+# test can assert it. Keyed by failure class. Must NOT assert forgery for `sig-mismatch` — a
+# PETASOS_SESSION_SECRET skew between gateway and dashboard is the overwhelmingly likely cause.
+# No em dash (house style).
+_INTEGRITY_REMEDIATION = {
+    "sig-mismatch": (
+        "the gateway and dashboard most likely hold different PETASOS_SESSION_SECRET values; "
+        "set the same secret on both processes and restart them. A forged row is rare but "
+        "possible; a single mismatched row among verified rows is the one to investigate."
+    ),
+    "sig-missing": (
+        "the writer is an older build that does not sign the spool, or it has no "
+        "PETASOS_SESSION_SECRET while the dashboard does; upgrade the writer, or set a matching "
+        "PETASOS_SESSION_SECRET on both and restart."
+    ),
+}
+# PET-157 (D9): mode-neutral note for the integrity-off (key_on False) health path. Does not
+# over-promise a specific log line because the two modes fail differently — embedded degrades
+# to off on invalid base64, standalone refuses to start. No em dash (house style).
+_INTEGRITY_KEY_OFF_NOTE = (
+    "Integrity is off because no valid PETASOS_SESSION_SECRET is configured for this process. "
+    "If you did set one, the value may not be valid base64; check this dashboard's startup log "
+    "for a base64 warning (embedded mode degrades to off, standalone refuses to start)."
+)
 # Cap on the surfaced enforcement `reason` length. The raw matched value lives in a
 # finding's `matched_text` (never surfaced); `reason` is the structured scanner/guard
 # message (e.g. "PII detected: PERSON"), already returned to the agent. We cap it so a
@@ -531,6 +562,14 @@ class ConsoleHandlers:
         self._scans_total = 0
         # One-shot guard so the first ring overflow logs exactly once per run, not per scan.
         self._ring_overflow_warned = False
+        # PET-157: self-diagnosing integrity state. `_integrity_recent` is a bounded window of
+        # the most recent `(provenance, failure_class)` tuples, fed ONLY by the live drain
+        # (`_surface_enforcement_event`); `get_health` reads it without draining (D8/D10).
+        # `failure_class` is non-None only for `unverifiable` entries (computed via the D3
+        # helper at record time). `_integrity_preflight_emitted` is the one-shot guard for the
+        # boot/preflight WARNING (D7), mirroring `_ring_overflow_warned`/`_history_sink_warned`.
+        self._integrity_recent: deque[tuple[str, str | None]] = deque(maxlen=_INTEGRITY_WINDOW)
+        self._integrity_preflight_emitted = False
 
         pipeline.add_audit_listener(self._on_audit)
         pipeline.add_alert_listener(self._on_alert)
@@ -586,13 +625,42 @@ class ConsoleHandlers:
             if now - self._integrity_log_last < _INTEGRITY_LOG_EVERY_S:
                 return
             self._integrity_log_last = now
-            failure_class = "sig-missing" if not isinstance(ev.get("sig"), str) else "sig-mismatch"
+            # PET-157 (D3): the single source of truth for the failure class. Byte-identical
+            # output to the prior inline expression for the dict this path always passes.
+            from petasos.console import _events
+
+            failure_class = _events.classify_integrity_failure(ev)
             _logger.warning(
                 "PETASOS_INTEGRITY_UNVERIFIABLE class=%s scan_id=%s session_id=%s — spool row "
                 "failed HMAC verification (forged, misconfigured, or legacy unsigned)",
                 failure_class,
                 ev.get("scan_id"),
                 ev.get("session_id"),
+            )
+        except Exception:
+            pass
+
+    def _log_integrity_preflight(self, ev: dict[str, Any], failure_class: str | None) -> None:
+        """PET-157 (D7): one-shot boot/preflight WARNING the first time this run surfaces a
+        key-on spool row that fails verification. Never raises.
+
+        Distinct from the per-row, rate-limited `PETASOS_INTEGRITY_UNVERIFIABLE` tripwire: this
+        fires exactly once per run (the caller sets `_integrity_preflight_emitted` before calling,
+        so even a suppressed raise here cannot double-fire it), names the remediation for the
+        likely cause (D9), and mirrors the one-shot `PETASOS_HISTORY_SINK_UNWRITABLE` /
+        `_ring_overflow_warned` convention. The greppable token is `PETASOS_INTEGRITY_PREFLIGHT`.
+        """
+        try:
+            remediation = _INTEGRITY_REMEDIATION.get(
+                failure_class or "", _INTEGRITY_REMEDIATION["sig-mismatch"]
+            )
+            _logger.warning(
+                "PETASOS_INTEGRITY_PREFLIGHT class=%s scan_id=%s session_id=%s — the dashboard "
+                "holds an integrity key but a spool row failed verification: %s",
+                failure_class,
+                ev.get("scan_id"),
+                ev.get("session_id"),
+                remediation,
             )
         except Exception:
             pass
@@ -699,6 +767,21 @@ class ConsoleHandlers:
         verified = _events.verify_event(ev, self._spool_key)
         key_on = self._spool_key is not None
         provenance = "unattested" if not key_on else ("genuine" if verified else "unverifiable")
+        # PET-157: record the verdict into the bounded window the get_health integrity field
+        # samples (D8), and fire the one-shot boot/preflight WARNING the first time a key-on row
+        # is unverifiable (D7). `failure_class` is computed via the D3 helper only for
+        # unverifiable rows; every other verdict carries None.
+        # NOTE (post-rotation ordering, deferred P2): a `.rot` recovery surfaces temporally-older
+        # rows at the window's newest end, so the window's dominant verdict is "dominant among
+        # most-recently-*surfaced*"; a brief counts.unverifiable spike right after a rotation is
+        # benign (the durable preflight + per-row log are unaffected), not a bug.
+        failure_class = (
+            _events.classify_integrity_failure(ev) if provenance == "unverifiable" else None
+        )
+        self._integrity_recent.append((provenance, failure_class))
+        if provenance == "unverifiable" and not self._integrity_preflight_emitted:
+            self._integrity_preflight_emitted = True
+            self._log_integrity_preflight(ev, failure_class)
         if key_on and not verified:
             self._log_integrity_failure(ev)
         summary = _enforcement_summary(ev, provenance=provenance)
@@ -1168,6 +1251,61 @@ class ConsoleHandlers:
             "session_id": session_id,
         }
 
+    def _integrity_health(self) -> dict[str, Any]:
+        """PET-157 (D8): assemble the additive `integrity` health field from the bounded
+        recent-verdict window WITHOUT draining. Pure and side-effect-free.
+
+        The live drain (`_surface_enforcement_event`) feeds the window; this only reads it, so a
+        health poll never gains enforcement side-effects (ring pushes, SSE broadcasts, rotation).
+        Snapshots the deque once (D10) so a concurrent append cannot change the counts
+        mid-computation. `key_on` is always exact (`self._spool_key is not None`), so the
+        no-regression key-off report (D2) holds from the first poll, even on an empty window.
+        `dominant_verdict` is the max-count verdict with a deterministic tie-break
+        (`unverifiable` > `unattested` > `genuine` — the more-alarming verdict wins a tie, so a
+        50/50 window never lulls the operator). `failure_class`/`remediation` are reported only
+        when the dominant verdict is `unverifiable`; when `key_on` is False the remediation is the
+        mode-neutral invalid-base64 note (D9), never an alarm.
+        """
+        window = list(self._integrity_recent)
+        counts = {"genuine": 0, "unattested": 0, "unverifiable": 0}
+        fc_counts = {"sig-missing": 0, "sig-mismatch": 0}
+        for provenance, fc in window:
+            if provenance in counts:
+                counts[provenance] += 1
+            if provenance == "unverifiable" and fc in fc_counts:
+                fc_counts[fc] += 1
+
+        key_on = self._spool_key is not None
+        # Tie-break ordering: more-alarming verdict wins on equal counts.
+        _order = {"unverifiable": 2, "unattested": 1, "genuine": 0}
+        dominant_verdict: str | None = None
+        if window:
+            dominant_verdict = max(counts, key=lambda v: (counts[v], _order[v]))
+            if counts[dominant_verdict] == 0:  # belt-and-suspenders; window != [] implies > 0
+                dominant_verdict = None
+
+        failure_class: str | None = None
+        remediation: str | None = None
+        if dominant_verdict == "unverifiable":
+            # Only two classes; ties break to sig-mismatch (the action-bearing one).
+            failure_class = (
+                "sig-mismatch"
+                if fc_counts["sig-mismatch"] >= fc_counts["sig-missing"]
+                else "sig-missing"
+            )
+            remediation = _INTEGRITY_REMEDIATION[failure_class]
+        elif not key_on:
+            remediation = _INTEGRITY_KEY_OFF_NOTE
+
+        return {
+            "key_on": key_on,
+            "dominant_verdict": dominant_verdict,
+            "failure_class": failure_class,
+            "counts": counts,
+            "window_size": len(window),
+            "remediation": remediation,
+        }
+
     async def get_health(self) -> dict[str, Any]:
         cfg = self.pipeline.config
         config_hash = hashlib.sha256(
@@ -1187,6 +1325,9 @@ class ConsoleHandlers:
             },
             "scanners": self.pipeline.scanner_health(),
             "feature_status": dict(self.pipeline._build_feature_status()),
+            # PET-157 (D5): additive integrity diagnostic. Existing consumers ignore unknown
+            # keys; no change to any other field or HTTP response shape.
+            "integrity": self._integrity_health(),
         }
 
     async def get_scan_history(
@@ -1380,6 +1521,17 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
 
     @app.on_event("startup")
     async def _startup() -> None:
+        # PET-157 (D7): drain the pre-existing spool tail once, synchronously, BEFORE spawning
+        # the tailer so the integrity preflight reflects the boot-time tail deterministically and
+        # testably (the tailer would surface it within one interval regardless). Wrapped in the
+        # SAME try/except the tailer body uses so a future drain regression can never break app
+        # startup (edge F-5); `_drain_enforcement_into_history` already never raises, so this is
+        # belt-and-suspenders parity with the tailer.
+        try:
+            await handlers._drain_enforcement_into_history()
+        except Exception:
+            _logger.debug("enforcement preflight drain failed", exc_info=True)
+
         async def _tail() -> None:
             while True:
                 try:

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -966,6 +966,20 @@
     }
     var wrap = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "6px" } });
     var keyOn = integrity.key_on === true;
+    var verdict = integrity.dominant_verdict;
+    // Coerce a counts entry to a non-negative number; anything odd reads as 0 (never throws).
+    function _n(x) { return (typeof x === "number" && isFinite(x) && x >= 0) ? x : 0; }
+    var c = (integrity.counts && typeof integrity.counts === "object") ? integrity.counts : null;
+    // Per-verdict counts over the recent window. Rendered whenever the backend supplied counts,
+    // in BOTH modes, so the "single bad row among genuines" case the backend already exposes is
+    // visible from the dashboard alone (PET-157 cry-wolf, brief other-implications bullet 1)
+    // instead of being masked by the dominant verdict pill.
+    function countsLine() {
+      if (!c) return null;
+      return Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)" } },
+        "recent: " + _n(c.genuine) + " genuine / " + _n(c.unattested) + " unattested / " +
+        _n(c.unverifiable) + " unverifiable (window " + _n(integrity.window_size) + ")");
+    }
 
     var headRow = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px" } });
     headRow.appendChild(Pet.h("span", { className: "mono", style: { fontSize: "12px", color: "var(--tx)", minWidth: "120px", display: "inline-block" } }, "integrity"));
@@ -979,11 +993,12 @@
         ? integrity.remediation
         : "integrity off (no session secret); rows are unattested";
       wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", whiteSpace: "pre-wrap", wordBreak: "break-word" } }, offNote));
+      var offCounts = countsLine();
+      if (offCounts) wrap.appendChild(offCounts);
       return wrap;
     }
 
     // ON: dominant verdict pill (genuine => ok, unattested => neutral, unverifiable => err).
-    var verdict = integrity.dominant_verdict;
     if (verdict) {
       var vPill = "pill";
       if (verdict === "genuine") vPill = "pill ok";
@@ -1000,7 +1015,25 @@
       wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)" } }, "no rows surfaced yet"));
     }
 
-    // Remediation line: present only when the dominant verdict is unverifiable.
+    var onCounts = countsLine();
+    if (onCounts) wrap.appendChild(onCounts);
+
+    // Cry-wolf guard: surface unverifiable rows even when they are NOT the dominant verdict (e.g.
+    // one mismatched row among many genuines), so the dominant pill cannot lull the operator into
+    // reading a tampered board as healthy. The dominant-unverifiable case already screams via the
+    // err pill + remediation, so skip it there to avoid duplication. No per-row class here: the
+    // backend reports failure_class only for the dominant-unverifiable case (D8), so this names
+    // the count and points the operator at the rows rather than guessing the class.
+    var nUnver = c ? _n(c.unverifiable) : 0;
+    if (nUnver > 0 && verdict !== "unverifiable") {
+      var warnRow = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px", marginTop: "2px" } });
+      warnRow.appendChild(Pet.h("span", { className: "pill err" }, nUnver + " unverifiable"));
+      warnRow.appendChild(Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", whiteSpace: "pre-wrap", wordBreak: "break-word" } },
+        (nUnver === 1 ? "1 row" : (nUnver + " rows")) + " in the recent window failed verification even though the dominant state is " + verdict + "; investigate before trusting this board."));
+      wrap.appendChild(warnRow);
+    }
+
+    // Remediation line: present (from the backend) only when the dominant verdict is unverifiable.
     if (typeof integrity.remediation === "string" && integrity.remediation) {
       wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", whiteSpace: "pre-wrap", wordBreak: "break-word", marginTop: "2px" } }, integrity.remediation));
     }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -355,6 +355,7 @@
     auditLog: [],
     scannerHealth: [],
     pipelineHealth: null,
+    integrityHealth: null, // PET-157: additive get_health `integrity` payload for the obs panel
     profiles: [],
     about: null,
     armed: true,  // PET-111: master Equipped/Unequipped bit; corrected by the mount fetch
@@ -502,6 +503,7 @@
             _healthLoaded = true;
             Pet.state.scannerHealth = h.scanners || [];
             Pet.state.pipelineHealth = h.pipeline || null;
+            Pet.state.integrityHealth = h.integrity || null; // PET-157: mirror pipelineHealth
           }
           startPolling();
           if (Pet.sse && Pet.sse.connect) Pet.sse.connect();
@@ -830,6 +832,7 @@
           _healthLoaded = true;  // PET-127: a poll settle that beats a slow in-render fetch flips the gate, not the skeleton
           Pet.state.scannerHealth = d.scanners || [];
           Pet.state.pipelineHealth = d.pipeline || null;
+          Pet.state.integrityHealth = d.integrity || null; // PET-157: mirror pipelineHealth (recurring poll)
           if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
         }
       });
@@ -945,6 +948,63 @@
       table.appendChild(cell);
     }
     return table;
+  };
+
+  // PET-157: Observability integrity panel builder (mirrors Pet.scannerHealthRows). Reads the
+  // additive get_health `integrity` field and renders the self-diagnosing state — ON/OFF, the
+  // dominant verdict pill, the failure class, and the remediation line — so an operator can tell
+  // config skew (sig-missing/sig-mismatch) from a genuine state from the dashboard alone. Never
+  // throws: tolerant of a missing/partial `integrity` object (renders "integrity status
+  // unavailable"), matching the scannerHealthRows([]) defensive idiom — the SSE _dispatch
+  // re-render path calls this synchronously, so an exception here would abort the live re-render.
+  // No alarm styling on the OFF / unattested paths (D2): bare `pill` is the neutral chip.
+  Pet.integrityRows = function (integrity) {
+    // Missing or partial payload (null/undefined/non-object, or no boolean `key_on`) renders the
+    // unavailable fallback rather than guessing a state — mirrors scannerHealthRows([]).
+    if (!integrity || typeof integrity !== "object" || typeof integrity.key_on !== "boolean") {
+      return Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, "integrity status unavailable");
+    }
+    var wrap = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "6px" } });
+    var keyOn = integrity.key_on === true;
+
+    var headRow = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px" } });
+    headRow.appendChild(Pet.h("span", { className: "mono", style: { fontSize: "12px", color: "var(--tx)", minWidth: "120px", display: "inline-block" } }, "integrity"));
+    // ON => ok pill; OFF => neutral (bare) pill, never an alarm (D2).
+    headRow.appendChild(Pet.h("span", { className: keyOn ? "pill ok" : "pill" }, keyOn ? "ON" : "OFF"));
+    wrap.appendChild(headRow);
+
+    if (!keyOn) {
+      // OFF: the mode-neutral invalid-base64 note (D9) when present, else a short default.
+      var offNote = (typeof integrity.remediation === "string" && integrity.remediation)
+        ? integrity.remediation
+        : "integrity off (no session secret); rows are unattested";
+      wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", whiteSpace: "pre-wrap", wordBreak: "break-word" } }, offNote));
+      return wrap;
+    }
+
+    // ON: dominant verdict pill (genuine => ok, unattested => neutral, unverifiable => err).
+    var verdict = integrity.dominant_verdict;
+    if (verdict) {
+      var vPill = "pill";
+      if (verdict === "genuine") vPill = "pill ok";
+      else if (verdict === "unverifiable") vPill = "pill err";
+      var vRow = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "8px" } });
+      vRow.appendChild(Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", minWidth: "120px", display: "inline-block" } }, "dominant verdict"));
+      vRow.appendChild(Pet.h("span", { className: vPill }, verdict));
+      if (typeof integrity.failure_class === "string" && integrity.failure_class) {
+        vRow.appendChild(Pet.h("span", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)" } }, integrity.failure_class));
+      }
+      wrap.appendChild(vRow);
+    } else {
+      // key on but the window is empty (no rows surfaced yet) — honest, not an error (D8).
+      wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)" } }, "no rows surfaced yet"));
+    }
+
+    // Remediation line: present only when the dominant verdict is unverifiable.
+    if (typeof integrity.remediation === "string" && integrity.remediation) {
+      wrap.appendChild(Pet.h("div", { className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)", whiteSpace: "pre-wrap", wordBreak: "break-word", marginTop: "2px" } }, integrity.remediation));
+    }
+    return wrap;
   };
 
   // PET-102: history rows derived from the in-memory scan-history buffer.
@@ -1653,6 +1713,19 @@
     });
     wrapper.appendChild(healthPanel);
 
+    // PET-157: integrity diagnostic panel, sibling to scanner health. Renders the additive
+    // get_health `integrity` field so config skew (sig-missing/sig-mismatch) is distinguishable
+    // from a genuine state and a key-off deployment, from the dashboard alone. A separate panel
+    // (not patched in place by the cold-mount getHealth settle below); refreshes on the next
+    // startPolling tick (<=10s) and on first paint — bounded, display-only staleness (D8 / F-1).
+    var integrityPanel = Pet.Panel({
+      icon: "shieldCheck", title: "integrity", place: "spool provenance", flush: true,
+      content: Pet.h("div", { style: { padding: "12px" } },
+        Pet.integrityRows(Pet.state.integrityHealth)
+      ),
+    });
+    wrapper.appendChild(integrityPanel);
+
     // Scan history — PET-148 back-pages. The live head renders the SSE-maintained ≤500
     // buffer with the PET-144 "last N of M" subtitle; paged-back views render fetched older
     // pages with a positional (no-total) label and Older/Newer controls (D-RESTART/D-PAGING).
@@ -1739,6 +1812,7 @@
         var hadHealth = Pet.state.pipelineHealth !== null;
         Pet.state.scannerHealth = d.scanners || [];
         Pet.state.pipelineHealth = d.pipeline || null;
+        Pet.state.integrityHealth = d.integrity || null; // PET-157: mirror pipelineHealth (cold-mount settle)
         var rows = Pet.scannerHealthRows(Pet.state.scannerHealth);
         var contentEl = healthPanel.querySelector("[style*='padding: 12px']") || healthPanel.querySelector("div > div");
         if (contentEl) { contentEl.innerHTML = ""; contentEl.appendChild(rows); }

--- a/tests/js/integrity-health.test.mjs
+++ b/tests/js/integrity-health.test.mjs
@@ -112,6 +112,37 @@ test("unverifiable / sig-mismatch renders the err pill + remediation line", () =
   assert.ok(cls.some((c) => c.split(" ").includes("err")), "unverifiable verdict should use the err pill");
 });
 
+test("cry-wolf: dominant genuine but a single unverifiable row stays visible", () => {
+  // Mirrors backend health-state 5 (test_console_integrity_health.py): a window of mostly
+  // genuine with one unverifiable row. The dominant pill says genuine, but the bad row MUST
+  // still be visible from the dashboard alone, not masked into a healthy-looking board.
+  const el = Pet.integrityRows({
+    key_on: true,
+    dominant_verdict: "genuine",
+    failure_class: null,
+    counts: { genuine: 8, unattested: 0, unverifiable: 1 },
+    window_size: 9,
+    remediation: null,
+  });
+  const txt = textOf(el);
+  assert.match(txt, /genuine/);       // dominant verdict still shown
+  assert.match(txt, /unverifiable/);  // the bad-row signal is present
+  assert.match(txt, /1/);             // the unverifiable count
+  // An err emphasis is present even under a genuine dominant, so the board does not read healthy.
+  const cls = classesOf(el);
+  assert.ok(cls.some((c) => c.split(" ").includes("err")), "cry-wolf must carry an err emphasis");
+});
+
+test("counts render in both modes; no false cry-wolf when all rows verify", () => {
+  // All-genuine: counts visible, but NO err emphasis (nothing to investigate).
+  const ok = Pet.integrityRows({
+    key_on: true, dominant_verdict: "genuine", failure_class: null,
+    counts: { genuine: 5, unattested: 0, unverifiable: 0 }, window_size: 5, remediation: null,
+  });
+  assert.match(textOf(ok), /5 genuine/);
+  assert.ok(!classesOf(ok).some((c) => c.split(" ").includes("err")), "no err when all verify");
+});
+
 test("missing/partial integrity object renders the unavailable fallback and never throws", () => {
   for (const bad of [undefined, null, {}, { key_on: "yes" }, 123, "nope"]) {
     let el;

--- a/tests/js/integrity-health.test.mjs
+++ b/tests/js/integrity-health.test.mjs
@@ -1,0 +1,122 @@
+// PET-157: Pet.integrityRows renders the self-diagnosing integrity state on the Observability
+// tab — integrity ON/OFF, the dominant verdict pill, the failure class, and the remediation
+// line — from the additive get_health `integrity` payload. It must NEVER throw (the SSE
+// _dispatch re-render path calls the obs render synchronously), so a missing/partial payload
+// renders an "unavailable" fallback rather than crashing, and the OFF / unattested paths carry
+// no alarm styling (bare `pill`, never `pill err`).
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped petasos.js.
+// Run with: node --test tests/js/integrity-health.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// Minimal DOM shim — Pet.integrityRows only builds elements + text nodes via Pet.h.
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute() {},
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+function textOf(node) {
+  if (!node) return "";
+  if (node.nodeType === 3) return node.nodeValue || "";
+  let s = "";
+  for (const c of (node.childNodes || [])) s += textOf(c);
+  return s;
+}
+function classesOf(node, acc) {
+  acc = acc || [];
+  if (!node) return acc;
+  if (node.className) acc.push(node.className);
+  for (const c of (node.childNodes || [])) classesOf(c, acc);
+  return acc;
+}
+
+test("loader: petasos.js exposes integrityRows", () => {
+  assert.equal(typeof Pet, "object");
+  assert.equal(typeof Pet.integrityRows, "function");
+});
+
+test("key_off renders the off/no-alarm copy with no err pill", () => {
+  const el = Pet.integrityRows({
+    key_on: false,
+    dominant_verdict: "unattested",
+    failure_class: null,
+    counts: { genuine: 0, unattested: 3, unverifiable: 0 },
+    window_size: 3,
+    remediation: "Integrity is off because no valid PETASOS_SESSION_SECRET is configured for this process.",
+  });
+  const txt = textOf(el);
+  assert.match(txt, /OFF/);
+  assert.match(txt, /no valid PETASOS_SESSION_SECRET/);
+  const cls = classesOf(el);
+  assert.ok(!cls.some((c) => c.split(" ").includes("err")), "OFF must carry no alarm (err) pill");
+});
+
+test("genuine renders the ok pill and no remediation line", () => {
+  const el = Pet.integrityRows({
+    key_on: true,
+    dominant_verdict: "genuine",
+    failure_class: null,
+    counts: { genuine: 5, unattested: 0, unverifiable: 0 },
+    window_size: 5,
+    remediation: null,
+  });
+  const txt = textOf(el);
+  assert.match(txt, /ON/);
+  assert.match(txt, /genuine/);
+  const cls = classesOf(el);
+  assert.ok(cls.some((c) => c.split(" ").includes("ok")), "genuine verdict should use the ok pill");
+  assert.ok(!cls.some((c) => c.split(" ").includes("err")), "genuine must carry no err pill");
+});
+
+test("unverifiable / sig-mismatch renders the err pill + remediation line", () => {
+  const remediation =
+    "the gateway and dashboard most likely hold different PETASOS_SESSION_SECRET values; " +
+    "set the same secret on both processes and restart them.";
+  const el = Pet.integrityRows({
+    key_on: true,
+    dominant_verdict: "unverifiable",
+    failure_class: "sig-mismatch",
+    counts: { genuine: 2, unattested: 0, unverifiable: 4 },
+    window_size: 6,
+    remediation,
+  });
+  const txt = textOf(el);
+  assert.match(txt, /unverifiable/);
+  assert.match(txt, /sig-mismatch/);
+  assert.match(txt, /restart them/);
+  const cls = classesOf(el);
+  assert.ok(cls.some((c) => c.split(" ").includes("err")), "unverifiable verdict should use the err pill");
+});
+
+test("missing/partial integrity object renders the unavailable fallback and never throws", () => {
+  for (const bad of [undefined, null, {}, { key_on: "yes" }, 123, "nope"]) {
+    let el;
+    assert.doesNotThrow(() => { el = Pet.integrityRows(bad); }, `input=${JSON.stringify(bad)}`);
+    const txt = textOf(el);
+    assert.match(txt, /integrity status unavailable/, `input=${JSON.stringify(bad)}`);
+  }
+});

--- a/tests/test_console_integrity_health.py
+++ b/tests/test_console_integrity_health.py
@@ -90,7 +90,9 @@ async def _drain(h: ConsoleHandlers) -> None:
 async def _integrity_of(h: ConsoleHandlers) -> dict[str, Any]:
     health = await h.get_health()
     assert "integrity" in health, "get_health must carry the additive integrity field"
-    return health["integrity"]
+    integ = health["integrity"]
+    assert isinstance(integ, dict)
+    return integ
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_console_integrity_health.py
+++ b/tests/test_console_integrity_health.py
@@ -1,0 +1,318 @@
+"""PET-157: the self-diagnosing ``get_health["integrity"]`` field.
+
+Today an all-Unverified Observability board is, from the UI alone, indistinguishable between
+the benign config-skew case and a genuinely forged row. This field surfaces the discriminator
+the system already computes (``sig-missing`` vs ``sig-mismatch``), the dominant verdict over a
+bounded recent window, and the actionable remediation, so an operator can tell integrity
+off-vs-on and (when on) genuine vs legacy-unsigned vs actively-mismatched without grepping the
+WARNING log. No verification math changes (D1).
+
+Harness mirrors ``tests/test_enforcement_integrity.py`` (the ``_keyed_handlers`` /
+``_unkeyed_handlers`` / ``_block`` / ``_append_raw`` / ``_drain`` helpers). The enforcement spool +
+history sink are redirected to temp files by the autouse conftest fixtures; the writer key is
+reset around each test here.
+Async tests bind to the anyio runner via ``anyio_mode = "auto"`` (no inline marker, PET-149).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import petasos.console._events as ev
+import petasos.console.server as server_mod
+from petasos import PetasosConfig, Pipeline
+from petasos.console.server import ConsoleHandlers
+from petasos.scanners.minimal import MinimalScanner
+
+_SECRET = b"pet157-session-secret-0123456789ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_spool_key_around_test() -> Iterator[None]:
+    """Contain the module-global writer key within each test (the conftest spool-isolation
+    fixture resets path/cap but not the key)."""
+    ev._reset_spool_key()
+    yield
+    ev._reset_spool_key()
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _keyed_handlers(secret: bytes = _SECRET) -> ConsoleHandlers:
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=secret),
+        host_id="petasos-test",  # required when session_secret is set
+    )
+    return ConsoleHandlers(pipeline)
+
+
+def _unkeyed_handlers() -> ConsoleHandlers:
+    pipeline = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    return ConsoleHandlers(pipeline)
+
+
+def _append_raw(path: str, rec: dict[str, Any]) -> None:
+    """Append a raw JSON line (bypasses emit's signing — for forged / legacy lines)."""
+    import json
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def _block(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "session_id": "sess-1",
+        "tool": "send_email",
+        "event_type": "block",
+        "tier": "tier2",
+        "reason": "blocked by escalation",
+        "armed": True,
+        "direction": "tool_call",
+    }
+    base.update(over)
+    return base
+
+
+async def _drain(h: ConsoleHandlers) -> None:
+    await h._drain_enforcement_into_history()
+
+
+async def _integrity_of(h: ConsoleHandlers) -> dict[str, Any]:
+    health = await h.get_health()
+    assert "integrity" in health, "get_health must carry the additive integrity field"
+    return health["integrity"]
+
+
+# ---------------------------------------------------------------------------
+# State 1 — all-genuine
+# ---------------------------------------------------------------------------
+
+
+async def test_all_genuine_reports_genuine_no_remediation() -> None:
+    ev.set_spool_key(_SECRET)
+    for i in range(3):
+        ev.emit_enforcement_event(_block(session_id="sess-A", scan_id=f"e-g{i}"))
+    handlers = _keyed_handlers()
+    await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    assert integ["key_on"] is True
+    assert integ["dominant_verdict"] == "genuine"
+    assert integ["failure_class"] is None
+    assert integ["remediation"] is None
+    assert integ["counts"]["genuine"] == 3
+    assert integ["counts"]["unverifiable"] == 0
+    assert integ["window_size"] == 3
+
+
+# ---------------------------------------------------------------------------
+# State 2 — sig-missing (legacy/unsigned writer under a configured key)
+# ---------------------------------------------------------------------------
+
+
+async def test_sig_missing_reports_unverifiable_with_upgrade_remediation() -> None:
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    for i in range(2):
+        _append_raw(path, _block(session_id="sess-M", scan_id=f"e-m{i}"))  # no sig
+    await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    assert integ["key_on"] is True
+    assert integ["dominant_verdict"] == "unverifiable"
+    assert integ["failure_class"] == "sig-missing"
+    assert integ["counts"]["unverifiable"] == 2
+    rem = integ["remediation"]
+    assert rem == server_mod._INTEGRITY_REMEDIATION["sig-missing"]
+    assert "upgrade the writer" in rem
+    assert "PETASOS_SESSION_SECRET" in rem
+
+
+# ---------------------------------------------------------------------------
+# State 3 — sig-mismatch (must NOT assert forgery; names config skew)
+# ---------------------------------------------------------------------------
+
+
+async def test_sig_mismatch_reports_align_secret_and_does_not_assert_forgery() -> None:
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    for i in range(2):
+        _append_raw(path, _block(session_id="sess-X", scan_id=f"e-x{i}", sig="0" * 64))
+    await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    assert integ["dominant_verdict"] == "unverifiable"
+    assert integ["failure_class"] == "sig-mismatch"
+    rem = integ["remediation"]
+    assert rem == server_mod._INTEGRITY_REMEDIATION["sig-mismatch"]
+    assert "PETASOS_SESSION_SECRET" in rem
+    assert "restart" in rem
+    # Does NOT flatly assert forgery: it names config skew as the *likely* cause and hedges
+    # the forgery possibility ("rare but possible"), per D9 / brief other-implications bullet 1.
+    assert "most likely" in rem
+    assert "rare but possible" in rem
+
+
+# ---------------------------------------------------------------------------
+# State 4 — key-off (no alarm, no preflight)
+# ---------------------------------------------------------------------------
+
+
+async def test_key_off_reports_off_no_alarm_no_preflight(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ev._reset_spool_key()  # writer key off too
+    handlers = _unkeyed_handlers()
+    ev.emit_enforcement_event(_block(session_id="sess-K"))
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    assert integ["key_on"] is False
+    assert integ["dominant_verdict"] == "unattested"  # never "unverifiable" with key off
+    assert integ["failure_class"] is None
+    assert integ["counts"]["unattested"] == 1
+    assert integ["counts"]["unverifiable"] == 0
+    assert integ["counts"]["genuine"] == 0
+    # Mode-neutral invalid-base64 note, never an alarm.
+    assert integ["remediation"] == server_mod._INTEGRITY_KEY_OFF_NOTE
+    assert "not be valid base64" in integ["remediation"]
+    assert handlers._integrity_preflight_emitted is False
+    assert "PETASOS_INTEGRITY_PREFLIGHT" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# State 5 — cry-wolf visibility in-window (one bad row among genuines)
+# ---------------------------------------------------------------------------
+
+
+async def test_cry_wolf_single_bad_row_visible_in_counts() -> None:
+    ev.set_spool_key(_SECRET)
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    for i in range(8):
+        ev.emit_enforcement_event(_block(session_id="sess-W", scan_id=f"e-ok{i}"))
+    _append_raw(path, _block(session_id="sess-W", scan_id="e-bad", sig="0" * 64))
+    await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    # Dominant stays genuine, but the single recent bad row is NOT masked.
+    assert integ["dominant_verdict"] == "genuine"
+    assert integ["counts"]["genuine"] == 8
+    assert integ["counts"]["unverifiable"] == 1
+
+
+# ---------------------------------------------------------------------------
+# State 5b — cry-wolf durability across window churn (D8 eviction trade-off)
+# ---------------------------------------------------------------------------
+
+
+async def test_cry_wolf_durable_across_window_eviction(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # One sig-mismatch (oldest), then _INTEGRITY_WINDOW + 1 genuine rows so the mismatch tuple
+    # ages out of the bounded window. The 257-row DRIVE (not a monkeypatched smaller window):
+    # deque(maxlen=...) binds maxlen at __init__ construction, so a post-construction monkeypatch
+    # would silently leave maxlen=256 and pass vacuously (round-2 edge F-2).
+    ev.set_spool_key(_SECRET)
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    _append_raw(path, _block(session_id="sess-D", scan_id="e-mm", sig="0" * 64))  # oldest
+    for i in range(server_mod._INTEGRITY_WINDOW + 1):  # 257 genuine, newest
+        ev.emit_enforcement_event(_block(session_id="sess-D", scan_id=f"e-d{i}"))
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    # The window honestly ages the mismatch out of the live counts...
+    assert integ["counts"]["unverifiable"] == 0
+    assert integ["window_size"] == server_mod._INTEGRITY_WINDOW
+    # ...but the DURABLE record survived: the one-shot preflight fired and never un-fires.
+    assert handlers._integrity_preflight_emitted is True
+    preflight = [r for r in caplog.records if "PETASOS_INTEGRITY_PREFLIGHT" in r.getMessage()]
+    assert len(preflight) == 1
+
+
+# ---------------------------------------------------------------------------
+# State 6 — empty window (fresh keyed handler, no drain)
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_window_reports_key_on_null_verdict() -> None:
+    handlers = _keyed_handlers()
+    integ = await _integrity_of(handlers)
+    assert integ["key_on"] is True
+    assert integ["dominant_verdict"] is None
+    assert integ["failure_class"] is None
+    assert integ["remediation"] is None
+    assert integ["counts"] == {"genuine": 0, "unattested": 0, "unverifiable": 0}
+    assert integ["window_size"] == 0
+
+
+# ---------------------------------------------------------------------------
+# State 7 — failure-class agreement: the health field and the D3 helper cannot disagree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_class"),
+    [
+        (_block(session_id="sess-fc1", scan_id="e-fc1"), "sig-missing"),  # no sig
+        (_block(session_id="sess-fc2", scan_id="e-fc2", sig="deadbeef"), "sig-mismatch"),
+    ],
+)
+async def test_failure_class_health_field_agrees_with_helper(
+    row: dict[str, Any], expected_class: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Fresh keyed handler + exactly one row of the class (a single-row window, so the dominant
+    # failure_class is unambiguous). The log path AND the health field both consume the D3
+    # helper, so asserting the health field against the helper directly is the robust form.
+    handlers = _keyed_handlers()
+    handlers._integrity_log_last = 0.0  # ensure the per-row tripwire window is open
+    _append_raw(ev._spool_path(), row)
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        await _drain(handlers)
+    integ = await _integrity_of(handlers)
+    assert integ["failure_class"] == ev.classify_integrity_failure(row) == expected_class
+    # Companion: the single drained row's per-row tripwire names the same class.
+    assert f"class={expected_class}" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# State 8 — characterization: classifier + tally byte-identical pre/post (D1)
+# ---------------------------------------------------------------------------
+
+
+async def test_characterization_provenance_and_tally_unchanged() -> None:
+    # genuine -> tally bumps; unverifiable -> tally does NOT; unattested -> bumps. Guards
+    # against the accumulator/preflight additions perturbing the classifier or the trust tally.
+
+    # genuine (keyed, signed)
+    ev.set_spool_key(_SECRET)
+    ev.emit_enforcement_event(_block(session_id="sess-gen", scan_id="e-c-gen"))
+    h_gen = _keyed_handlers()
+    await _drain(h_gen)
+    gen = h_gen.scan_history.to_list(500)[-1]
+    assert gen["provenance"] == "genuine"
+    assert h_gen.block_tally_for("sess-gen") == 1
+
+    # unverifiable (keyed, bad sig) — surfaced but NOT tallied
+    h_unv = _keyed_handlers()
+    _append_raw(ev._spool_path(), _block(session_id="sess-unv", scan_id="e-c-unv", sig="0" * 64))
+    await _drain(h_unv)
+    unv = next(s for s in h_unv.scan_history.to_list(500) if s.get("scan_id") == "e-c-unv")
+    assert unv["provenance"] == "unverifiable"
+    assert h_unv.block_tally_for("sess-unv") == 0
+
+    # unattested (key off) — surfaced AND tallied, exactly as pre-PET-139/157
+    ev._reset_spool_key()
+    h_un = _unkeyed_handlers()
+    ev.emit_enforcement_event(_block(session_id="sess-un", scan_id="e-c-un"))
+    await _drain(h_un)
+    un = next(s for s in h_un.scan_history.to_list(500) if s.get("scan_id") == "e-c-un")
+    assert un["provenance"] == "unattested"
+    assert h_un.block_tally_for("sess-un") == 1

--- a/tests/test_console_integrity_preflight.py
+++ b/tests/test_console_integrity_preflight.py
@@ -1,0 +1,195 @@
+"""PET-157: the one-shot boot/preflight WARNING (``PETASOS_INTEGRITY_PREFLIGHT``).
+
+The preflight fires exactly once per run, the first time the live drain surfaces a key-on spool
+row whose provenance is ``unverifiable`` (D7). It names the failure class + remediation (D9) and
+is distinct from the per-row, rate-limited ``PETASOS_INTEGRITY_UNVERIFIABLE`` tripwire. Nothing
+fires when integrity is off or when the tail verifies.
+
+Both modes are covered: standalone drives the explicit boot drain through the real ``build_app``
+``startup`` lifespan (not a bare ``_drain_*`` call), and embedded fires on the first
+``get_scan_history`` drain-on-read. Async tests bind via ``anyio_mode = "auto"`` (PET-149).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import petasos.console._events as ev
+import petasos.console.server as server_mod
+from petasos import PetasosConfig, Pipeline
+from petasos.console.server import ConsoleHandlers
+from petasos.scanners.minimal import MinimalScanner
+
+_SECRET = b"pet157-preflight-secret-0123456789ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_spool_key_around_test() -> Iterator[None]:
+    ev._reset_spool_key()
+    yield
+    ev._reset_spool_key()
+
+
+def _keyed_handlers(secret: bytes = _SECRET) -> ConsoleHandlers:
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=secret),
+        host_id="petasos-test",
+    )
+    return ConsoleHandlers(pipeline)
+
+
+def _unkeyed_handlers() -> ConsoleHandlers:
+    pipeline = Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+    return ConsoleHandlers(pipeline)
+
+
+def _append_raw(path: str, rec: dict[str, Any]) -> None:
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def _block(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "session_id": "sess-1",
+        "tool": "send_email",
+        "event_type": "block",
+        "tier": "tier2",
+        "reason": "blocked by escalation",
+        "armed": True,
+        "direction": "tool_call",
+    }
+    base.update(over)
+    return base
+
+
+def _preflight_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "PETASOS_INTEGRITY_PREFLIGHT" in r.getMessage()]
+
+
+# ---------------------------------------------------------------------------
+# 1 — fires once, key-on + unverifiable (holds across two drain calls)
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_fires_once_key_on_unverifiable(caplog: pytest.LogCaptureFixture) -> None:
+    handlers = _keyed_handlers()
+    path = ev._spool_path()
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        _append_raw(path, _block(session_id="sess-1", scan_id="e-p1"))  # no sig -> sig-missing
+        await handlers._drain_enforcement_into_history()
+        _append_raw(path, _block(session_id="sess-1", scan_id="e-p2", sig="0" * 64))  # mismatch
+        await handlers._drain_enforcement_into_history()
+    records = _preflight_records(caplog)
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "class=sig-missing" in msg  # the FIRST surfaced unverifiable row drives it
+    # Names the remediation (D9).
+    assert server_mod._INTEGRITY_REMEDIATION["sig-missing"] in msg
+    assert handlers._integrity_preflight_emitted is True
+
+
+# ---------------------------------------------------------------------------
+# 2 — silent when key-off
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_silent_key_off(caplog: pytest.LogCaptureFixture) -> None:
+    ev._reset_spool_key()
+    handlers = _unkeyed_handlers()
+    path = ev._spool_path()
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        _append_raw(path, _block(session_id="sess-2", scan_id="e-k1"))  # no sig, but key off
+        _append_raw(path, _block(session_id="sess-2", scan_id="e-k2", sig="0" * 64))
+        await handlers._drain_enforcement_into_history()
+    assert _preflight_records(caplog) == []
+    assert handlers._integrity_preflight_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# 3 — silent when every row verifies
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_silent_all_genuine(caplog: pytest.LogCaptureFixture) -> None:
+    ev.set_spool_key(_SECRET)
+    handlers = _keyed_handlers()
+    for i in range(3):
+        ev.emit_enforcement_event(_block(session_id="sess-3", scan_id=f"e-v{i}"))
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        await handlers._drain_enforcement_into_history()
+    assert _preflight_records(caplog) == []
+    assert handlers._integrity_preflight_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# 4 — standalone boot drain via the real lifespan (exercises the _startup await-drain edit)
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_standalone_boot_via_lifespan(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    pytest.importorskip("fastapi")
+    import asyncio
+
+    from petasos.console.server import build_app
+
+    # Pre-seed an unverifiable (unsigned) tail BEFORE the app exists, so the boot drain classifies
+    # it. Key on via the pipeline's session_secret; the row carries no sig -> unverifiable.
+    _append_raw(ev._spool_path(), _block(session_id="sess-boot", scan_id="e-boot"))
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=_SECRET),
+        host_id="dashboard",
+    )
+    # Shrink the tailer interval so it ticks several times during the test, proving the one-shot
+    # holds across the explicit-drain -> tailer handoff and does not double-fire.
+    monkeypatch.setattr(server_mod, "_ENFORCEMENT_TAIL_INTERVAL_S", 0.01)
+    app = build_app(pipeline)
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        # Drive the REGISTERED startup callbacks (runs the real _startup: explicit await-drain
+        # then spawns the tailer) — the spec-sanctioned "invoke the app.router.on_startup
+        # callback" path, not a bare handlers._drain_* call.
+        for handler in app.router.on_startup:
+            await handler()
+        try:
+            await asyncio.sleep(0.08)  # ~8 tailer ticks at the 0.01s interval
+        finally:
+            for handler in app.router.on_shutdown:
+                await handler()  # cancels the tailer, closes SSE
+    records = _preflight_records(caplog)
+    assert len(records) == 1  # one-shot across explicit drain + every tailer tick
+    assert "class=sig-missing" in records[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# 5 — embedded first-read fires on the first get_scan_history drain-on-read, not before
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_embedded_first_read(caplog: pytest.LogCaptureFixture) -> None:
+    pytest.importorskip("fastapi")
+    from petasos.console.hermes import plugin_api
+
+    _append_raw(ev._spool_path(), _block(session_id="sess-5", scan_id="e-e1"))  # unsigned tail
+    pipeline = Pipeline(
+        scanners=[MinimalScanner()],
+        config=PetasosConfig(fail_mode="degraded", session_secret=_SECRET),
+        host_id="dashboard",
+    )
+    plugin_api.init_handlers(pipeline)
+    handlers = plugin_api._handlers
+    assert handlers is not None
+    assert handlers._integrity_preflight_emitted is False  # nothing fires before the first read
+    with caplog.at_level(logging.WARNING, logger="petasos.console.server"):
+        await handlers.get_scan_history()  # drain-on-read is the embedded floor
+    assert handlers._integrity_preflight_emitted is True
+    assert len(_preflight_records(caplog)) == 1


### PR DESCRIPTION
## Summary
- Surfaces the integrity discriminator the system **already computes** (`sig-missing` vs `sig-mismatch`) at the dashboard, so an all-Unverified Observability board is no longer ambiguous between benign `PETASOS_SESSION_SECRET` config skew and a genuinely forged row — no more grepping the WARNING log + JSONL to learn the cause.
- Lifts the failure-class split into one shared `_events.classify_integrity_failure` helper (D3) consumed by the log path, the new `get_health["integrity"]` field, and the boot preflight, so the three cannot drift.
- **No verification math changes** (D1): `verify_event` / `verify_history_row`, the HMAC preimage, the subkey derivation, and the block-tally trust rules are untouched.

## Layered defense
- **Health field** (`get_health["integrity"]`, D5/D8) — the *live recent view*: `key_on`, dominant verdict over a bounded 256-entry window, failure class, per-verdict `counts` (so a single bad row among genuines stays visible), `window_size`, and actionable `remediation`. Reads the drain-maintained window without itself draining; `key_on` is always exact so the key-off no-regression report (D2) holds from the first poll.
- **One-shot preflight** (`PETASOS_INTEGRITY_PREFLIGHT`, D7) — the *durable record*: fires once per run the first time the live drain surfaces a key-on `unverifiable` row, names the remediation (D9), survives window eviction, and never un-fires. Standalone drives it via an explicit boot drain in `_startup` (guarded parity with the tailer); embedded fires on the first `get_scan_history` drain-on-read.
- **Remediation copy** (D9) never over-claims forgery for `sig-mismatch` — it names the likely `PETASOS_SESSION_SECRET` skew and hedges the rare forgery case; the key-off note is mode-neutral about invalid base64.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_events.py` | Adds the pure/total `classify_integrity_failure` helper (D3) |
| `petasos/console/server.py` | Accumulator + one-shot guard, shared-helper call, `_log_integrity_preflight`, `_integrity_health`, additive `get_health` field, `_startup` boot drain |
| `petasos/console/static/petasos.js` | Never-throw `Pet.integrityRows` builder + obs-tab mount; `Pet.state.integrityHealth` at all three `pipelineHealth` assign sites |
| `tests/test_console_integrity_health.py` | New — health-field states 1-8 + characterization |
| `tests/test_console_integrity_preflight.py` | New — one-shot preflight in both modes (standalone lifespan + embedded) |
| `tests/js/integrity-health.test.mjs` | New — the `Pet.integrityRows` render builder |

## Test plan
- [x] `C:\python310\python.exe -m pytest tests/test_console_integrity_health.py tests/test_console_integrity_preflight.py tests/test_enforcement_integrity.py tests/test_console_handlers.py -p no:cacheprovider --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 87/87 pass
- [x] `node --test tests/js/integrity-health.test.mjs tests/js/enforcement-provenance.test.mjs` — 12/12 pass
- [x] `ruff check` (changed files) — clean; `mypy --strict petasos/console/server.py petasos/console/_events.py` — clean
- [x] `test_default_ignorable_rejected` deselect is the pre-existing Unicode-13-vs-14 failure, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “integrity” diagnostic panel to the dashboard driven by the `/health` endpoint.
  * `/health` now includes a bounded integrity status (dominant verdict plus counts) and failure classification with operator remediation; also shows key-off/off-mode guidance and a one-time preflight warning for unverifiable signatures.
  * Frontend rendering is defensive, showing an “integrity status unavailable” fallback for missing/invalid data.
* **Tests**
  * Added backend and UI coverage for integrity verdict selection, bounded-window churn, one-shot preflight behavior, key-on/off cases, and `Pet.integrityRows` rendering robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->