### PR TITLE
feat(pet-162): demote LlamaFirewall PromptGuard under code_generation (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [Unreleased]
 
+### Changed
+
+- **`code_generation` profile now demotes LlamaFirewall PromptGuard**
+  (`petasos.llamafirewall.prompt-guard`) to a non-blocking LOW, alongside the LLM
+  Guard injection verdict it already demoted (PET-135). Both ML prompt-injection
+  classifiers fire on a coding agent's own outbound tool calls that handle
+  attack-shaped text as data (for example a heredoc that greps for
+  `ignore-previous`); the override keeps the finding visible for audit without
+  blocking the call. The demote is direction-blind, so this profile remains
+  unsuitable for inbound untrusted content; `customer_service` keeps PromptGuard
+  at full strength. The residual *syntactic* injection-floor block requires a
+  net-new direction-scoped capability (PET-162 Part 2) and is unchanged here.
+
 ### Added
 
 - **Agent-directed fetch directive rule** (`MinimalScanner`): a new

--- a/petasos/session/profiles/code_generation.json
+++ b/petasos/session/profiles/code_generation.json
@@ -1,6 +1,6 @@
 {
   "name": "code_generation",
-  "description": "Tuned for coding agents. Suppresses encoding and shell-command rules that fire constantly on legitimate code (base64, homoglyphs, pipe-to-shell, decode/fetch-exec, recursive deletes), raises the confidence floor to 0.6, and downgrades the LLM Guard ML prompt-injection verdict (petasos.llmguard.injection) to non-blocking. That ML classifier flags ordinary outbound tool calls (ls, curl, git status, file searches over security docs) as injection at confidence 0.5-1.0, so the 0.6 floor cannot tame it; the override keeps the finding visible for audit (still logged at low, and still counted toward session frequency/escalation, so an armed session may sit at a non-blocking tier1) without blocking. For: code-writing and dev-tooling agents. Trade-off: the suppressed command family means destructive shell commands DO NOT BLOCK under this profile: a real `rm -rf /` (petasos.syntactic.command.destructive-recursive) passes; and ML prompt-injection on tool-call params no longer blocks. The injection downgrade is direction-blind, so if this profile is ever used on an inbound surface, ML injection blocking is off there too. Still blocking: syntactic injection + role-switch rules (unsuppressible), LlamaFirewall PromptGuard, structural anomalies, and Presidio PII egress (PET-135).",
+  "description": "Tuned for coding agents. Suppresses encoding and shell-command rules that fire constantly on legitimate code (base64, homoglyphs, pipe-to-shell, decode/fetch-exec, recursive deletes), raises the confidence floor to 0.6, and downgrades the two ML prompt-injection verdicts (LLM Guard's petasos.llmguard.injection and LlamaFirewall's petasos.llamafirewall.prompt-guard) to non-blocking. Those ML classifiers flag ordinary outbound tool calls (ls, curl, git status, file searches over security docs, heredocs that process attack strings as data) as injection at confidence 0.5-1.0, so the 0.6 floor cannot tame them; the overrides keep the findings visible for audit (still logged at low, and still counted toward session frequency/escalation, so an armed session may sit at a non-blocking tier1) without blocking. For: code-writing and dev-tooling agents. Trade-off: the suppressed command family means destructive shell commands DO NOT BLOCK under this profile: a real `rm -rf /` (petasos.syntactic.command.destructive-recursive) passes; and ML prompt-injection on tool-call params no longer blocks. The ML injection downgrades are direction-blind, so if this profile is ever used on an inbound surface, ML injection blocking is off there too. Still blocking: syntactic injection + role-switch rules (unsuppressible), structural anomalies, and Presidio PII egress (PET-135, PET-162).",
   "suppress_rules": [
     "petasos.syntactic.encoding.invisible-chars",
     "petasos.syntactic.encoding.base64-in-text",
@@ -13,7 +13,8 @@
     "petasos.syntactic.command.destructive-recursive"
   ],
   "severity_overrides": {
-    "petasos.llmguard.injection": "low"
+    "petasos.llmguard.injection": "low",
+    "petasos.llamafirewall.prompt-guard": "low"
   },
   "confidence_floor": 0.6,
   "tier_thresholds": null,

--- a/tests/test_pet135_codegen_tuning.py
+++ b/tests/test_pet135_codegen_tuning.py
@@ -54,7 +54,12 @@ _BLOCKING_SEVERITIES = {Severity.CRITICAL, Severity.HIGH}
 
 # The exact tuned configuration this investigation decided (PET-135).
 _EXPECTED_SUPPRESS = _ENCODING_RULE_IDS | _COMMAND_RULE_IDS
-_EXPECTED_SEVERITY_OVERRIDES = {"petasos.llmguard.injection": "low"}
+# PET-162 Part 1 added the LlamaFirewall PromptGuard demote alongside PET-135's
+# LLM Guard injection demote (both ML prompt-injection verdicts, both non-floor).
+_EXPECTED_SEVERITY_OVERRIDES = {
+    "petasos.llmguard.injection": "low",
+    "petasos.llamafirewall.prompt-guard": "low",
+}
 _EXPECTED_CONFIDENCE_FLOOR = 0.6
 _NOISY_ML_RULE = "petasos.llmguard.injection"
 _STRUCTURAL_DEPTH_RULE = "petasos.syntactic.structural.excessive-depth"
@@ -72,7 +77,7 @@ _EM_DASH = "—"
 # dash or silently drops the trade-off note trips review. Kept on one line so the
 # equality is character-for-character against the code_generation.json string;
 # E501 is suppressed deliberately for the pin (D-PROFILE-CONTRACT).
-_EXPECTED_DESCRIPTION = "Tuned for coding agents. Suppresses encoding and shell-command rules that fire constantly on legitimate code (base64, homoglyphs, pipe-to-shell, decode/fetch-exec, recursive deletes), raises the confidence floor to 0.6, and downgrades the LLM Guard ML prompt-injection verdict (petasos.llmguard.injection) to non-blocking. That ML classifier flags ordinary outbound tool calls (ls, curl, git status, file searches over security docs) as injection at confidence 0.5-1.0, so the 0.6 floor cannot tame it; the override keeps the finding visible for audit (still logged at low, and still counted toward session frequency/escalation, so an armed session may sit at a non-blocking tier1) without blocking. For: code-writing and dev-tooling agents. Trade-off: the suppressed command family means destructive shell commands DO NOT BLOCK under this profile: a real `rm -rf /` (petasos.syntactic.command.destructive-recursive) passes; and ML prompt-injection on tool-call params no longer blocks. The injection downgrade is direction-blind, so if this profile is ever used on an inbound surface, ML injection blocking is off there too. Still blocking: syntactic injection + role-switch rules (unsuppressible), LlamaFirewall PromptGuard, structural anomalies, and Presidio PII egress (PET-135)."  # noqa: E501
+_EXPECTED_DESCRIPTION = "Tuned for coding agents. Suppresses encoding and shell-command rules that fire constantly on legitimate code (base64, homoglyphs, pipe-to-shell, decode/fetch-exec, recursive deletes), raises the confidence floor to 0.6, and downgrades the two ML prompt-injection verdicts (LLM Guard's petasos.llmguard.injection and LlamaFirewall's petasos.llamafirewall.prompt-guard) to non-blocking. Those ML classifiers flag ordinary outbound tool calls (ls, curl, git status, file searches over security docs, heredocs that process attack strings as data) as injection at confidence 0.5-1.0, so the 0.6 floor cannot tame them; the overrides keep the findings visible for audit (still logged at low, and still counted toward session frequency/escalation, so an armed session may sit at a non-blocking tier1) without blocking. For: code-writing and dev-tooling agents. Trade-off: the suppressed command family means destructive shell commands DO NOT BLOCK under this profile: a real `rm -rf /` (petasos.syntactic.command.destructive-recursive) passes; and ML prompt-injection on tool-call params no longer blocks. The ML injection downgrades are direction-blind, so if this profile is ever used on an inbound surface, ML injection blocking is off there too. Still blocking: syntactic injection + role-switch rules (unsuppressible), structural anomalies, and Presidio PII egress (PET-135, PET-162)."  # noqa: E501
 
 
 def _blocking(findings: tuple[ScanFinding, ...]) -> list[ScanFinding]:
@@ -271,6 +276,7 @@ class TestSuppressionSetIsExactlyDecided:
         # The key trade-off notes must stay legible to operators.
         for phrase in (
             "petasos.llmguard.injection",
+            "petasos.llamafirewall.prompt-guard",
             "DO NOT BLOCK",
             "direction-blind",
             "still counted toward session frequency/escalation",

--- a/tests/test_pet162_prompt_guard_demote.py
+++ b/tests/test_pet162_prompt_guard_demote.py
@@ -1,0 +1,121 @@
+"""PET-162 Part 1 regression: demote LlamaFirewall PromptGuard under code_generation.
+
+Triage of the live gibson audit spools (2026-06-26) showed the on-state is very
+quiet once the profile is correct, with a sharply-defined ML residual: one
+`petasos.llamafirewall.prompt-guard` HIGH at p=0.998, on a `terminal` tool call
+running a heredoc that *handled an attack string as data*. That is a coding
+agent operating on injection-shaped text on its OWN outbound tool call, not
+untrusted content being injected into the model: a false positive.
+
+PromptGuard is a non-floor ML rule (`petasos.llamafirewall.prompt-guard`,
+finding_type "injection", HIGH), structurally identical to the LLM Guard
+injection verdict PET-135 already demoted. So the same proven lever applies: a
+`severity_overrides` entry remaps it to LOW, which keeps the finding visible for
+audit while it no longer blocks.
+
+These tests pin both sides of the change with a deterministic stub standing in
+for the (nondeterministic, model-gated) LlamaFirewall backend:
+  * non-blocking + retained-at-LOW under code_generation (the fix), and
+  * STILL blocking under general AND customer_service (no collateral disarm of
+    the inbound-facing profile that exists precisely to distrust its input).
+
+The injection-floor scoping that would also clear the residual *syntactic*
+`ignore-previous` block (PET-162 Part 2) is a separate, net-new capability and
+is out of scope here.
+"""
+
+from __future__ import annotations
+
+from petasos._types import Direction, ScanFinding, ScanResult, Severity
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+
+# The real residual rule_id / severity / confidence from the triage.
+_PROMPT_GUARD_RULE = "petasos.llamafirewall.prompt-guard"
+_BLOCKING_SEVERITIES = {Severity.CRITICAL, Severity.HIGH}
+
+
+def _blocking(findings: tuple[ScanFinding, ...]) -> list[ScanFinding]:
+    return [f for f in findings if f.severity in _BLOCKING_SEVERITIES and f.finding_type != "pii"]
+
+
+class _StubPromptGuardScanner:
+    """Deterministic stand-in for the LlamaFirewall PromptGuard component.
+
+    Emits exactly the finding that drove the live residual:
+    petasos.llamafirewall.prompt-guard at HIGH / confidence 0.998. Mirrors the
+    real `_COMPONENT_TAXONOMY` mapping (rule_id, "injection", Severity.HIGH) so
+    this test does not need the gated PromptGuard 2 model installed.
+    """
+
+    name = "stub_promptguard"
+
+    async def scan(
+        self, text: str, *, direction: Direction = "inbound", session_id: str | None = None
+    ) -> ScanResult:
+        return ScanResult(
+            scanner_name=self.name,
+            findings=(
+                ScanFinding(
+                    rule_id=_PROMPT_GUARD_RULE,
+                    finding_type="injection",
+                    severity=Severity.HIGH,
+                    confidence=0.998,
+                    message="LlamaFirewall PromptGuard injection verdict",
+                    scanner_name=self.name,
+                ),
+            ),
+            duration_ms=1.0,
+        )
+
+
+class TestPromptGuardDowngradedUnderCodegen:
+    """The load-bearing change: PromptGuard's HIGH verdict is downgraded to a
+    non-blocking LOW under code_generation, but kept (retained for audit)."""
+
+    async def test_prompt_guard_is_nonblocking_under_codegen(self) -> None:
+        pipe = Pipeline(
+            config=PetasosConfig(profile_name="code_generation"),
+            scanners=[_StubPromptGuardScanner()],
+        )
+        # Benign input on purpose: the Pipeline always runs MinimalScanner, so any
+        # literal syntactic injection phrase (e.g. "ignore previous instructions")
+        # would trip the unsuppressible syntactic floor and block regardless of
+        # this profile. That residual is exactly PET-162 Part 2's scope, NOT Part 1.
+        # Here we isolate the ML PromptGuard verdict (the stub) and prove the Part 1
+        # demote alone makes a coder's own outbound tool call non-blocking.
+        res = await pipe.inspect("git status && ls -la ~", direction="outbound")
+        hit = [f for f in res.findings if f.rule_id == _PROMPT_GUARD_RULE]
+        assert hit, "expected the prompt-guard finding to be retained for audit"
+        assert hit[0].severity == Severity.LOW, "should be downgraded to LOW"
+        assert not _blocking(res.findings), "downgraded finding must not block"
+        assert res.safe is True
+
+
+class TestPromptGuardStillBlocksElsewhere:
+    """No collateral disarm: profiles that do NOT override prompt-guard must keep
+    it blocking. customer_service is the inbound-facing profile that exists to
+    distrust its input, so it is the important non-regression here."""
+
+    async def test_prompt_guard_still_blocks_under_general(self) -> None:
+        pipe = Pipeline(
+            config=PetasosConfig(profile_name="general"),
+            scanners=[_StubPromptGuardScanner()],
+        )
+        res = await pipe.inspect("anything", direction="outbound")
+        blocking = _blocking(res.findings)
+        assert any(f.rule_id == _PROMPT_GUARD_RULE for f in blocking), (
+            "general must NOT downgrade prompt-guard; it should still block"
+        )
+
+    async def test_prompt_guard_still_blocks_under_customer_service_inbound(self) -> None:
+        pipe = Pipeline(
+            config=PetasosConfig(profile_name="customer_service"),
+            scanners=[_StubPromptGuardScanner()],
+        )
+        res = await pipe.inspect("anything", direction="inbound")
+        blocking = _blocking(res.findings)
+        assert any(f.rule_id == _PROMPT_GUARD_RULE for f in blocking), (
+            "customer_service must keep prompt-guard blocking on inbound (the threat surface)"
+        )
+        assert res.safe is False

--- a/tests/test_pet162_prompt_guard_demote.py
+++ b/tests/test_pet162_prompt_guard_demote.py
@@ -29,10 +29,24 @@ from __future__ import annotations
 from petasos._types import Direction, ScanFinding, ScanResult, Severity
 from petasos.config import PetasosConfig
 from petasos.pipeline import Pipeline
+from petasos.scanners.llama_firewall import _COMPONENT_TAXONOMY
 
-# The real residual rule_id / severity / confidence from the triage.
+# The rule_id the code_generation severity_override targets (the shipped config
+# contract). Pinned as a literal so a drift between the override key and the real
+# backend's emitted rule_id (sourced below) trips these tests rather than passing.
 _PROMPT_GUARD_RULE = "petasos.llamafirewall.prompt-guard"
 _BLOCKING_SEVERITIES = {Severity.CRITICAL, Severity.HIGH}
+
+# Source the stand-in's finding from the REAL LlamaFirewall PromptGuard wiring
+# (petasos/scanners/llama_firewall.py) instead of hardcoding it. This anchors the
+# deterministic stub to the production taxonomy: if the backend's rule_id /
+# finding_type / severity ever diverges, the stub diverges with it and the
+# override-contract assertions below fail loudly, which is exactly the real-wiring
+# regression a free-floating protocol stub would otherwise hide. The module is
+# import-safe without the llamafirewall extra (the package is probed lazily, not
+# imported at module load), and the model-gated real-backend coverage that
+# exercises the live scanner path lives in tests/test_llama_firewall_scanner.py.
+_PG_RULE_ID, _PG_FINDING_TYPE, _PG_SEVERITY = _COMPONENT_TAXONOMY["prompt_guard"]
 
 
 def _blocking(findings: tuple[ScanFinding, ...]) -> list[ScanFinding]:
@@ -42,10 +56,11 @@ def _blocking(findings: tuple[ScanFinding, ...]) -> list[ScanFinding]:
 class _StubPromptGuardScanner:
     """Deterministic stand-in for the LlamaFirewall PromptGuard component.
 
-    Emits exactly the finding that drove the live residual:
-    petasos.llamafirewall.prompt-guard at HIGH / confidence 0.998. Mirrors the
-    real `_COMPONENT_TAXONOMY` mapping (rule_id, "injection", Severity.HIGH) so
-    this test does not need the gated PromptGuard 2 model installed.
+    Emits exactly the finding that drove the live residual at confidence 0.998,
+    with its rule_id / finding_type / severity sourced from the real
+    `_COMPONENT_TAXONOMY` mapping (rather than hardcoded) so the stand-in cannot
+    silently diverge from the production wiring. Needs no gated PromptGuard 2
+    model installed.
     """
 
     name = "stub_promptguard"
@@ -57,9 +72,9 @@ class _StubPromptGuardScanner:
             scanner_name=self.name,
             findings=(
                 ScanFinding(
-                    rule_id=_PROMPT_GUARD_RULE,
-                    finding_type="injection",
-                    severity=Severity.HIGH,
+                    rule_id=_PG_RULE_ID,
+                    finding_type=_PG_FINDING_TYPE,
+                    severity=_PG_SEVERITY,
                     confidence=0.998,
                     message="LlamaFirewall PromptGuard injection verdict",
                     scanner_name=self.name,
@@ -107,6 +122,7 @@ class TestPromptGuardStillBlocksElsewhere:
         assert any(f.rule_id == _PROMPT_GUARD_RULE for f in blocking), (
             "general must NOT downgrade prompt-guard; it should still block"
         )
+        assert res.safe is False
 
     async def test_prompt_guard_still_blocks_under_customer_service_inbound(self) -> None:
         pipe = Pipeline(


### PR DESCRIPTION
## What

PET-162 **Part 1** (config-only, mirrors PET-135). Makes the `code_generation` profile keepable-on for coding agents by demoting the LlamaFirewall PromptGuard verdict (`petasos.llamafirewall.prompt-guard`) to a non-blocking LOW.

## Why

Triage of the live gibson audit spools (4413 scans, 2026-06-26) showed the on-state is 98.7% clean once the profile is correctly set. The ML residual that still blocked was a single `petasos.llamafirewall.prompt-guard` HIGH (p=0.998) firing on a coder's **own outbound** terminal call that handled an attack string **as data** (a heredoc that greps for an injection phrase). That is the agent operating on injection-shaped text, not untrusted content being injected into the model: a false positive.

PromptGuard is a non-floor ML rule (finding_type `injection`, HIGH), structurally identical to the LLM Guard injection verdict PET-135 already demoted, so the same proven `severity_overrides` lever applies: remap to LOW, which keeps the finding visible for audit while it no longer blocks.

## Scope / safety

- The demote is **direction-blind**, so `code_generation` remains unsuitable for inbound untrusted content. `customer_service` (the inbound-facing profile) keeps PromptGuard at **full strength** (verified by a new regression test).
- The PET-124 invariant is untouched: this only relaxes a non-floor ML rule via the existing override machinery. The unsuppressible syntactic injection floor is unchanged.
- The residual **syntactic** injection-floor block (`ignore-previous` on a coder's own `write_file`/`search_files`) needs the net-new direction-scoped capability tracked as **PET-162 Part 2** and is explicitly out of scope here.

## Changes

- `petasos/session/profiles/code_generation.json`: add `petasos.llamafirewall.prompt-guard: "low"`; update the description (drop PromptGuard from "Still blocking", note both ML verdicts are now demoted, preserve house-style no-em-dash).
- `tests/test_pet135_codegen_tuning.py`: update the frozen `severity_overrides` + character-for-character description pins; add the prompt-guard rule_id to the trade-off phrase checks.
- `tests/test_pet162_prompt_guard_demote.py` (new): behavioral regression with a deterministic stub PromptGuard scanner. Non-blocking + retained-at-LOW under `code_generation`; still blocks under `general` and under `customer_service` inbound.
- `CHANGELOG.md`: `[Unreleased] / Changed` entry.

## Tests

`C:\python310\python.exe -m pytest tests/test_pet162_prompt_guard_demote.py tests/test_pet135_codegen_tuning.py tests/test_profiles.py -q` -> **60 passed**. `ruff check`, `ruff format --check`, `mypy --strict` on the changed files all clean. Stub-driven, so no gated PromptGuard 2 model is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MinimalScanner rule family to detect agent-directed fetch/install/execute behavior involving external resources.
* **Bug Fixes**
  * Updated the `code_generation` profile so LlamaFirewall PromptGuard is downgraded to non-blocking LOW (and aligned with the existing prompt-injection LOW behavior).
* **Tests**
  * Added regression coverage for PET-162 (ensuring `safe=true` in `code_generation`) and updated PET-135 expectations for the expanded severity overrides set.
* **Documentation**
  * Updated `CHANGELOG.md` with the new Unreleased items and the revised severity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->