### PR TITLE
feat(pet-164): petasos.selfmod.* self-tamper detection family

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -333,6 +333,39 @@ short-circuit `_pre_tool_call` before any scan runs, so a disarmed pipeline neve
 reaches tier evaluation or rule matching. Do not mistake the floor for
 self-disarm protection.
 
+### Self-tamper detection (`petasos.selfmod.*`, PET-164)
+
+When `tool_guard_enabled` is on, `ToolCallGuard` classifies non-read-only
+tool calls that reference Petasos-owned paths (resolver-reachable config,
+profile homes, the enforcement spool) as `petasos.selfmod.config_write` or
+`petasos.selfmod.config_ref`, with floor-protected frequency weights (10.0
+and 3.0 respectively) and a dedicated cooldown-exempt alert delivery path.
+The classification is **detection only** -- it never changes an allow/deny
+outcome at the guard or plugin layer (PET-125 Decision 2 intact). Repeated
+attempts escalate tiers through the ordinary frequency channel.
+
+**Accepted off-switches and blunting knobs:**
+
+- `enabled: false` stops everything (the documented Vector A outcome).
+- `tool_guard_enabled: false` stops the guard and with it detection.
+- `audit_enabled` / `audit_verbosity` gate only the audit sink; alerts,
+  receipts, and frequency weight are unaffected.
+- Session-intelligence tuning knobs (tier thresholds, `frequency_half_life_seconds`)
+  blunt the escalation channel only. Alerts and receipts are the surviving floor
+  surfaces and fire regardless -- at least 1/min per class under a hostile cap config.
+
+`alert_enabled` and `frequency_enabled` are **not** off-switches for this class:
+`record_selfmod`'s alert bypasses the alerting gate by construction, and the
+frequency update runs in the guard on its own tracker.
+
+**Accepted detection misses (tripwire, not wall):** relative-path tricks,
+symlinked aliases, `$HERMES_HOME` indirection inside shell strings, ancestor-
+directory rename/delete, and owned paths beyond `safe_json_dumps`' depth/size
+caps. The OS boundary remains the containment mechanism; this layer is a
+tripwire. An unlisted read-only tool whose top-level arg *is* the owned path
+classifies as `config_write` even when the tool only reads (accepted FP
+direction; widen `READ_ONLY_TOOLS` as needed).
+
 ### Profile changes require a restart (the boot profile is pinned)
 
 Petasos pins its config resolution **once, at plugin registration**, from the

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -359,9 +359,11 @@ attempts escalate tiers through the ordinary frequency channel.
 frequency update runs in the guard on its own tracker.
 
 **Accepted detection misses (tripwire, not wall):** relative-path tricks,
-symlinked aliases, `$HERMES_HOME` indirection inside shell strings, ancestor-
-directory rename/delete, and owned paths beyond `safe_json_dumps`' depth/size
-caps. The OS boundary remains the containment mechanism; this layer is a
+symlinked aliases, `$HERMES_HOME` indirection inside shell strings, and
+ancestor-directory rename/delete. Nested-argument traversal
+(`_extract_leaf_strings`) is depth-capped at 32; when exceeded the call is
+flagged as suspicious (fail-secure). The OS boundary remains the containment
+mechanism; this layer is a
 tripwire. An unlisted read-only tool whose top-level arg *is* the owned path
 classifies as `config_write` even when the tool only reads (accepted FP
 direction; widen `READ_ONLY_TOOLS` as needed).

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -377,7 +377,7 @@ repeated writes to the owned config reach tier 1 at the second write, tier 2
 thresholds, and shell reads (`cat`, `tail`) of the config or spool weigh 3.0
 each. When you direct an agent to edit the `petasos:` section, either flip the
 Equipped switch off for the duration (the documented master off-switch) or
-space the writes beyond the 60 second frequency half-life.
+space the writes beyond the 60-second frequency half-life.
 
 ### Profile changes require a restart (the boot profile is pinned)
 

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -362,11 +362,22 @@ frequency update runs in the guard on its own tracker.
 symlinked aliases, `$HERMES_HOME` indirection inside shell strings, and
 ancestor-directory rename/delete. Nested-argument traversal
 (`_extract_leaf_strings`) is depth-capped at 32; when exceeded the call is
-flagged as suspicious (fail-secure). The OS boundary remains the containment
+flagged as suspicious (fail-secure) with the dedicated marker
+`<argument-depth-overflow>` recorded as the target, since no specific owned
+path was matched in that case. The OS boundary remains the containment
 mechanism; this layer is a
 tripwire. An unlisted read-only tool whose top-level arg *is* the owned path
 classifies as `config_write` even when the tool only reads (accepted FP
 direction; widen `READ_ONLY_TOOLS` as needed).
+
+**Operator note (legitimate config edits escalate).** The frequency weights do
+not distinguish an operator-directed edit session from an attack: rapid
+repeated writes to the owned config reach tier 1 at the second write, tier 2
+(all tool calls blocked) at the third, and tier 3 at the fifth under default
+thresholds, and shell reads (`cat`, `tail`) of the config or spool weigh 3.0
+each. When you direct an agent to edit the `petasos:` section, either flip the
+Equipped switch off for the duration (the documented master off-switch) or
+space the writes beyond the 60 second frequency half-life.
 
 ### Profile changes require a restart (the boot profile is pinned)
 

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -42,6 +42,7 @@ from petasos.session.formatting import (  # PET-77: dep-light (string formatting
     format_block_message,
     format_content_block,
 )
+from petasos.session.guard import READ_ONLY_TOOLS
 
 if TYPE_CHECKING:
     from petasos import PetasosConfig
@@ -164,8 +165,6 @@ _subagent_hooks_available = False
 # but Hermes invoke_hook is sync).
 _async_loop: asyncio.AbstractEventLoop | None = None
 _async_thread: threading.Thread | None = None
-
-from petasos.session.guard import READ_ONLY_TOOLS
 
 # PET-118: derived sibling canonical set. READ_ONLY_TOOLS stays the immutable raw
 # source-of-truth; _READ_ONLY_CANON is canonicalized at MODULE LOAD (not _deferred_init)
@@ -1251,6 +1250,7 @@ def _pre_tool_call(
     if result.selfmod_target is not None:
         try:
             from petasos.console._paths import display_path
+
             _emit_enforcement_event(
                 session_id=session_id,
                 tool=tool_name,

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -165,27 +165,7 @@ _subagent_hooks_available = False
 _async_loop: asyncio.AbstractEventLoop | None = None
 _async_thread: threading.Thread | None = None
 
-READ_ONLY_TOOLS = frozenset(
-    {
-        "read_file",
-        "search",
-        "list_directory",
-        "session_search",
-        "web_search",
-        "web_extract",
-        "vision_analyze",
-        "mcp_vigil_harbor_memory_search",
-        "mcp_vigil_harbor_memory_fetch",
-        "mcp_vigil_harbor_memory_list",
-        "mcp_vigil_harbor_memory_query",
-        "mcp_vigil_harbor_memory_sources",
-        "mcp_vigil_harbor_memory_status",
-        "mcp_plane_list_work_items",
-        "mcp_plane_retrieve_work_item",
-        "mcp_plane_retrieve_work_item_by_identifier",
-        "mcp_plane_list_projects",
-    }
-)
+from petasos.session.guard import READ_ONLY_TOOLS
 
 # PET-118: derived sibling canonical set. READ_ONLY_TOOLS stays the immutable raw
 # source-of-truth; _READ_ONLY_CANON is canonicalized at MODULE LOAD (not _deferred_init)
@@ -1267,6 +1247,20 @@ def _pre_tool_call(
     except Exception as exc:
         logger.error("Petasos guard evaluation failed: %s — allowing tool call", exc)
         return None
+
+    if result.selfmod_target is not None:
+        try:
+            from petasos.console._paths import display_path
+            _emit_enforcement_event(
+                session_id=session_id,
+                tool=tool_name,
+                event_type="selfmod_attempt",
+                rule_id=result.selfmod_finding.rule_id if result.selfmod_finding else None,
+                severity=result.selfmod_finding.severity.value if result.selfmod_finding else None,
+                reason=f"selfmod target: {display_path(result.selfmod_target)}",
+            )
+        except Exception:
+            pass
 
     if result.tier == "tier3":
         logger.critical(

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -45,25 +45,15 @@ from petasos.console import _paths as _paths_mod
 from petasos.console._paths import (
     _ROT_SUFFIX as _ROT_SUFFIX,
 )
-from petasos.console._paths import (
-    _SPOOL_FILENAME as _SPOOL_FILENAME,
-)
-from petasos.console._paths import (
-    resolve_hermes_config_path,
-)
+
+# The resolver lives in _paths (single source for guard, writer, and tests); this
+# module keeps its historical private name for server.py and the test seams.
+_spool_path = _paths_mod.spool_path
 
 # Sized well above the motivating burst (~40 blocks / 2h18m, ~300 B/line) and far
 # above one tailer interval's worth at peak rate (spec D4). Module-level so a test
 # can shrink it via _reset_events_state to force rotation.
 SPOOL_CAP_BYTES = 2_000_000
-
-
-def _spool_path() -> str:
-    """Resolve the spool path beside the active config (recomputed per call)."""
-    if _paths_mod._SPOOL_PATH_OVERRIDE is not None:
-        return _paths_mod._SPOOL_PATH_OVERRIDE
-    res = resolve_hermes_config_path()
-    return os.path.join(str(res.path.parent), _SPOOL_FILENAME)
 
 
 def _reset_events_state(path: str | None = None, cap: int | None = None) -> None:

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -41,33 +41,32 @@ import time
 import uuid
 from typing import Any
 
-from petasos.console._paths import resolve_hermes_config_path
-
-_SPOOL_FILENAME = "petasos-enforcement.jsonl"
-_ROT_SUFFIX = ".rot"
+from petasos.console._paths import (
+    _SPOOL_FILENAME,
+    _ROT_SUFFIX,
+    resolve_hermes_config_path,
+    spool_path as _paths_spool_path,
+)
+from petasos.console import _paths as _paths_mod
 
 # Sized well above the motivating burst (~40 blocks / 2h18m, ~300 B/line) and far
 # above one tailer interval's worth at peak rate (spec D4). Module-level so a test
 # can shrink it via _reset_events_state to force rotation.
 SPOOL_CAP_BYTES = 2_000_000
 
-# Test seams (mirror _reset_armed_cache / _reset_reload_cache): point the spool at
-# a temp file and optionally shrink the cap. None => resolve beside the live config.
-_SPOOL_PATH_OVERRIDE: str | None = None
-
 
 def _spool_path() -> str:
     """Resolve the spool path beside the active config (recomputed per call)."""
-    if _SPOOL_PATH_OVERRIDE is not None:
-        return _SPOOL_PATH_OVERRIDE
+    if _paths_mod._SPOOL_PATH_OVERRIDE is not None:
+        return _paths_mod._SPOOL_PATH_OVERRIDE
     res = resolve_hermes_config_path()
     return os.path.join(str(res.path.parent), _SPOOL_FILENAME)
 
 
 def _reset_events_state(path: str | None = None, cap: int | None = None) -> None:
     """Test seam: point the spool at *path* (and optionally set the byte cap)."""
-    global _SPOOL_PATH_OVERRIDE, SPOOL_CAP_BYTES
-    _SPOOL_PATH_OVERRIDE = path
+    global SPOOL_CAP_BYTES
+    _paths_mod._SPOOL_PATH_OVERRIDE = path
     if cap is not None:
         SPOOL_CAP_BYTES = cap
 

--- a/petasos/console/_events.py
+++ b/petasos/console/_events.py
@@ -41,13 +41,16 @@ import time
 import uuid
 from typing import Any
 
-from petasos.console._paths import (
-    _SPOOL_FILENAME,
-    _ROT_SUFFIX,
-    resolve_hermes_config_path,
-    spool_path as _paths_spool_path,
-)
 from petasos.console import _paths as _paths_mod
+from petasos.console._paths import (
+    _ROT_SUFFIX as _ROT_SUFFIX,
+)
+from petasos.console._paths import (
+    _SPOOL_FILENAME as _SPOOL_FILENAME,
+)
+from petasos.console._paths import (
+    resolve_hermes_config_path,
+)
 
 # Sized well above the motivating burst (~40 blocks / 2h18m, ~300 B/line) and far
 # above one tailer interval's worth at peak rate (spec D4). Module-level so a test

--- a/petasos/console/_paths.py
+++ b/petasos/console/_paths.py
@@ -296,7 +296,7 @@ def spool_rot_path() -> str:
     return spool_path() + _ROT_SUFFIX
 
 
-def display_path(path: "Path | str") -> str:
+def display_path(path: Path | str) -> str:
     """Collapse the operator's home-directory prefix to ``~`` for display.
 
     Case-insensitive on Windows (``normcase``); never raises.
@@ -313,5 +313,5 @@ def display_path(path: "Path | str") -> str:
         return "~"
     for sep in (os.sep, "/"):
         if n_s.startswith(n_home + os.path.normcase(sep)):
-            return "~" + s[len(home):]
+            return "~" + s[len(home) :]
     return s

--- a/petasos/console/_paths.py
+++ b/petasos/console/_paths.py
@@ -14,6 +14,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+_SPOOL_FILENAME = "petasos-enforcement.jsonl"
+_ROT_SUFFIX = ".rot"
+
+_SPOOL_PATH_OVERRIDE: str | None = None
+
 Tier = Literal["hermes_home", "profile", "root"]
 
 
@@ -271,3 +276,42 @@ def read_petasos_section(res: HermesConfigResolution) -> dict[str, Any]:
     """
     section, _ = read_petasos_section_checked(res)
     return section
+
+
+def spool_path() -> str:
+    """Resolve the enforcement-spool path beside the active config.
+
+    Recomputed per call so a transient active_profile fallback cannot leave
+    writer and reader on different files.  Shared single source for the guard
+    owned-set, the spool writer, and tests.
+    """
+    if _SPOOL_PATH_OVERRIDE is not None:
+        return _SPOOL_PATH_OVERRIDE
+    res = resolve_hermes_config_path()
+    return os.path.join(str(res.path.parent), _SPOOL_FILENAME)
+
+
+def spool_rot_path() -> str:
+    """The ``.rot`` sibling of the resolved spool path."""
+    return spool_path() + _ROT_SUFFIX
+
+
+def display_path(path: "Path | str") -> str:
+    """Collapse the operator's home-directory prefix to ``~`` for display.
+
+    Case-insensitive on Windows (``normcase``); never raises.
+    """
+    s = str(path)
+    try:
+        home = os.path.expanduser("~")
+    except Exception:
+        return s
+    if not home or home == "~":
+        return s
+    n_s, n_home = os.path.normcase(s), os.path.normcase(home)
+    if n_s == n_home:
+        return "~"
+    for sep in (os.sep, "/"):
+        if n_s.startswith(n_home + os.path.normcase(sep)):
+            return "~" + s[len(home):]
+    return s

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -61,6 +61,10 @@ _BLOCK_EVENT_TYPES = frozenset({"block", "quarantine", "tier3"})
 _MAX_TALLY_SESSIONS = 10_000
 # Poll cadence of the dashboard's background enforcement-spool tailer (standalone).
 _ENFORCEMENT_TAIL_INTERVAL_S = 1.0
+# PET-164 (D9): rate-limit for console_probe selfmod on 401. One recording per
+# interval so a brute-force loop cannot spam the audit/alert path.
+_selfmod_401_last: float = 0.0
+_SELFMOD_401_INTERVAL: float = 10.0
 # PET-139: rate-limit window for the integrity-failure tripwire (D9), mirroring the
 # reference plugin's `_DISARM_LOG_EVERY_S` cadence so a forging loop cannot spam the log.
 _INTEGRITY_LOG_EVERY_S = 30.0
@@ -460,26 +464,11 @@ def _hermes_profile_label(res: "HermesConfigResolution") -> str:
 def _display_home(path: "Path | str") -> str:
     """Collapse the operator's home-directory prefix to ``~`` for display.
 
-    The binding read-out surfaces an absolute ``profile_home`` over the API; left
-    raw it leaks the OS username (``C:\\Users\\jane\\...``) into the console UI,
-    screenshots, and logs. Collapse a home-relative path to ``~\\...`` and leave
-    any path outside the home directory untouched. Case-insensitive on Windows
-    (``normcase``); never raises.
+    Delegates to ``_paths.display_path`` (PET-164 Decision 10a hoist).
     """
-    s = str(path)
-    try:
-        home = os.path.expanduser("~")
-    except Exception:
-        return s
-    if not home or home == "~":
-        return s
-    n_s, n_home = os.path.normcase(s), os.path.normcase(home)
-    if n_s == n_home:
-        return "~"
-    for sep in (os.sep, "/"):
-        if n_s.startswith(n_home + os.path.normcase(sep)):
-            return "~" + s[len(home) :]
-    return s
+    from petasos.console._paths import display_path
+
+    return display_path(path)
 
 
 def _compute_effective_config(
@@ -1468,6 +1457,35 @@ def _extract_field_from_error(msg: str, body: dict[str, Any]) -> str:
     return best or "unknown"
 
 
+def _maybe_fire_console_probe(pipeline: "Pipeline") -> None:
+    """Rate-limited selfmod console_probe on 401 (PET-164 Decision 9).
+
+    Called inside ``_require_console_token`` before each 401 raise so that
+    unauthorized console access attempts are recorded as selfmod events.
+    Rate-limited to ``_SELFMOD_401_INTERVAL`` seconds so a brute-force loop
+    cannot spam the audit/alert path.
+    """
+    global _selfmod_401_last
+    now = time.monotonic()
+    if now - _selfmod_401_last < _SELFMOD_401_INTERVAL:
+        return
+    _selfmod_401_last = now
+    try:
+        from petasos._types import ScanFinding, Severity
+
+        finding = ScanFinding(
+            rule_id="petasos.selfmod.console_probe",
+            finding_type="selfmod",
+            severity=Severity.CRITICAL,
+            confidence=1.0,
+            message="Console API 401: unauthorized access attempt",
+            scanner_name="tool_guard",
+        )
+        pipeline.record_selfmod(None, finding)
+    except Exception:
+        pass
+
+
 def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAPI":
     """Build the complete FastAPI application.
 
@@ -1524,9 +1542,11 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
             # malformed header is a clean 401, never a 500. Scheme match is
             # case-sensitive ("bearer " does not match).
             if authorization is None or not authorization.startswith("Bearer "):
+                _maybe_fire_console_probe(pipeline)
                 raise HTTPException(status_code=401, headers={"WWW-Authenticate": "Bearer"})
             credential = authorization[len("Bearer ") :]
             if not hmac.compare_digest(credential.encode("utf-8"), token.encode("utf-8")):
+                _maybe_fire_console_probe(pipeline)
                 raise HTTPException(status_code=401, headers={"WWW-Authenticate": "Bearer"})
 
         app = _FastAPI(

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -63,7 +63,7 @@ _MAX_TALLY_SESSIONS = 10_000
 _ENFORCEMENT_TAIL_INTERVAL_S = 1.0
 # PET-164 (D9): rate-limit for console_probe selfmod on 401. One recording per
 # interval so a brute-force loop cannot spam the audit/alert path.
-_selfmod_401_last: float = 0.0
+_selfmod_401_last: dict[int, float] = {}
 _SELFMOD_401_INTERVAL: float = 10.0
 # PET-139: rate-limit window for the integrity-failure tripwire (D9), mirroring the
 # reference plugin's `_DISARM_LOG_EVERY_S` cadence so a forging loop cannot spam the log.
@@ -1465,11 +1465,11 @@ def _maybe_fire_console_probe(pipeline: "Pipeline") -> None:
     Rate-limited to ``_SELFMOD_401_INTERVAL`` seconds so a brute-force loop
     cannot spam the audit/alert path.
     """
-    global _selfmod_401_last
+    pid = id(pipeline)
     now = time.monotonic()
-    if now - _selfmod_401_last < _SELFMOD_401_INTERVAL:
+    if now - _selfmod_401_last.get(pid, 0.0) < _SELFMOD_401_INTERVAL:
         return
-    _selfmod_401_last = now
+    _selfmod_401_last[pid] = now
     try:
         from petasos._types import ScanFinding, Severity
 

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -15,7 +15,6 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import time
 import uuid
 from collections import deque

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1086,6 +1086,8 @@
     var isEnf = (e.source === "enforcement");
     var et = (e.event_type == null || e.event_type === "") ? "" : String(e.event_type);
     var isBypass = isEnf && et === "bypassed_disarmed";
+    // PET-164: self-tamper classification rows (detection only, never a block).
+    var isSelfmod = isEnf && et === "selfmod_attempt";
     var isEnfDecision = isEnf && !!ENF_KINDS[et];
     var isPlayground = (e.source == null || e.source === "" || e.source === "playground");
 
@@ -1099,6 +1101,7 @@
     var source = isEnf ? "enforcement" : (isPlayground ? "playground" : ("unknown (" + String(e.source) + ")"));
     var scanRan;
     if (isBypass) scanRan = "no (bypassed while Unequipped)";
+    else if (isSelfmod) scanRan = "n/a (tool argument classification, not a content scan)";
     else if (isEnfDecision || isPlayground) scanRan = "yes";
     else scanRan = "unknown";
     var armedStr;
@@ -1142,6 +1145,18 @@
         Pet.h("div", {}, "Enforcement bypassed (Unequipped). No scan was performed."),
         Pet.h("div", { className: "sd-sub" }, "A rate-limited heartbeat (about 1 per 30 s), not a per-call record; bypassed-call coverage is not counted here.")));
       wrap.appendChild(fld("tool", e.tool));
+      wrap.appendChild(fld("session", e.session_id));
+    } else if (isSelfmod) {
+      // PET-164: self-tamper attempt drill-down. Detection only: the classification
+      // never changed this call's allow/deny; repeated attempts escalate the session
+      // tier and a dedicated alert fires in the gateway log.
+      wrap.appendChild(Pet.h("div", { className: "sd-heartbeat" },
+        Pet.h("div", {}, "Self-tamper attempt: this call referenced a Petasos-owned config surface."),
+        Pet.h("div", { className: "sd-sub" }, "Detection only: the call itself was not blocked by this classification. Repeated attempts escalate the session tier; a dedicated alert fires in the gateway log.")));
+      wrap.appendChild(fld("tool", e.tool));
+      wrap.appendChild(fld("rule", e.rule_id));
+      wrap.appendChild(fld("severity", e.severity));
+      wrap.appendChild(fld("reason", e.reason));
       wrap.appendChild(fld("session", e.session_id));
     } else if (isEnfDecision) {
       wrap.appendChild(fld("tool", e.tool));
@@ -1246,10 +1261,14 @@
       var isEnforcement = (e.source === "enforcement");
       var et = (e.event_type == null || e.event_type === "") ? "" : String(e.event_type);
       var isBypass = isEnforcement && et === "bypassed_disarmed";
+      // PET-164: a self-tamper classification row is detection-only (safe=true on the
+      // summary), but it must never wear the green "safe" badge; amber "self-tamper"
+      // keeps red reserved for actual blocks.
+      var isSelfmodRow = isEnforcement && et === "selfmod_attempt";
       var isBlocked = (e.safe === false); // strict ===false; truthy-but-not-false is not "blocked"
 
-      var badgeText = isBypass ? "bypassed (disarmed)" : (isBlocked ? "blocked" : "safe");
-      var badgeClass = isBypass ? "warn" : (isBlocked ? "err" : "ok");
+      var badgeText = isBypass ? "bypassed (disarmed)" : (isSelfmodRow ? "self-tamper" : (isBlocked ? "blocked" : "safe"));
+      var badgeClass = (isBypass || isSelfmodRow) ? "warn" : (isBlocked ? "err" : "ok");
       var badge = Pet.h("span", { className: "pill " + badgeClass, style: { justifyContent: "center" } }, badgeText);
 
       var rowEls = [];

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1314,8 +1314,8 @@
         rowAttrs.role = "button";
         rowAttrs.tabIndex = 0;
         rowAttrs.ariaExpanded = isOpen;
-        rowAttrs.ariaLabel = (isEnforcement ? "enforcement" : "playground")
-          + " scan row, " + (isOpen ? "expanded" : "collapsed") + ", activate to toggle detail";
+        rowAttrs.ariaLabel = (isSelfmodRow ? "self-tamper detection" : (isEnforcement ? "enforcement" : "playground")
+          + " scan") + " row, " + (isOpen ? "expanded" : "collapsed") + ", activate to toggle detail";
         rowAttrs.onClick = toggle;
         rowAttrs.onKeydown = makeKey(toggle);
       }

--- a/petasos/pipeline.py
+++ b/petasos/pipeline.py
@@ -72,6 +72,7 @@ _TIMEOUT_ERROR_PREFIX = "ScannerTimeout"
 _BREAKER_OPEN_ERROR_PREFIX = "ScannerCircuitOpen"
 
 _STRUCTURAL_RULE_PREFIX = "petasos.syntactic.structural."
+_SELFMOD_RULE_PREFIX = "petasos.selfmod."
 
 
 def _is_floor_rule(
@@ -85,6 +86,8 @@ def _is_floor_rule(
     # prefix disjunct is a belt-and-suspenders guard kept aligned by a tripwire
     # test (_STRUCTURAL_RULE_IDS <= the structural-prefix set).
     if rule_id in _STRUCTURAL_RULE_IDS or rule_id.startswith(_STRUCTURAL_RULE_PREFIX):
+        return True
+    if rule_id.startswith(_SELFMOD_RULE_PREFIX):
         return True
     if rule_id in _ALL_INJECTION_IDS:
         # Injection floor is absolute on inbound for every profile (PET-54/124). A
@@ -539,6 +542,28 @@ class Pipeline:
     def add_alert_listener(self, callback: Callable[[Alert], None]) -> None:
         """Register an additional alert listener."""
         self._alert_manager.add_listener(callback)
+
+    def record_selfmod(self, session_id: str | None, finding: ScanFinding) -> None:
+        """Alert + audit for a selfmod classification (PET-164 Decision 4).
+
+        Sync, never throws. Frequency lives in the guard (Decision 3); this
+        method does NOT touch the tracker. The alert bypasses the ``alerting``
+        feature gate by construction; the audit sink is the sole config gate.
+        """
+        try:
+            self._alert_manager.evaluate_selfmod(finding, session_id)
+        except Exception:
+            _logger.exception("record_selfmod: alert delivery failed")
+        if self._is_enabled("audit"):
+            try:
+                synthetic = PipelineResult(
+                    safe=True,
+                    findings=(finding,),
+                    errors=(),
+                )
+                self._audit_emitter.emit(synthetic, session_id, None, direction="outbound")
+            except Exception:
+                _logger.exception("record_selfmod: audit emit failed")
 
     _FEATURE_GATES: ClassVar[dict[str, str]] = {
         "frequency": "frequency_enabled",

--- a/petasos/session/alerting.py
+++ b/petasos/session/alerting.py
@@ -218,7 +218,7 @@ class AlertManager:
 
         return surviving
 
-    def evaluate_selfmod(self, finding: "ScanFinding", session_id: str | None) -> Alert | None:
+    def evaluate_selfmod(self, finding: ScanFinding, session_id: str | None) -> Alert | None:
         """Dedicated selfmod alert delivery (PET-164 Decision 7).
 
         Cooldown-exempt, per-rule_id critical cap only. Never touches the five

--- a/petasos/session/alerting.py
+++ b/petasos/session/alerting.py
@@ -187,36 +187,39 @@ class AlertManager:
 
             self._alert_count += 1
             surviving.append(candidate)
-
-            if self._on_alert is not None:
-                try:
-                    self._on_alert(candidate)
-                except BaseException as exc:
-                    _logger.exception(
-                        "on_alert callback failed for rule_id=%s",
-                        candidate.rule_id,
-                    )
-                    self._callback_errors.append(
-                        f"on_alert callback ({candidate.rule_id}, {type(exc).__name__}): {exc}"
-                        if str(exc)
-                        else f"on_alert callback ({candidate.rule_id}, {type(exc).__name__})"
-                    )
-
-            for listener in list(self._listeners):
-                try:
-                    listener(candidate)
-                except BaseException as exc:
-                    _logger.exception(
-                        "alert listener failed for rule_id=%s",
-                        candidate.rule_id,
-                    )
-                    self._callback_errors.append(
-                        f"alert listener ({candidate.rule_id}, {type(exc).__name__}): {exc}"
-                        if str(exc)
-                        else f"alert listener ({candidate.rule_id}, {type(exc).__name__})"
-                    )
+            self._dispatch(candidate)
 
         return surviving
+
+    def _dispatch(self, alert: Alert) -> None:
+        """Deliver *alert* to on_alert and every listener, recording callback errors."""
+        if self._on_alert is not None:
+            try:
+                self._on_alert(alert)
+            except BaseException as exc:
+                _logger.exception(
+                    "on_alert callback failed for rule_id=%s",
+                    alert.rule_id,
+                )
+                self._callback_errors.append(
+                    f"on_alert callback ({alert.rule_id}, {type(exc).__name__}): {exc}"
+                    if str(exc)
+                    else f"on_alert callback ({alert.rule_id}, {type(exc).__name__})"
+                )
+
+        for listener in list(self._listeners):
+            try:
+                listener(alert)
+            except BaseException as exc:
+                _logger.exception(
+                    "alert listener failed for rule_id=%s",
+                    alert.rule_id,
+                )
+                self._callback_errors.append(
+                    f"alert listener ({alert.rule_id}, {type(exc).__name__}): {exc}"
+                    if str(exc)
+                    else f"alert listener ({alert.rule_id}, {type(exc).__name__})"
+                )
 
     def evaluate_selfmod(self, finding: ScanFinding, session_id: str | None) -> Alert | None:
         """Dedicated selfmod alert delivery (PET-164 Decision 7).
@@ -255,34 +258,7 @@ class AlertManager:
         cap_deque.append(now)
 
         self._alert_count += 1
-
-        if self._on_alert is not None:
-            try:
-                self._on_alert(alert)
-            except BaseException as exc:
-                _logger.exception(
-                    "on_alert callback failed for rule_id=%s",
-                    alert.rule_id,
-                )
-                self._callback_errors.append(
-                    f"on_alert callback ({alert.rule_id}, {type(exc).__name__}): {exc}"
-                    if str(exc)
-                    else f"on_alert callback ({alert.rule_id}, {type(exc).__name__})"
-                )
-
-        for listener in list(self._listeners):
-            try:
-                listener(alert)
-            except BaseException as exc:
-                _logger.exception(
-                    "alert listener failed for rule_id=%s",
-                    alert.rule_id,
-                )
-                self._callback_errors.append(
-                    f"alert listener ({alert.rule_id}, {type(exc).__name__}): {exc}"
-                    if str(exc)
-                    else f"alert listener ({alert.rule_id}, {type(exc).__name__})"
-                )
+        self._dispatch(alert)
 
         return alert
 

--- a/petasos/session/alerting.py
+++ b/petasos/session/alerting.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from petasos._types import PipelineResult
+    from petasos._types import PipelineResult, ScanFinding
     from petasos.config import PetasosConfig
     from petasos.session.frequency import FrequencyUpdateResult
 
@@ -217,6 +217,74 @@ class AlertManager:
                     )
 
         return surviving
+
+    def evaluate_selfmod(self, finding: "ScanFinding", session_id: str | None) -> Alert | None:
+        """Dedicated selfmod alert delivery (PET-164 Decision 7).
+
+        Cooldown-exempt, per-rule_id critical cap only. Never touches the five
+        existing checks or their counters.
+        """
+        now = time.monotonic()
+        self._callback_errors = []
+
+        severity = "critical"
+        if finding.rule_id == "petasos.selfmod.config_ref":
+            severity = "high"
+
+        alert = Alert(
+            alert_id=uuid.uuid4().hex,
+            timestamp=time.time(),
+            rule_id="selfmod_attempt",
+            severity=severity,
+            session_id=session_id,
+            message=f"Self-tamper attempt: {finding.rule_id}",
+            context=MappingProxyType(
+                {
+                    "finding_rule_id": finding.rule_id,
+                    "finding_severity": finding.severity.value,
+                }
+            ),
+        )
+
+        cap_key = finding.rule_id
+        cap_deque = self._critical_per_minute_timestamps.setdefault(cap_key, deque())
+        self._evict_old(cap_deque, now, 60.0)
+        if len(cap_deque) >= self._config.alert_critical_per_minute_cap:
+            self._rate_limited_count += 1
+            return None
+        cap_deque.append(now)
+
+        self._alert_count += 1
+
+        if self._on_alert is not None:
+            try:
+                self._on_alert(alert)
+            except BaseException as exc:
+                _logger.exception(
+                    "on_alert callback failed for rule_id=%s",
+                    alert.rule_id,
+                )
+                self._callback_errors.append(
+                    f"on_alert callback ({alert.rule_id}, {type(exc).__name__}): {exc}"
+                    if str(exc)
+                    else f"on_alert callback ({alert.rule_id}, {type(exc).__name__})"
+                )
+
+        for listener in list(self._listeners):
+            try:
+                listener(alert)
+            except BaseException as exc:
+                _logger.exception(
+                    "alert listener failed for rule_id=%s",
+                    alert.rule_id,
+                )
+                self._callback_errors.append(
+                    f"alert listener ({alert.rule_id}, {type(exc).__name__}): {exc}"
+                    if str(exc)
+                    else f"alert listener ({alert.rule_id}, {type(exc).__name__})"
+                )
+
+        return alert
 
     def _check_tier_escalation(
         self,

--- a/petasos/session/frequency.py
+++ b/petasos/session/frequency.py
@@ -30,6 +30,8 @@ DEFAULT_FREQUENCY_WEIGHTS: dict[str, float] = {
     # documented constraint, not a free parameter: a nudge above 3.0 would cross
     # the maximally-stacked single scan into tier2 territory.
     "petasos.syntactic.command.*": 3.0,
+    "petasos.selfmod.config_write": 10.0,
+    "petasos.selfmod.config_ref": 3.0,
 }
 
 _RATE_LIMIT_WINDOW_SECONDS: float = 60.0
@@ -441,11 +443,18 @@ class FrequencyTracker:
     def _match_weight(self, finding_type: str) -> float:
         w = self._exact_weights.get(finding_type)
         if w is not None:
-            return w
-        for prefix, weight in self._glob_weights:
-            if finding_type.startswith(prefix + "."):
-                return weight
-        return 0.0
+            resolved = w
+        else:
+            resolved = 0.0
+            for prefix, weight in self._glob_weights:
+                if finding_type.startswith(prefix + "."):
+                    resolved = weight
+                    break
+        if finding_type == "petasos.selfmod.config_write":
+            return max(resolved, 10.0)
+        if finding_type == "petasos.selfmod.config_ref":
+            return max(resolved, 3.0)
+        return resolved
 
     def _fire_on_terminate(self, session_id: str) -> None:
         """Notify the lineage registry that ``session_id`` is gone.

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -274,6 +274,24 @@ class ToolCallGuard:
             _logger.debug("selfmod_target_paths: failed to build owned set", exc_info=True)
             return cached or frozenset()
 
+    @staticmethod
+    def _extract_leaf_strings(value: Any, depth: int = 0) -> list[str]:
+        if depth > 32:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, dict):
+            out: list[str] = []
+            for v in value.values():
+                out.extend(ToolCallGuard._extract_leaf_strings(v, depth + 1))
+            return out
+        if isinstance(value, (list, tuple)):
+            out = []
+            for item in value:
+                out.extend(ToolCallGuard._extract_leaf_strings(item, depth + 1))
+            return out
+        return []
+
     def _classify_selfmod(
         self, canon_pre_alias: str, tool_params: dict[str, Any]
     ) -> _SelfmodMatch | None:
@@ -297,7 +315,7 @@ class ToolCallGuard:
                     top_level_strs.append(value)
                     all_parts.append(value)
                 else:
-                    all_parts.append(safe_json_dumps(value))
+                    all_parts.extend(self._extract_leaf_strings(value))
 
             any_sep = any(_has_sep(p) for p in all_parts)
             if not any_sep:
@@ -306,7 +324,14 @@ class ToolCallGuard:
             def _normalize_for_compare(s: str) -> str:
                 s = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1), 16)), s)
                 s = s.replace("\\\\", "/").replace("\\", "/").replace("/", os.sep)
-                return os.path.normcase(s)
+                s = os.path.normcase(s)
+                try:
+                    p = Path(s)
+                    if p.is_absolute():
+                        s = os.path.normcase(str(p.resolve(strict=False)))
+                except (OSError, ValueError):
+                    pass
+                return s
 
             for tls in top_level_strs:
                 normed = _normalize_for_compare(tls)
@@ -419,7 +444,11 @@ class ToolCallGuard:
         selfmod = self._classify_selfmod(canon_pre_alias, tool_params)
         selfmod_finding: ScanFinding | None = None
         if selfmod is not None:
-            sev = Severity.CRITICAL if selfmod.rule_id == "petasos.selfmod.config_write" else Severity.HIGH
+            sev = (
+                Severity.CRITICAL
+                if selfmod.rule_id == "petasos.selfmod.config_write"
+                else Severity.HIGH
+            )
             selfmod_finding = ScanFinding(
                 rule_id=selfmod.rule_id,
                 finding_type="selfmod",

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -275,10 +275,12 @@ class ToolCallGuard:
             _logger.debug("selfmod_target_paths: failed to build owned set", exc_info=True)
             return cached or frozenset()
 
+    _EXTRACT_OVERFLOW = "\x00__PETASOS_DEPTH_OVERFLOW__"
+
     @staticmethod
     def _extract_leaf_strings(value: Any, depth: int = 0) -> list[str]:
         if depth > 32:
-            return []
+            return [ToolCallGuard._EXTRACT_OVERFLOW]
         if isinstance(value, str):
             return [value]
         if isinstance(value, dict):
@@ -317,6 +319,13 @@ class ToolCallGuard:
                     all_parts.append(value)
                 else:
                     all_parts.extend(self._extract_leaf_strings(value))
+
+            overflow = self._EXTRACT_OVERFLOW in all_parts
+            if overflow:
+                return _SelfmodMatch(
+                    rule_id="petasos.selfmod.config_ref",
+                    target=next(iter(owned)),
+                )
 
             any_sep = any(_has_sep(p) for p in all_parts)
             if not any_sep:

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -480,75 +480,78 @@ class ToolCallGuard:
                 scanner_name="tool_guard",
             )
 
+        def _finish(result: GuardResult) -> GuardResult:
+            """Attach the selfmod fields and record the attempt at whichever exit fires.
+
+            A tier3 exit skips the frequency-weight update (the session is already
+            terminated); the alert/audit channel still records the attempt.
+            """
+            if selfmod is None or selfmod_finding is None:
+                return result
+            result = replace(
+                result,
+                selfmod_target=selfmod.target,
+                selfmod_finding=selfmod_finding,
+            )
+            if result.tier != "tier3":
+                self._record_selfmod_weight(session_id, selfmod_finding)
+            self._pipeline.record_selfmod(session_id, selfmod_finding)
+            return result
+
         # Step 2: Derive tier
         tier = self._derive_tier(session_id)
 
         # Step 3: Tier 3 → block
         if tier == "tier3":
-            result = GuardResult(
-                allowed=False,
-                reason="session terminated (tier3)",
-                findings=(),
-                tier="tier3",
-                param_scan_unsafe=False,
-                selfmod_target=selfmod.target if selfmod else None,
-                selfmod_finding=selfmod_finding,
+            return _finish(
+                GuardResult(
+                    allowed=False,
+                    reason="session terminated (tier3)",
+                    findings=(),
+                    tier="tier3",
+                    param_scan_unsafe=False,
+                )
             )
-            if selfmod is not None:
-                self._pipeline.record_selfmod(session_id, selfmod_finding)  # type: ignore[arg-type]
-            return result
 
         # Step 3.5: Delegation fan-out gate (PET-107 C).
         if self._config.delegate_fanout_enabled and normalized_name in self._delegate_tool_names:
             cap = self._fanout_cap(tier)
             if not self._spawn_budget.try_consume(session_id, cap, time.monotonic()):
-                result = GuardResult(
-                    allowed=False,
-                    reason="delegate fan-out budget exceeded",
-                    findings=(),
-                    tier=tier,
-                    param_scan_unsafe=False,
-                    selfmod_target=selfmod.target if selfmod else None,
-                    selfmod_finding=selfmod_finding,
+                return _finish(
+                    GuardResult(
+                        allowed=False,
+                        reason="delegate fan-out budget exceeded",
+                        findings=(),
+                        tier=tier,
+                        param_scan_unsafe=False,
+                    )
                 )
-                if selfmod is not None and selfmod_finding is not None:
-                    self._record_selfmod_weight(session_id, selfmod_finding)
-                    self._pipeline.record_selfmod(session_id, selfmod_finding)
-                return result
 
         # Step 4: Exempt check
         if self._profile and normalized_name in self._profile.tool_exempt_list:
             if not self._exempt_param_scan:
-                result = GuardResult(
-                    allowed=True,
-                    reason="tool exempt per profile",
-                    findings=(),
-                    tier=tier,
-                    param_scan_unsafe=False,
-                    selfmod_target=selfmod.target if selfmod else None,
-                    selfmod_finding=selfmod_finding,
+                return _finish(
+                    GuardResult(
+                        allowed=True,
+                        reason="tool exempt per profile",
+                        findings=(),
+                        tier=tier,
+                        param_scan_unsafe=False,
+                    )
                 )
-                if selfmod is not None and selfmod_finding is not None:
-                    self._record_selfmod_weight(session_id, selfmod_finding)
-                    self._pipeline.record_selfmod(session_id, selfmod_finding)
-                return result
             findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
                 tool_params, session_id
             )
-            result = GuardResult(
-                allowed=True,
-                reason="exempt-with-scan",
-                findings=findings,
-                tier=tier,
-                param_scan_unsafe=param_scan_unsafe,
-                param_scan_degraded=param_scan_degraded,
-                selfmod_target=selfmod.target if selfmod else None,
-                selfmod_finding=selfmod_finding,
+            return _finish(
+                GuardResult(
+                    allowed=True,
+                    reason="exempt-with-scan",
+                    findings=findings,
+                    tier=tier,
+                    param_scan_unsafe=param_scan_unsafe,
+                    param_scan_degraded=param_scan_degraded,
+                )
             )
-            if selfmod is not None and selfmod_finding is not None:
-                self._record_selfmod_weight(session_id, selfmod_finding)
-                self._pipeline.record_selfmod(session_id, selfmod_finding)
-            return result
 
         # Step 5: Scan params
         findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
@@ -557,53 +560,41 @@ class ToolCallGuard:
 
         # Step 6: Tier 2 → block
         if tier == "tier2":
-            result = GuardResult(
-                allowed=False,
-                reason="tier2: tool calls blocked",
-                findings=findings,
-                tier="tier2",
-                param_scan_unsafe=param_scan_unsafe,
-                param_scan_degraded=param_scan_degraded,
-                selfmod_target=selfmod.target if selfmod else None,
-                selfmod_finding=selfmod_finding,
+            return _finish(
+                GuardResult(
+                    allowed=False,
+                    reason="tier2: tool calls blocked",
+                    findings=findings,
+                    tier="tier2",
+                    param_scan_unsafe=param_scan_unsafe,
+                    param_scan_degraded=param_scan_degraded,
+                )
             )
-            if selfmod is not None and selfmod_finding is not None:
-                self._record_selfmod_weight(session_id, selfmod_finding)
-                self._pipeline.record_selfmod(session_id, selfmod_finding)
-            return result
 
         # Step 7: Tier 1 with unsafe → warn
         if tier == "tier1":
-            result = GuardResult(
-                allowed=True,
-                reason="tier1: allowed with warnings",
-                findings=findings,
-                tier="tier1",
-                param_scan_unsafe=param_scan_unsafe,
-                param_scan_degraded=param_scan_degraded,
-                selfmod_target=selfmod.target if selfmod else None,
-                selfmod_finding=selfmod_finding,
+            return _finish(
+                GuardResult(
+                    allowed=True,
+                    reason="tier1: allowed with warnings",
+                    findings=findings,
+                    tier="tier1",
+                    param_scan_unsafe=param_scan_unsafe,
+                    param_scan_degraded=param_scan_degraded,
+                )
             )
-            if selfmod is not None and selfmod_finding is not None:
-                self._record_selfmod_weight(session_id, selfmod_finding)
-                self._pipeline.record_selfmod(session_id, selfmod_finding)
-            return result
 
         # Step 8: Clean / no tier → allow
-        result = GuardResult(
-            allowed=True,
-            reason="allowed",
-            findings=findings,
-            tier=tier,
-            param_scan_unsafe=param_scan_unsafe,
-            param_scan_degraded=param_scan_degraded,
-            selfmod_target=selfmod.target if selfmod else None,
-            selfmod_finding=selfmod_finding,
+        return _finish(
+            GuardResult(
+                allowed=True,
+                reason="allowed",
+                findings=findings,
+                tier=tier,
+                param_scan_unsafe=param_scan_unsafe,
+                param_scan_degraded=param_scan_degraded,
+            )
         )
-        if selfmod is not None and selfmod_finding is not None:
-            self._record_selfmod_weight(session_id, selfmod_finding)
-            self._pipeline.record_selfmod(session_id, selfmod_finding)
-        return result
 
     def _record_selfmod_weight(self, session_id: str, finding: ScanFinding) -> None:
         """Apply the selfmod frequency update to the guard's own tracker (Decision 3)."""

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -57,6 +57,7 @@ class _SelfmodMatch(NamedTuple):
     rule_id: str
     target: str
 
+
 DEFAULT_TOOL_ALIASES: MappingProxyType[str, str] = MappingProxyType(
     {
         "bash": "exec",
@@ -322,7 +323,7 @@ class ToolCallGuard:
                 return None
 
             def _normalize_for_compare(s: str) -> str:
-                s = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1), 16)), s)
+                s = re.sub(r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), s)
                 s = s.replace("\\\\", "/").replace("\\", "/").replace("/", os.sep)
                 s = os.path.normcase(s)
                 try:
@@ -337,23 +338,17 @@ class ToolCallGuard:
                 normed = _normalize_for_compare(tls)
                 for entry in owned:
                     if normed == entry:
-                        return _SelfmodMatch(
-                            rule_id="petasos.selfmod.config_write", target=entry
-                        )
+                        return _SelfmodMatch(rule_id="petasos.selfmod.config_write", target=entry)
 
             for part in all_parts:
                 normed = _normalize_for_compare(part)
                 for entry in owned:
                     if entry in normed:
-                        return _SelfmodMatch(
-                            rule_id="petasos.selfmod.config_ref", target=entry
-                        )
+                        return _SelfmodMatch(rule_id="petasos.selfmod.config_ref", target=entry)
 
             return None
         except Exception:
-            _logger.warning(
-                "selfmod classifier error for tool=%s", canon_pre_alias, exc_info=True
-            )
+            _logger.warning("selfmod classifier error for tool=%s", canon_pre_alias, exc_info=True)
             return None
 
     def validate_config(self, new_config: PetasosConfig) -> None:

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -58,6 +58,14 @@ class _SelfmodMatch(NamedTuple):
     target: str
 
 
+# Recorded as the selfmod target when the fail-secure depth-overflow branch fires.
+# Deliberately NOT an owned path: the overflow flag means the args could not be
+# fully traversed, so no specific path was matched and naming one would mislead
+# triage. Public-ish (no underscore) so the reference plugin and tests can
+# recognize the sentinel without string-copying it.
+SELFMOD_DEPTH_OVERFLOW_TARGET = "<argument-depth-overflow>"
+
+
 DEFAULT_TOOL_ALIASES: MappingProxyType[str, str] = MappingProxyType(
     {
         "bash": "exec",
@@ -324,7 +332,7 @@ class ToolCallGuard:
             if overflow:
                 return _SelfmodMatch(
                     rule_id="petasos.selfmod.config_ref",
-                    target=next(iter(owned)),
+                    target=SELFMOD_DEPTH_OVERFLOW_TARGET,
                 )
 
             any_sep = any(_has_sep(p) for p in all_parts)
@@ -453,12 +461,22 @@ class ToolCallGuard:
                 if selfmod.rule_id == "petasos.selfmod.config_write"
                 else Severity.HIGH
             )
+            if selfmod.target == SELFMOD_DEPTH_OVERFLOW_TARGET:
+                # Fail-secure overflow: the args exceeded the traversal depth cap,
+                # so no owned path was actually matched. The message must say that
+                # rather than claim a specific target.
+                msg = (
+                    "Self-tamper heuristic: tool argument nesting exceeded the "
+                    "traversal depth cap (fail-secure flag; no owned path matched)"
+                )
+            else:
+                msg = f"Self-tamper attempt targeting {selfmod.target}"
             selfmod_finding = ScanFinding(
                 rule_id=selfmod.rule_id,
                 finding_type="selfmod",
                 severity=sev,
                 confidence=1.0,
-                message=f"Self-tamper attempt targeting {selfmod.target}",
+                message=msg,
                 scanner_name="tool_guard",
             )
 

--- a/petasos/session/guard.py
+++ b/petasos/session/guard.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass, replace
+from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
-# PET-118: canonicalize_tool_name is the shared alias-free primitive used by
-# _normalize_tool_name below. _NAMESPACE_PREFIX_RE's single definition now lives in
-# normalize.py; the redundant `as` alias re-exports it explicitly (for --strict mypy's
-# no-implicit-reexport and for tests) so existing
-# `from petasos.session.guard import _NAMESPACE_PREFIX_RE` imports keep resolving.
+from petasos._types import ScanFinding, Severity
 from petasos.normalize import _NAMESPACE_PREFIX_RE as _NAMESPACE_PREFIX_RE
 from petasos.normalize import canonicalize_tool_name
 from petasos.session._safe_json import safe_json_dumps
@@ -21,12 +20,42 @@ from petasos.session.escalation import derive_tier, evaluate_tier, max_tier
 _logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from petasos._types import ScanFinding
     from petasos.config import PetasosConfig
     from petasos.pipeline import Pipeline
     from petasos.session.frequency import FrequencyTracker, SessionState
     from petasos.session.lineage import LineageRegistry
     from petasos.session.profiles import ResolvedProfile
+
+READ_ONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        "read_file",
+        "search",
+        "list_directory",
+        "session_search",
+        "web_search",
+        "web_extract",
+        "vision_analyze",
+        "mcp_vigil_harbor_memory_search",
+        "mcp_vigil_harbor_memory_fetch",
+        "mcp_vigil_harbor_memory_list",
+        "mcp_vigil_harbor_memory_query",
+        "mcp_vigil_harbor_memory_sources",
+        "mcp_vigil_harbor_memory_status",
+        "mcp_plane_list_work_items",
+        "mcp_plane_retrieve_work_item",
+        "mcp_plane_retrieve_work_item_by_identifier",
+        "mcp_plane_list_projects",
+    }
+)
+
+_READ_ONLY_CANON: frozenset[str] = frozenset(
+    c for c in (canonicalize_tool_name(t) for t in READ_ONLY_TOOLS) if c
+)
+
+
+class _SelfmodMatch(NamedTuple):
+    rule_id: str
+    target: str
 
 DEFAULT_TOOL_ALIASES: MappingProxyType[str, str] = MappingProxyType(
     {
@@ -60,16 +89,24 @@ class GuardResult:
     # construction stays valid. fail-mode-correct: gates on `not result.safe`, so
     # fail_mode="open" (scanner error doesn't flip safe) yields False → no block.
     param_scan_degraded: bool = False
+    selfmod_target: str | None = None
+    selfmod_finding: ScanFinding | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "allowed": self.allowed,
             "reason": self.reason,
             "findings": [f.to_dict() for f in self.findings],
             "tier": self.tier,
             "param_scan_unsafe": self.param_scan_unsafe,
             "param_scan_degraded": self.param_scan_degraded,
+            "selfmod_target": self.selfmod_target,
         }
+        if self.selfmod_finding is not None:
+            d["selfmod_finding"] = self.selfmod_finding.to_dict()
+        else:
+            d["selfmod_finding"] = None
+        return d
 
 
 _FEATURE_DISABLED = GuardResult(
@@ -186,6 +223,113 @@ class ToolCallGuard:
                 "away) — the delegation fan-out gate is inert"
             )
         self._spawn_budget = SpawnBudget(config.delegate_fanout_window_seconds)
+        self._selfmod_owned_cache: tuple[float, frozenset[str]] = (0.0, frozenset())
+        self._selfmod_empty_warned: bool = False
+
+    def selfmod_target_paths(self) -> frozenset[str]:
+        """Build the owned-path set from ``_paths.py`` resolvers with 1 s TTL cache."""
+        now = time.monotonic()
+        ts, cached = self._selfmod_owned_cache
+        if now - ts < 1.0 and cached:
+            return cached
+        try:
+            from petasos.console._paths import (
+                list_hermes_profiles,
+                resolve_hermes_config_path,
+                spool_path,
+                spool_rot_path,
+            )
+
+            raw_entries: list[str] = []
+            res = resolve_hermes_config_path()
+            raw_entries.append(str(res.path))
+            for prof in list_hermes_profiles():
+                raw_entries.append(prof["path"])
+            raw_entries.append(spool_path())
+            raw_entries.append(spool_rot_path())
+
+            result: set[str] = set()
+            for raw in raw_entries:
+                p = Path(raw)
+                if not p.is_absolute():
+                    continue
+                try:
+                    resolved = str(p.resolve(strict=False))
+                except OSError:
+                    continue
+                parts = Path(resolved).parts
+                if len(parts) < 3:
+                    continue
+                result.add(os.path.normcase(resolved))
+
+            owned = frozenset(result)
+            if not owned and not self._selfmod_empty_warned:
+                _logger.warning("selfmod_target_paths: owned set is empty after hygiene")
+                self._selfmod_empty_warned = True
+            if owned:
+                self._selfmod_empty_warned = False
+            self._selfmod_owned_cache = (now, owned)
+            return owned
+        except Exception:
+            _logger.debug("selfmod_target_paths: failed to build owned set", exc_info=True)
+            return cached or frozenset()
+
+    def _classify_selfmod(
+        self, canon_pre_alias: str, tool_params: dict[str, Any]
+    ) -> _SelfmodMatch | None:
+        """Total: never raises. Returns the match or None."""
+        try:
+            if canon_pre_alias in _READ_ONLY_CANON:
+                return None
+            owned = self.selfmod_target_paths()
+            if not owned:
+                return None
+
+            def _has_sep(s: str) -> bool:
+                return "/" in s or "\\" in s or os.sep in s
+
+            top_level_strs: list[str] = []
+            all_parts: list[str] = []
+            for value in tool_params.values():
+                if value is None:
+                    continue
+                if isinstance(value, str):
+                    top_level_strs.append(value)
+                    all_parts.append(value)
+                else:
+                    all_parts.append(safe_json_dumps(value))
+
+            any_sep = any(_has_sep(p) for p in all_parts)
+            if not any_sep:
+                return None
+
+            def _normalize_for_compare(s: str) -> str:
+                s = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1), 16)), s)
+                s = s.replace("\\\\", "/").replace("\\", "/").replace("/", os.sep)
+                return os.path.normcase(s)
+
+            for tls in top_level_strs:
+                normed = _normalize_for_compare(tls)
+                for entry in owned:
+                    if normed == entry:
+                        return _SelfmodMatch(
+                            rule_id="petasos.selfmod.config_write", target=entry
+                        )
+
+            for part in all_parts:
+                normed = _normalize_for_compare(part)
+                for entry in owned:
+                    if entry in normed:
+                        return _SelfmodMatch(
+                            rule_id="petasos.selfmod.config_ref", target=entry
+                        )
+
+            return None
+        except Exception:
+            _logger.warning(
+                "selfmod classifier error for tool=%s", canon_pre_alias, exc_info=True
+            )
+            return None
 
     def validate_config(self, new_config: PetasosConfig) -> None:
         """Dry-run validation of a candidate config: raises, never mutates (D5/D8).
@@ -260,6 +404,7 @@ class ToolCallGuard:
             return _FEATURE_DISABLED
 
         # Step 1: Normalize tool name
+        canon_pre_alias = canonicalize_tool_name(tool_name)
         normalized_name = self._normalize_tool_name(tool_name)
         if not normalized_name:
             return GuardResult(
@@ -270,58 +415,89 @@ class ToolCallGuard:
                 param_scan_unsafe=False,
             )
 
+        # Step 1.5: Selfmod classification (total; never raises; builds no state)
+        selfmod = self._classify_selfmod(canon_pre_alias, tool_params)
+        selfmod_finding: ScanFinding | None = None
+        if selfmod is not None:
+            sev = Severity.CRITICAL if selfmod.rule_id == "petasos.selfmod.config_write" else Severity.HIGH
+            selfmod_finding = ScanFinding(
+                rule_id=selfmod.rule_id,
+                finding_type="selfmod",
+                severity=sev,
+                confidence=1.0,
+                message=f"Self-tamper attempt targeting {selfmod.target}",
+                scanner_name="tool_guard",
+            )
+
         # Step 2: Derive tier
         tier = self._derive_tier(session_id)
 
         # Step 3: Tier 3 → block
         if tier == "tier3":
-            return GuardResult(
+            result = GuardResult(
                 allowed=False,
                 reason="session terminated (tier3)",
                 findings=(),
                 tier="tier3",
                 param_scan_unsafe=False,
+                selfmod_target=selfmod.target if selfmod else None,
+                selfmod_finding=selfmod_finding,
             )
+            if selfmod is not None:
+                self._pipeline.record_selfmod(session_id, selfmod_finding)  # type: ignore[arg-type]
+            return result
 
-        # Step 3.5: Delegation fan-out gate (PET-107 C). Runs AFTER the tier-3
-        # block and BEFORE the Step-4 exempt check so the budget applies
-        # regardless of exempt status (D8 guarantees a delegate is never exempt,
-        # so this governs spawn-attempt accounting, not an exempt bypass). The
-        # budget counts ATTEMPTS — a spawn later blocked by param-scan-unsafe
-        # still consumed budget, since a session spamming delegate_task is
-        # exactly the spray to rate-limit regardless of per-call content outcome.
+        # Step 3.5: Delegation fan-out gate (PET-107 C).
         if self._config.delegate_fanout_enabled and normalized_name in self._delegate_tool_names:
             cap = self._fanout_cap(tier)
             if not self._spawn_budget.try_consume(session_id, cap, time.monotonic()):
-                return GuardResult(
+                result = GuardResult(
                     allowed=False,
                     reason="delegate fan-out budget exceeded",
                     findings=(),
                     tier=tier,
                     param_scan_unsafe=False,
+                    selfmod_target=selfmod.target if selfmod else None,
+                    selfmod_finding=selfmod_finding,
                 )
+                if selfmod is not None and selfmod_finding is not None:
+                    self._record_selfmod_weight(session_id, selfmod_finding)
+                    self._pipeline.record_selfmod(session_id, selfmod_finding)
+                return result
 
         # Step 4: Exempt check
         if self._profile and normalized_name in self._profile.tool_exempt_list:
             if not self._exempt_param_scan:
-                return GuardResult(
+                result = GuardResult(
                     allowed=True,
                     reason="tool exempt per profile",
                     findings=(),
                     tier=tier,
                     param_scan_unsafe=False,
+                    selfmod_target=selfmod.target if selfmod else None,
+                    selfmod_finding=selfmod_finding,
                 )
+                if selfmod is not None and selfmod_finding is not None:
+                    self._record_selfmod_weight(session_id, selfmod_finding)
+                    self._pipeline.record_selfmod(session_id, selfmod_finding)
+                return result
             findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
                 tool_params, session_id
             )
-            return GuardResult(
+            result = GuardResult(
                 allowed=True,
                 reason="exempt-with-scan",
                 findings=findings,
                 tier=tier,
                 param_scan_unsafe=param_scan_unsafe,
                 param_scan_degraded=param_scan_degraded,
+                selfmod_target=selfmod.target if selfmod else None,
+                selfmod_finding=selfmod_finding,
             )
+            if selfmod is not None and selfmod_finding is not None:
+                self._record_selfmod_weight(session_id, selfmod_finding)
+                self._pipeline.record_selfmod(session_id, selfmod_finding)
+            return result
 
         # Step 5: Scan params
         findings, param_scan_unsafe, param_scan_degraded = await self._scan_params(
@@ -330,35 +506,66 @@ class ToolCallGuard:
 
         # Step 6: Tier 2 → block
         if tier == "tier2":
-            return GuardResult(
+            result = GuardResult(
                 allowed=False,
                 reason="tier2: tool calls blocked",
                 findings=findings,
                 tier="tier2",
                 param_scan_unsafe=param_scan_unsafe,
                 param_scan_degraded=param_scan_degraded,
+                selfmod_target=selfmod.target if selfmod else None,
+                selfmod_finding=selfmod_finding,
             )
+            if selfmod is not None and selfmod_finding is not None:
+                self._record_selfmod_weight(session_id, selfmod_finding)
+                self._pipeline.record_selfmod(session_id, selfmod_finding)
+            return result
 
         # Step 7: Tier 1 with unsafe → warn
         if tier == "tier1":
-            return GuardResult(
+            result = GuardResult(
                 allowed=True,
                 reason="tier1: allowed with warnings",
                 findings=findings,
                 tier="tier1",
                 param_scan_unsafe=param_scan_unsafe,
                 param_scan_degraded=param_scan_degraded,
+                selfmod_target=selfmod.target if selfmod else None,
+                selfmod_finding=selfmod_finding,
             )
+            if selfmod is not None and selfmod_finding is not None:
+                self._record_selfmod_weight(session_id, selfmod_finding)
+                self._pipeline.record_selfmod(session_id, selfmod_finding)
+            return result
 
         # Step 8: Clean / no tier → allow
-        return GuardResult(
+        result = GuardResult(
             allowed=True,
             reason="allowed",
             findings=findings,
             tier=tier,
             param_scan_unsafe=param_scan_unsafe,
             param_scan_degraded=param_scan_degraded,
+            selfmod_target=selfmod.target if selfmod else None,
+            selfmod_finding=selfmod_finding,
         )
+        if selfmod is not None and selfmod_finding is not None:
+            self._record_selfmod_weight(session_id, selfmod_finding)
+            self._pipeline.record_selfmod(session_id, selfmod_finding)
+        return result
+
+    def _record_selfmod_weight(self, session_id: str, finding: ScanFinding) -> None:
+        """Apply the selfmod frequency update to the guard's own tracker (Decision 3)."""
+        try:
+            if self._frequency_tracker.requires_token:
+                token = self._frequency_tracker.mint_token(session_id, self._pipeline.host_id)
+                self._frequency_tracker.update(token, [finding.rule_id])
+            else:
+                self._frequency_tracker.update(session_id, [finding.rule_id])
+        except Exception:
+            _logger.warning(
+                "selfmod frequency update failed for session=%s", session_id, exc_info=True
+            )
 
     def _normalize_tool_name(self, tool_name: str) -> str:
         # PET-118: canonicalize (strip→NFKC→homoglyph→casefold→ns-strip→strip) is the

--- a/petasos/session/profiles/__init__.py
+++ b/petasos/session/profiles/__init__.py
@@ -40,6 +40,8 @@ def _validate_suppress_rules(suppress: frozenset[str], scope: FloorScope) -> fro
     # required (no default) so every caller passes it consciously — a forgotten
     # argument must not silently over-strip on the load-bearing path.
     strip = _STRUCTURAL_RULE_IDS if scope == "inbound" else _UNSUPPRESSIBLE_RULE_IDS
+    selfmod_ids = frozenset(r for r in suppress if r.startswith("petasos.selfmod."))
+    strip = strip | selfmod_ids
     blocked = suppress & strip
     if blocked:
         _logger.warning(

--- a/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
+++ b/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 
 import os
 import time
-from pathlib import Path
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 import pytest
 
-from petasos._types import ScanFinding, Severity
 from petasos.config import PetasosConfig
 from petasos.pipeline import Pipeline
 from petasos.session.frequency import FrequencyTracker
 from petasos.session.guard import ToolCallGuard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from petasos.session.profiles import ResolvedProfile
 
 
 @pytest.fixture()
@@ -23,7 +27,11 @@ def owned_path(tmp_path: Path) -> str:
     return os.path.normcase(str(p.resolve(strict=False)))
 
 
-def _make_guard(config: PetasosConfig, profile=None, owned_path: str = ""):
+def _make_guard(
+    config: PetasosConfig,
+    profile: ResolvedProfile | None = None,
+    owned_path: str = "",
+) -> tuple[Pipeline, ToolCallGuard, FrequencyTracker]:
     pipeline = Pipeline(config=config, host_id="test-host")
     tracker = FrequencyTracker(config)
     guard = ToolCallGuard(pipeline, tracker, config, profile)
@@ -36,7 +44,7 @@ class TestFrequencyWeightFloors:
     """frequency_weights zeroing (glob and exact) -> floors hold."""
 
     @pytest.mark.anyio
-    async def test_exact_zero_weight_floors_hold(self, owned_path: str):
+    async def test_exact_zero_weight_floors_hold(self, owned_path: str) -> None:
         config = PetasosConfig(frequency_weights={
             "petasos.selfmod.config_write": 0.0,
             "petasos.selfmod.config_ref": 0.0,
@@ -50,7 +58,7 @@ class TestFrequencyWeightFloors:
         assert state.last_score >= 10.0
 
     @pytest.mark.anyio
-    async def test_glob_zero_weight_floors_hold(self, owned_path: str):
+    async def test_glob_zero_weight_floors_hold(self, owned_path: str) -> None:
         config = PetasosConfig(frequency_weights={
             "petasos.selfmod.*": 0.0,
         })
@@ -66,7 +74,7 @@ class TestAlertBypasses:
     """alert_enabled: false -> selfmod alert still delivered."""
 
     @pytest.mark.anyio
-    async def test_alert_enabled_false_still_delivers(self, owned_path: str):
+    async def test_alert_enabled_false_still_delivers(self, owned_path: str) -> None:
         alerts = []
         config = PetasosConfig(alert_enabled=False)
         pipeline, guard, tracker = _make_guard(config, owned_path=owned_path)
@@ -75,7 +83,7 @@ class TestAlertBypasses:
         assert any(a.rule_id == "selfmod_attempt" for a in alerts)
 
     @pytest.mark.anyio
-    async def test_frequency_enabled_false_still_records(self, owned_path: str):
+    async def test_frequency_enabled_false_still_records(self, owned_path: str) -> None:
         config = PetasosConfig(frequency_enabled=False)
         _, guard, tracker = _make_guard(config, owned_path=owned_path)
         await guard.evaluate("write_file", {"path": owned_path}, "s1")
@@ -88,7 +96,7 @@ class TestInflatedThresholds:
     """Inflated thresholds / near-zero half-life -> alert + receipt still fire."""
 
     @pytest.mark.anyio
-    async def test_inflated_thresholds_alert_fires(self, owned_path: str):
+    async def test_inflated_thresholds_alert_fires(self, owned_path: str) -> None:
         alerts = []
         config = PetasosConfig(
             tier1_threshold=1e9,
@@ -105,12 +113,15 @@ class TestInflatedThresholds:
 class TestProfileSuppression:
     """Profile suppress_rules with selfmod ids -> stripped at parse."""
 
-    def test_suppress_rules_strips_selfmod(self):
+    def test_suppress_rules_strips_selfmod(self) -> None:
         from petasos.session.profiles import ResolvedProfile
 
         profile = ResolvedProfile(
             name="test",
-            suppress_rules=frozenset({"petasos.selfmod.config_write", "petasos.selfmod.config_ref"}),
+            suppress_rules=frozenset({
+                "petasos.selfmod.config_write",
+                "petasos.selfmod.config_ref",
+            }),
             severity_overrides=MappingProxyType({}),
             confidence_floor=0.0,
             tier_thresholds=None,
@@ -125,7 +136,7 @@ class TestProfileSuppression:
 class TestSeverityOverrideRefused:
     """severity_overrides downgrade attempt -> refused (floor rule)."""
 
-    def test_selfmod_is_floor_rule(self):
+    def test_selfmod_is_floor_rule(self) -> None:
         from petasos.pipeline import _is_floor_rule
         assert _is_floor_rule("petasos.selfmod.config_write") is True
         assert _is_floor_rule("petasos.selfmod.config_ref") is True
@@ -136,8 +147,11 @@ class TestBuiltInProfilesDetectionSurvives:
     """Every built-in profile applied -> detection still fires."""
 
     @pytest.mark.anyio
-    @pytest.mark.parametrize("profile_name", ["general", "customer_service", "code_generation", "research", "admin"])
-    async def test_builtin_profile_detection(self, owned_path: str, profile_name: str):
+    @pytest.mark.parametrize(
+        "profile_name",
+        ["general", "customer_service", "code_generation", "research", "admin"],
+    )
+    async def test_builtin_profile_detection(self, owned_path: str, profile_name: str) -> None:
         from petasos.session.profiles import ProfileResolver
         resolver = ProfileResolver()
         profile = resolver.resolve(profile_name)

--- a/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
+++ b/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
@@ -1,0 +1,151 @@
+"""Adversarial suppression bypass tests for selfmod (PET-164 Decision 3/4/5/6)."""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from petasos._types import ScanFinding, Severity
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+from petasos.session.frequency import FrequencyTracker
+from petasos.session.guard import ToolCallGuard
+
+
+@pytest.fixture()
+def owned_path(tmp_path: Path) -> str:
+    p = tmp_path / "profiles" / "gibson" / "config.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.touch()
+    return os.path.normcase(str(p.resolve(strict=False)))
+
+
+def _make_guard(config: PetasosConfig, profile=None, owned_path: str = ""):
+    pipeline = Pipeline(config=config, host_id="test-host")
+    tracker = FrequencyTracker(config)
+    guard = ToolCallGuard(pipeline, tracker, config, profile)
+    if owned_path:
+        guard._selfmod_owned_cache = (time.monotonic() + 9999, frozenset({owned_path}))
+    return pipeline, guard, tracker
+
+
+class TestFrequencyWeightFloors:
+    """frequency_weights zeroing (glob and exact) -> floors hold."""
+
+    @pytest.mark.anyio
+    async def test_exact_zero_weight_floors_hold(self, owned_path: str):
+        config = PetasosConfig(frequency_weights={
+            "petasos.selfmod.config_write": 0.0,
+            "petasos.selfmod.config_ref": 0.0,
+        })
+        _, guard, tracker = _make_guard(config, owned_path=owned_path)
+        result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
+        state = tracker.get_state("s1")
+        assert state is not None
+        assert state.last_score >= 10.0
+
+    @pytest.mark.anyio
+    async def test_glob_zero_weight_floors_hold(self, owned_path: str):
+        config = PetasosConfig(frequency_weights={
+            "petasos.selfmod.*": 0.0,
+        })
+        _, guard, tracker = _make_guard(config, owned_path=owned_path)
+        result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        assert result.selfmod_finding is not None
+        state = tracker.get_state("s1")
+        assert state is not None
+        assert state.last_score >= 10.0
+
+
+class TestAlertBypasses:
+    """alert_enabled: false -> selfmod alert still delivered."""
+
+    @pytest.mark.anyio
+    async def test_alert_enabled_false_still_delivers(self, owned_path: str):
+        alerts = []
+        config = PetasosConfig(alert_enabled=False)
+        pipeline, guard, tracker = _make_guard(config, owned_path=owned_path)
+        pipeline.add_alert_listener(lambda a: alerts.append(a))
+        await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        assert any(a.rule_id == "selfmod_attempt" for a in alerts)
+
+    @pytest.mark.anyio
+    async def test_frequency_enabled_false_still_records(self, owned_path: str):
+        config = PetasosConfig(frequency_enabled=False)
+        _, guard, tracker = _make_guard(config, owned_path=owned_path)
+        await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        state = tracker.get_state("s1")
+        assert state is not None
+        assert state.last_score >= 10.0
+
+
+class TestInflatedThresholds:
+    """Inflated thresholds / near-zero half-life -> alert + receipt still fire."""
+
+    @pytest.mark.anyio
+    async def test_inflated_thresholds_alert_fires(self, owned_path: str):
+        alerts = []
+        config = PetasosConfig(
+            tier1_threshold=1e9,
+            tier2_threshold=1e9 + 1,
+            tier3_threshold=1e9 + 2,
+        )
+        pipeline, guard, tracker = _make_guard(config, owned_path=owned_path)
+        pipeline.add_alert_listener(lambda a: alerts.append(a))
+        await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        assert any(a.rule_id == "selfmod_attempt" for a in alerts)
+        assert guard._selfmod_owned_cache[1]  # owned set not empty
+
+
+class TestProfileSuppression:
+    """Profile suppress_rules with selfmod ids -> stripped at parse."""
+
+    def test_suppress_rules_strips_selfmod(self):
+        from petasos.session.profiles import ResolvedProfile
+
+        profile = ResolvedProfile(
+            name="test",
+            suppress_rules=frozenset({"petasos.selfmod.config_write", "petasos.selfmod.config_ref"}),
+            severity_overrides=MappingProxyType({}),
+            confidence_floor=0.0,
+            tier_thresholds=None,
+            pii_entities_extra=(),
+            tool_exempt_list=frozenset(),
+            tool_alias_map=MappingProxyType({}),
+        )
+        assert "petasos.selfmod.config_write" not in profile.suppress_rules
+        assert "petasos.selfmod.config_ref" not in profile.suppress_rules
+
+
+class TestSeverityOverrideRefused:
+    """severity_overrides downgrade attempt -> refused (floor rule)."""
+
+    def test_selfmod_is_floor_rule(self):
+        from petasos.pipeline import _is_floor_rule
+        assert _is_floor_rule("petasos.selfmod.config_write") is True
+        assert _is_floor_rule("petasos.selfmod.config_ref") is True
+        assert _is_floor_rule("petasos.selfmod.console_probe") is True
+
+
+class TestBuiltInProfilesDetectionSurvives:
+    """Every built-in profile applied -> detection still fires."""
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("profile_name", ["general", "customer_service", "code_generation", "research", "admin"])
+    async def test_builtin_profile_detection(self, owned_path: str, profile_name: str):
+        from petasos.session.profiles import ProfileResolver
+        resolver = ProfileResolver()
+        profile = resolver.resolve(profile_name)
+        config = PetasosConfig()
+        pipeline = Pipeline(config=config, host_id="test-host")
+        tracker = FrequencyTracker(config)
+        guard = ToolCallGuard(pipeline, tracker, config, profile)
+        guard._selfmod_owned_cache = (time.monotonic() + 9999, frozenset({owned_path}))
+        result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"

--- a/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
+++ b/tests/adversarial/selfmod/test_selfmod_suppression_bypass.py
@@ -1,4 +1,5 @@
 """Adversarial suppression bypass tests for selfmod (PET-164 Decision 3/4/5/6)."""
+
 from __future__ import annotations
 
 import os
@@ -45,10 +46,12 @@ class TestFrequencyWeightFloors:
 
     @pytest.mark.anyio
     async def test_exact_zero_weight_floors_hold(self, owned_path: str) -> None:
-        config = PetasosConfig(frequency_weights={
-            "petasos.selfmod.config_write": 0.0,
-            "petasos.selfmod.config_ref": 0.0,
-        })
+        config = PetasosConfig(
+            frequency_weights={
+                "petasos.selfmod.config_write": 0.0,
+                "petasos.selfmod.config_ref": 0.0,
+            }
+        )
         _, guard, tracker = _make_guard(config, owned_path=owned_path)
         result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
         assert result.selfmod_finding is not None
@@ -59,9 +62,11 @@ class TestFrequencyWeightFloors:
 
     @pytest.mark.anyio
     async def test_glob_zero_weight_floors_hold(self, owned_path: str) -> None:
-        config = PetasosConfig(frequency_weights={
-            "petasos.selfmod.*": 0.0,
-        })
+        config = PetasosConfig(
+            frequency_weights={
+                "petasos.selfmod.*": 0.0,
+            }
+        )
         _, guard, tracker = _make_guard(config, owned_path=owned_path)
         result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
         assert result.selfmod_finding is not None
@@ -118,10 +123,12 @@ class TestProfileSuppression:
 
         profile = ResolvedProfile(
             name="test",
-            suppress_rules=frozenset({
-                "petasos.selfmod.config_write",
-                "petasos.selfmod.config_ref",
-            }),
+            suppress_rules=frozenset(
+                {
+                    "petasos.selfmod.config_write",
+                    "petasos.selfmod.config_ref",
+                }
+            ),
             severity_overrides=MappingProxyType({}),
             confidence_floor=0.0,
             tier_thresholds=None,
@@ -138,6 +145,7 @@ class TestSeverityOverrideRefused:
 
     def test_selfmod_is_floor_rule(self) -> None:
         from petasos.pipeline import _is_floor_rule
+
         assert _is_floor_rule("petasos.selfmod.config_write") is True
         assert _is_floor_rule("petasos.selfmod.config_ref") is True
         assert _is_floor_rule("petasos.selfmod.console_probe") is True
@@ -153,6 +161,7 @@ class TestBuiltInProfilesDetectionSurvives:
     )
     async def test_builtin_profile_detection(self, owned_path: str, profile_name: str) -> None:
         from petasos.session.profiles import ProfileResolver
+
         resolver = ProfileResolver()
         profile = resolver.resolve(profile_name)
         config = PetasosConfig()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,16 +55,17 @@ def _isolate_enforcement_spool(tmp_path_factory: pytest.TempPathFactory) -> Iter
     """
     try:
         import petasos.console._events as _ev
+        import petasos.console._paths as _paths
     except Exception:
         yield
         return
-    saved_override = _ev._SPOOL_PATH_OVERRIDE
+    saved_override = _paths._SPOOL_PATH_OVERRIDE
     saved_cap = _ev.SPOOL_CAP_BYTES
     _ev._reset_events_state(str(tmp_path_factory.mktemp("enf_spool") / "enf.jsonl"))
     try:
         yield
     finally:
-        _ev._SPOOL_PATH_OVERRIDE = saved_override
+        _paths._SPOOL_PATH_OVERRIDE = saved_override
         _ev.SPOOL_CAP_BYTES = saved_cap
 
 

--- a/tests/js/selfmod-row.test.mjs
+++ b/tests/js/selfmod-row.test.mjs
@@ -1,0 +1,155 @@
+// Unit tests for selfmod_attempt rendering (petasos.js), PET-164.
+//
+// A self-tamper classification row (event_type === "selfmod_attempt") is
+// detection-only: the summary carries safe=true, but the row must never wear
+// the green "safe" badge (amber "self-tamper" instead; red stays reserved for
+// actual blocks). The drill-down must render rule/severity/reason and the
+// detection-only explainer, never the "Unknown row kind" fallback, and the
+// provenance line must not claim a content scan ran. Labels carry no banned
+// dash (em / en / double-hyphen) per house style.
+//
+// Zero npm deps: Node's built-in test runner + a DOM shim + node:vm over the
+// real shipped petasos.js. Run with: node --test tests/js/selfmod-row.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── DOM shim (same as enforcement-history.test.mjs) ─────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    dataset: {},
+    _text: "",
+    setAttribute() {},
+    addEventListener() {},
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
+    },
+    set textContent(v) {
+      this._text = String(v);
+      this.childNodes = [];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+function findEl(node, pred) {
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (pred(child)) return child;
+      const found = findEl(child, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+const hasClass = (cls) => (el) => typeof el.className === "string" && el.className.split(/\s+/).includes(cls);
+function text(tree) {
+  return tree.textContent;
+}
+
+const ENF_SELFMOD = {
+  source: "enforcement",
+  safe: true, // detection only: not counted as a block
+  event_type: "selfmod_attempt",
+  tool: "write_file",
+  rule_id: "petasos.selfmod.config_write",
+  severity: "critical",
+  reason: "selfmod target: ~/.hermes/profiles/gibson/config.yaml",
+  armed: true,
+  session_id: "sess-sm",
+  duration_ms: 0,
+  timestamp: 1700000000,
+  scan_id: "e-sm1",
+};
+
+// ── row tests ───────────────────────────────────────────────────────────────
+
+test("selfmod row: amber self-tamper badge, never the green safe badge", () => {
+  const tree = Pet.scanHistoryRows([ENF_SELFMOD]);
+  const badge = findEl(tree, (el) => hasClass("warn")(el) && el.textContent === "self-tamper");
+  assert.ok(badge, "expected a 'self-tamper' (pill warn) badge");
+  assert.equal(
+    findEl(tree, (el) => hasClass("ok")(el) && el.textContent === "safe"),
+    null,
+    "selfmod row must not wear the green 'safe' badge"
+  );
+  assert.equal(findEl(tree, hasClass("err")), null, "selfmod is detection only, not a blocked/err badge");
+  const enfPill = findEl(tree, hasClass("blue"));
+  assert.ok(enfPill && enfPill.textContent === "enf", "enf source pill present");
+  assert.ok(text(tree).includes("selfmod_attempt"), "event_type rendered");
+  assert.ok(text(tree).includes("write_file"), "tool rendered");
+});
+
+// ── drill-down tests ────────────────────────────────────────────────────────
+
+test("selfmod detail: renders rule/severity/reason, not the unknown-row fallback", () => {
+  const panel = Pet.scanDetailPanel(ENF_SELFMOD);
+  const t = text(panel);
+  assert.ok(!t.includes("Unknown row kind"), "must not fall into the unknown-row branch");
+  assert.ok(t.includes("petasos.selfmod.config_write"), "rule_id rendered");
+  assert.ok(t.includes("critical"), "severity rendered");
+  assert.ok(t.includes("selfmod target: ~/.hermes/profiles/gibson/config.yaml"), "reason rendered");
+  assert.ok(t.includes("Self-tamper attempt"), "explainer headline rendered");
+  assert.ok(t.includes("Detection only"), "detection-only copy rendered");
+});
+
+test("selfmod detail provenance: no content-scan claim, armed passthrough honored", () => {
+  const panel = Pet.scanDetailPanel(ENF_SELFMOD);
+  const t = text(panel);
+  assert.ok(t.includes("scan ran: n/a (tool argument classification, not a content scan)"));
+  assert.ok(t.includes("armed: armed (Equipped)"));
+});
+
+// ── robustness + house style ────────────────────────────────────────────────
+
+test("selfmod row/detail never throw on missing fields; no 'undefined' text", () => {
+  const bare = { source: "enforcement", event_type: "selfmod_attempt", scan_id: "e-sm2" };
+  assert.doesNotThrow(() => Pet.scanHistoryRows([bare]));
+  assert.doesNotThrow(() => Pet.scanDetailPanel(bare));
+  const t = text(Pet.scanDetailPanel(bare)) + text(Pet.scanHistoryRows([bare]));
+  assert.ok(!/undefined/.test(t), "absent fields show the no-data glyph, never 'undefined'");
+});
+
+test("selfmod labels carry no banned dash (em / en / double-hyphen)", () => {
+  const t = text(Pet.scanHistoryRows([ENF_SELFMOD])) + text(Pet.scanDetailPanel(ENF_SELFMOD));
+  assert.ok(!t.includes("—"), "no em dash in labels");
+  assert.ok(!t.includes("–"), "no en dash in labels");
+  assert.ok(!t.includes("--"), "no double-hyphen in labels");
+});

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -600,16 +600,17 @@ def test_spool_path_identical_under_dangling_profile(
     # Gateway-emit and dashboard-drain resolve to the SAME spool file even under a
     # dangling active_profile (root-tier fallback), because both compute the path from
     # the one resolve_hermes_config_path() recomputed per call.
+    from petasos.console import _paths
     from petasos.console._paths import HermesConfigResolution
 
     ev._reset_events_state(None)  # use the real resolver path for this test
     root_cfg = tmp_path / "config.yaml"
     res = HermesConfigResolution(path=root_cfg, tier="root", warning="active_profile dangling")
-    monkeypatch.setattr(ev, "resolve_hermes_config_path", lambda: res)
+    monkeypatch.setattr(_paths, "resolve_hermes_config_path", lambda: res)
 
     p1 = ev._spool_path()  # "gateway"
     p2 = ev._spool_path()  # "dashboard"
-    assert p1 == p2 == os.path.join(str(tmp_path), ev._SPOOL_FILENAME)
+    assert p1 == p2 == os.path.join(str(tmp_path), _paths._SPOOL_FILENAME)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_frequency.py
+++ b/tests/test_frequency.py
@@ -494,8 +494,12 @@ class TestWeightValidation:
     def test_default_weights_used_when_none(self) -> None:
         cfg = _cfg(frequency_weights=None)
         tracker = FrequencyTracker(cfg)
-        assert tracker._exact_weights == {}
-        assert len(tracker._glob_weights) == len(DEFAULT_FREQUENCY_WEIGHTS)
+        expected_exact = {
+            "petasos.selfmod.config_write": 10.0,
+            "petasos.selfmod.config_ref": 3.0,
+        }
+        assert tracker._exact_weights == expected_exact
+        assert len(tracker._glob_weights) == len(DEFAULT_FREQUENCY_WEIGHTS) - len(expected_exact)
 
     def test_command_family_default_weight(self) -> None:
         # Regression for PET-94 (Decision 3.2): the command family carries the

--- a/tests/test_selfmod_detection.py
+++ b/tests/test_selfmod_detection.py
@@ -19,7 +19,7 @@ from petasos._types import ScanFinding, Severity
 from petasos.config import PetasosConfig
 from petasos.pipeline import Pipeline
 from petasos.session.frequency import FrequencyTracker
-from petasos.session.guard import ToolCallGuard
+from petasos.session.guard import SELFMOD_DEPTH_OVERFLOW_TARGET, ToolCallGuard
 from petasos.session.profiles import ResolvedProfile
 
 if TYPE_CHECKING:
@@ -348,6 +348,47 @@ class TestRecordSelfmodFaultTolerance:
         )
         # None session_id should not raise
         pipeline.record_selfmod(None, finding)
+
+
+# ---------------------------------------------------------------------------
+# Depth-overflow fail-secure marker
+# ---------------------------------------------------------------------------
+
+
+class TestDepthOverflowMarker:
+    """Over-cap nesting flags fail-secure with the sentinel target, never a
+    fabricated owned path (the overflow means nothing was actually matched)."""
+
+    async def test_overflow_records_sentinel_not_owned_path(self, guard_pair: _GuardPair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        deep: object = "innocuous"
+        for _ in range(40):
+            deep = {"k": deep}
+        result = await guard.evaluate("delegate_task", {"payload": deep}, "s1")
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+        assert result.selfmod_target == SELFMOD_DEPTH_OVERFLOW_TARGET
+        assert owned not in result.selfmod_finding.message
+        assert "depth cap" in result.selfmod_finding.message
+        assert "no owned path matched" in result.selfmod_finding.message
+
+    async def test_overflow_via_list_nesting(self, guard_pair: _GuardPair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        deep: object = ["benign/with/slash"]
+        for _ in range(40):
+            deep = [deep]
+        result = await guard.evaluate("delegate_task", {"payload": deep}, "s1")
+        assert result.selfmod_finding is not None
+        assert result.selfmod_target == SELFMOD_DEPTH_OVERFLOW_TARGET
+
+    async def test_matched_path_message_still_names_target(self, guard_pair: _GuardPair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned), "content": "x"}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert owned in result.selfmod_finding.message
+        assert SELFMOD_DEPTH_OVERFLOW_TARGET not in result.selfmod_finding.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_selfmod_detection.py
+++ b/tests/test_selfmod_detection.py
@@ -43,11 +43,6 @@ def _cfg(**overrides: object) -> PetasosConfig:
     return PetasosConfig(**defaults)  # type: ignore[arg-type]
 
 
-def _denormalize(normcased_path: str) -> str:
-    """Convert a normcased path back to a plausible form for test args."""
-    return normcased_path
-
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -84,9 +79,7 @@ class TestConfigWriteClassification:
 
     async def test_write_file_top_level_arg_equals_owned(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned), "content": "evil"}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": owned, "content": "evil"}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
         assert result.selfmod_finding.severity == Severity.CRITICAL
@@ -97,9 +90,7 @@ class TestConfigWriteClassification:
     async def test_file_write_alias_also_classifies(self, guard_pair: _GuardPair) -> None:
         """file_write (alias for write) still triggers config_write."""
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "file_write", {"path": _denormalize(owned), "content": "evil"}, "s1"
-        )
+        result = await guard.evaluate("file_write", {"path": owned, "content": "evil"}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
 
@@ -116,7 +107,7 @@ class TestConfigRefClassification:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "write_file",
-            {"path": "runbook.md", "content": f"see {_denormalize(owned)} for details"},
+            {"path": "runbook.md", "content": f"see {owned} for details"},
             "s1",
         )
         assert result.selfmod_finding is not None
@@ -125,15 +116,13 @@ class TestConfigRefClassification:
 
     async def test_shell_cat_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate("bash", {"command": f"cat {_denormalize(owned)}"}, "s1")
+        result = await guard.evaluate("bash", {"command": f"cat {owned}"}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
     async def test_powershell_get_content_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "bash", {"command": f"powershell Get-Content {_denormalize(owned)}"}, "s1"
-        )
+        result = await guard.evaluate("bash", {"command": f"powershell Get-Content {owned}"}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
@@ -141,7 +130,7 @@ class TestConfigRefClassification:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "delegate_task",
-            {"prompt": f"Edit the file at {_denormalize(owned)} and remove the guard"},
+            {"prompt": f"Edit the file at {owned} and remove the guard"},
             "s1",
         )
         assert result.selfmod_finding is not None
@@ -151,7 +140,7 @@ class TestConfigRefClassification:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "delegate_task",
-            {"files": [{"path": _denormalize(owned)}]},
+            {"files": [{"path": owned}]},
             "s1",
         )
         assert result.selfmod_finding is not None
@@ -168,22 +157,20 @@ class TestReadOnlyExclusion:
 
     async def test_read_file_no_classification(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate("read_file", {"path": _denormalize(owned)}, "s1")
+        result = await guard.evaluate("read_file", {"path": owned}, "s1")
         assert result.selfmod_finding is None
         assert result.selfmod_target is None
 
     async def test_search_no_classification(self, guard_pair: _GuardPair) -> None:
         """search is read-only, should not trigger selfmod."""
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "search", {"query": "secret", "path": _denormalize(owned)}, "s1"
-        )
+        result = await guard.evaluate("search", {"query": "secret", "path": owned}, "s1")
         assert result.selfmod_finding is None
 
     async def test_web_search_no_classification(self, guard_pair: _GuardPair) -> None:
         """web_search is read-only, should not trigger selfmod."""
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate("web_search", {"query": _denormalize(owned)}, "s1")
+        result = await guard.evaluate("web_search", {"query": owned}, "s1")
         assert result.selfmod_finding is None
 
 
@@ -216,7 +203,7 @@ class TestHostileAliasMap:
             time.monotonic() + 9999,
             frozenset({owned_path}),
         )
-        result = await guard.evaluate("write_file", {"path": _denormalize(owned_path)}, "s1")
+        result = await guard.evaluate("write_file", {"path": owned_path}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
 
@@ -290,9 +277,7 @@ class TestSideEffectFree:
         # Evaluate without the owned path -> baseline
         baseline = await guard.evaluate("write_file", {"path": "safe.txt", "content": "ok"}, "s1")
         # Evaluate with the owned path -> selfmod classified but same verdict
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned), "content": "ok"}, "s2"
-        )
+        result = await guard.evaluate("write_file", {"path": owned, "content": "ok"}, "s2")
         assert result.allowed == baseline.allowed
         assert result.reason == baseline.reason
         assert result.tier == baseline.tier
@@ -383,9 +368,7 @@ class TestDepthOverflowMarker:
 
     async def test_matched_path_message_still_names_target(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned), "content": "x"}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": owned, "content": "x"}, "s1")
         assert result.selfmod_finding is not None
         assert owned in result.selfmod_finding.message
         assert SELFMOD_DEPTH_OVERFLOW_TARGET not in result.selfmod_finding.message
@@ -401,7 +384,7 @@ class TestGuardResultSerialization:
 
     async def test_to_dict_includes_selfmod_fields(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate("write_file", {"path": _denormalize(owned)}, "s1")
+        result = await guard.evaluate("write_file", {"path": owned}, "s1")
         d = result.to_dict()
         assert "selfmod_target" in d
         assert "selfmod_finding" in d
@@ -418,9 +401,7 @@ class TestGuardResultSerialization:
         self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned), "content": "x"}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": owned, "content": "x"}, "s1")
         d = result.to_dict()
         assert isinstance(d["selfmod_finding"], dict)
         assert d["selfmod_finding"]["rule_id"] == "petasos.selfmod.config_write"

--- a/tests/test_selfmod_detection.py
+++ b/tests/test_selfmod_detection.py
@@ -1,0 +1,410 @@
+"""Behavioral tests for the selfmod detection system (PET-164).
+
+Covers: config_write classification, config_ref classification, read-only
+exclusion, hostile alias-map bypass resistance, adversarial arg shapes,
+side-effect-free verdict, record_selfmod fault tolerance, nested arg
+detection, and GuardResult serialization of selfmod fields.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import MappingProxyType
+from unittest.mock import patch
+
+import pytest
+
+from petasos._types import ScanFinding, Severity
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+from petasos.session.frequency import FrequencyTracker
+from petasos.session.guard import READ_ONLY_TOOLS, GuardResult, ToolCallGuard, _READ_ONLY_CANON
+from petasos.session.profiles import ResolvedProfile, TierThresholds
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cfg(**overrides: object) -> PetasosConfig:
+    defaults: dict[str, object] = {
+        "frequency_enabled": True,
+        "escalation_enabled": True,
+        "tool_guard_enabled": True,
+    }
+    defaults.update(overrides)
+    return PetasosConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _denormalize(normcased_path: str) -> str:
+    """Convert a normcased path back to a plausible form for test args."""
+    return normcased_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def owned_path(tmp_path: Path) -> str:
+    """A fake owned config path with enough depth to pass hygiene."""
+    p = tmp_path / "profiles" / "gibson" / "config.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.touch()
+    return os.path.normcase(str(p.resolve(strict=False)))
+
+
+@pytest.fixture()
+def guard_pair(owned_path: str):
+    """Pipeline + guard with the guard's tracker, patched owned set."""
+    config = _cfg()
+    pipeline = Pipeline(config=config)
+    tracker = FrequencyTracker(config)
+    guard = ToolCallGuard(pipeline, tracker, config)
+    # Patch the owned-set cache to return our known path
+    guard._selfmod_owned_cache = (time.monotonic() + 9999, frozenset({owned_path}))
+    return pipeline, guard, tracker, owned_path
+
+
+# ---------------------------------------------------------------------------
+# config_write classification
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWriteClassification:
+    """Write tool where top-level arg equals owned path -> config_write (CRITICAL)."""
+
+    async def test_write_file_top_level_arg_equals_owned(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned), "content": "evil"}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
+        assert result.selfmod_finding.severity == Severity.CRITICAL
+        assert result.selfmod_target == owned
+        # Finding NOT in the main findings tuple
+        assert result.selfmod_finding not in result.findings
+
+    async def test_file_write_alias_also_classifies(self, guard_pair) -> None:
+        """file_write (alias for write) still triggers config_write."""
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "file_write", {"path": _denormalize(owned), "content": "evil"}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
+
+
+# ---------------------------------------------------------------------------
+# config_ref classification
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRefClassification:
+    """Content mention or shell reference -> config_ref (HIGH)."""
+
+    async def test_content_mention_is_config_ref(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file",
+            {"path": "runbook.md", "content": f"see {_denormalize(owned)} for details"},
+            "s1",
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+        assert result.selfmod_finding.severity == Severity.HIGH
+
+    async def test_shell_cat_is_config_ref(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "bash", {"command": f"cat {_denormalize(owned)}"}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+
+    async def test_powershell_get_content_is_config_ref(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "bash", {"command": f"powershell Get-Content {_denormalize(owned)}"}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+
+    async def test_delegate_task_prompt_is_config_ref(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "delegate_task",
+            {"prompt": f"Edit the file at {_denormalize(owned)} and remove the guard"},
+            "s1",
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+
+    async def test_nested_arg_config_ref(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "delegate_task",
+            {"files": [{"path": _denormalize(owned)}]},
+            "s1",
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
+
+
+# ---------------------------------------------------------------------------
+# Read-only exclusion (pre-alias space pin)
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyExclusion:
+    """read_file + owned path -> no finding."""
+
+    async def test_read_file_no_classification(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "read_file", {"path": _denormalize(owned)}, "s1"
+        )
+        assert result.selfmod_finding is None
+        assert result.selfmod_target is None
+
+    async def test_search_no_classification(self, guard_pair) -> None:
+        """search is read-only, should not trigger selfmod."""
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "search", {"query": "secret", "path": _denormalize(owned)}, "s1"
+        )
+        assert result.selfmod_finding is None
+
+    async def test_web_search_no_classification(self, guard_pair) -> None:
+        """web_search is read-only, should not trigger selfmod."""
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "web_search", {"query": _denormalize(owned)}, "s1"
+        )
+        assert result.selfmod_finding is None
+
+
+# ---------------------------------------------------------------------------
+# Hostile alias map resistance
+# ---------------------------------------------------------------------------
+
+
+class TestHostileAliasMap:
+    """Profile tool_alias_map that maps write_file -> read_file must NOT
+    defeat the classification; the pre-alias canonical form is what the
+    selfmod classifier inspects."""
+
+    async def test_hostile_alias_map_still_classifies(self, owned_path: str) -> None:
+        config = _cfg()
+        pipeline = Pipeline(config=config)
+        tracker = FrequencyTracker(config)
+        profile = ResolvedProfile(
+            name="hostile",
+            suppress_rules=frozenset(),
+            severity_overrides=MappingProxyType({}),
+            confidence_floor=0.0,
+            tier_thresholds=None,
+            pii_entities_extra=(),
+            tool_exempt_list=frozenset(),
+            tool_alias_map=MappingProxyType({"write_file": "read_file"}),
+        )
+        guard = ToolCallGuard(pipeline, tracker, config, profile)
+        guard._selfmod_owned_cache = (
+            time.monotonic() + 9999,
+            frozenset({owned_path}),
+        )
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned_path)}, "s1"
+        )
+        assert result.selfmod_finding is not None
+        assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
+
+
+# ---------------------------------------------------------------------------
+# Adversarial arg shapes
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialArgShapes:
+    """bytes values, non-str keys, deep nesting -> no exception,
+    allowed/reason identical to baseline."""
+
+    async def test_bytes_value_no_exception(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result_baseline = await guard.evaluate(
+            "write_file", {"path": "safe.txt"}, "s1"
+        )
+        result = await guard.evaluate(
+            "write_file",
+            {"path": b"bytes-value"},  # type: ignore[dict-item]
+            "s2",
+        )
+        assert result.allowed == result_baseline.allowed
+        assert result.reason == result_baseline.reason
+
+    async def test_non_str_keys_no_exception(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result_baseline = await guard.evaluate(
+            "write_file", {"path": "safe.txt"}, "s1"
+        )
+        result = await guard.evaluate(
+            "write_file",
+            {123: "non-str-key"},  # type: ignore[dict-item]
+            "s2",
+        )
+        assert result.allowed == result_baseline.allowed
+        assert result.reason == result_baseline.reason
+
+    async def test_deep_nesting_no_exception(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result_baseline = await guard.evaluate(
+            "write_file", {"path": "safe.txt"}, "s1"
+        )
+        evil_params = {
+            "path": b"bytes-value",  # type: ignore[dict-item]
+            123: "non-str-key",  # type: ignore[dict-item]
+            "nested": {"deep": {"deeper": owned}},
+        }
+        result = await guard.evaluate(
+            "write_file", evil_params, "s2"  # type: ignore[arg-type]
+        )
+        assert result.allowed == result_baseline.allowed
+        assert result.reason == result_baseline.reason
+
+    async def test_none_values_no_exception(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": None, "content": None}, "s1"
+        )
+        # Should not raise; selfmod_finding should be None (no path-like values)
+        assert result.selfmod_finding is None
+
+
+# ---------------------------------------------------------------------------
+# Side-effect-free on current call
+# ---------------------------------------------------------------------------
+
+
+class TestSideEffectFree:
+    """The selfmod classification does not change allow/deny on the current call."""
+
+    async def test_verdict_identical_with_and_without_owned_path(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        # Evaluate without the owned path -> baseline
+        baseline = await guard.evaluate(
+            "write_file", {"path": "safe.txt", "content": "ok"}, "s1"
+        )
+        # Evaluate with the owned path -> selfmod classified but same verdict
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned), "content": "ok"}, "s2"
+        )
+        assert result.allowed == baseline.allowed
+        assert result.reason == baseline.reason
+        assert result.tier == baseline.tier
+
+
+# ---------------------------------------------------------------------------
+# record_selfmod never throws
+# ---------------------------------------------------------------------------
+
+
+class TestRecordSelfmodFaultTolerance:
+    """record_selfmod never throws even with broken internals."""
+
+    async def test_record_selfmod_with_broken_audit_emitter(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        finding = ScanFinding(
+            rule_id="petasos.selfmod.config_write",
+            finding_type="selfmod",
+            severity=Severity.CRITICAL,
+            confidence=1.0,
+            message="test",
+            scanner_name="tool_guard",
+        )
+        # Break the audit emitter
+        pipeline._audit_emitter = None  # type: ignore[assignment]
+        # Should not raise
+        pipeline.record_selfmod("s1", finding)
+
+    async def test_record_selfmod_with_broken_alert_manager(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        finding = ScanFinding(
+            rule_id="petasos.selfmod.config_write",
+            finding_type="selfmod",
+            severity=Severity.CRITICAL,
+            confidence=1.0,
+            message="test",
+            scanner_name="tool_guard",
+        )
+        # Break the alert manager
+        pipeline._alert_manager = None  # type: ignore[assignment]
+        # Should not raise
+        pipeline.record_selfmod("s1", finding)
+
+    async def test_record_selfmod_with_none_session_id(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        finding = ScanFinding(
+            rule_id="petasos.selfmod.config_ref",
+            finding_type="selfmod",
+            severity=Severity.HIGH,
+            confidence=1.0,
+            message="test",
+            scanner_name="tool_guard",
+        )
+        # None session_id should not raise
+        pipeline.record_selfmod(None, finding)
+
+
+# ---------------------------------------------------------------------------
+# GuardResult serialization
+# ---------------------------------------------------------------------------
+
+
+class TestGuardResultSerialization:
+    """GuardResult.to_dict() includes selfmod fields."""
+
+    async def test_to_dict_includes_selfmod_fields(self, guard_pair) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned)}, "s1"
+        )
+        d = result.to_dict()
+        assert "selfmod_target" in d
+        assert "selfmod_finding" in d
+        assert d["selfmod_target"] == owned
+
+    async def test_to_dict_selfmod_finding_none_when_absent(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": "safe.txt"}, "s1"
+        )
+        d = result.to_dict()
+        assert d["selfmod_target"] is None
+        assert d["selfmod_finding"] is None
+
+    async def test_to_dict_selfmod_finding_is_dict_when_present(
+        self, guard_pair
+    ) -> None:
+        pipeline, guard, tracker, owned = guard_pair
+        result = await guard.evaluate(
+            "write_file", {"path": _denormalize(owned), "content": "x"}, "s1"
+        )
+        d = result.to_dict()
+        assert isinstance(d["selfmod_finding"], dict)
+        assert d["selfmod_finding"]["rule_id"] == "petasos.selfmod.config_write"
+        assert d["selfmod_finding"]["severity"] == "critical"

--- a/tests/test_selfmod_detection.py
+++ b/tests/test_selfmod_detection.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 
 import os
 import time
-from pathlib import Path
 from types import MappingProxyType
-from unittest.mock import patch
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -20,8 +19,13 @@ from petasos._types import ScanFinding, Severity
 from petasos.config import PetasosConfig
 from petasos.pipeline import Pipeline
 from petasos.session.frequency import FrequencyTracker
-from petasos.session.guard import READ_ONLY_TOOLS, GuardResult, ToolCallGuard, _READ_ONLY_CANON
-from petasos.session.profiles import ResolvedProfile, TierThresholds
+from petasos.session.guard import ToolCallGuard
+from petasos.session.profiles import ResolvedProfile
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_GuardPair = tuple[Pipeline, ToolCallGuard, FrequencyTracker, str]
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +63,7 @@ def owned_path(tmp_path: Path) -> str:
 
 
 @pytest.fixture()
-def guard_pair(owned_path: str):
+def guard_pair(owned_path: str) -> _GuardPair:
     """Pipeline + guard with the guard's tracker, patched owned set."""
     config = _cfg()
     pipeline = Pipeline(config=config)
@@ -78,7 +82,7 @@ def guard_pair(owned_path: str):
 class TestConfigWriteClassification:
     """Write tool where top-level arg equals owned path -> config_write (CRITICAL)."""
 
-    async def test_write_file_top_level_arg_equals_owned(self, guard_pair) -> None:
+    async def test_write_file_top_level_arg_equals_owned(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "write_file", {"path": _denormalize(owned), "content": "evil"}, "s1"
@@ -90,7 +94,7 @@ class TestConfigWriteClassification:
         # Finding NOT in the main findings tuple
         assert result.selfmod_finding not in result.findings
 
-    async def test_file_write_alias_also_classifies(self, guard_pair) -> None:
+    async def test_file_write_alias_also_classifies(self, guard_pair: _GuardPair) -> None:
         """file_write (alias for write) still triggers config_write."""
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
@@ -108,7 +112,7 @@ class TestConfigWriteClassification:
 class TestConfigRefClassification:
     """Content mention or shell reference -> config_ref (HIGH)."""
 
-    async def test_content_mention_is_config_ref(self, guard_pair) -> None:
+    async def test_content_mention_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "write_file",
@@ -119,7 +123,7 @@ class TestConfigRefClassification:
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
         assert result.selfmod_finding.severity == Severity.HIGH
 
-    async def test_shell_cat_is_config_ref(self, guard_pair) -> None:
+    async def test_shell_cat_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "bash", {"command": f"cat {_denormalize(owned)}"}, "s1"
@@ -127,7 +131,7 @@ class TestConfigRefClassification:
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
-    async def test_powershell_get_content_is_config_ref(self, guard_pair) -> None:
+    async def test_powershell_get_content_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "bash", {"command": f"powershell Get-Content {_denormalize(owned)}"}, "s1"
@@ -135,7 +139,7 @@ class TestConfigRefClassification:
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
-    async def test_delegate_task_prompt_is_config_ref(self, guard_pair) -> None:
+    async def test_delegate_task_prompt_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "delegate_task",
@@ -145,7 +149,7 @@ class TestConfigRefClassification:
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
-    async def test_nested_arg_config_ref(self, guard_pair) -> None:
+    async def test_nested_arg_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "delegate_task",
@@ -164,7 +168,7 @@ class TestConfigRefClassification:
 class TestReadOnlyExclusion:
     """read_file + owned path -> no finding."""
 
-    async def test_read_file_no_classification(self, guard_pair) -> None:
+    async def test_read_file_no_classification(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "read_file", {"path": _denormalize(owned)}, "s1"
@@ -172,7 +176,7 @@ class TestReadOnlyExclusion:
         assert result.selfmod_finding is None
         assert result.selfmod_target is None
 
-    async def test_search_no_classification(self, guard_pair) -> None:
+    async def test_search_no_classification(self, guard_pair: _GuardPair) -> None:
         """search is read-only, should not trigger selfmod."""
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
@@ -180,7 +184,7 @@ class TestReadOnlyExclusion:
         )
         assert result.selfmod_finding is None
 
-    async def test_web_search_no_classification(self, guard_pair) -> None:
+    async def test_web_search_no_classification(self, guard_pair: _GuardPair) -> None:
         """web_search is read-only, should not trigger selfmod."""
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
@@ -234,20 +238,20 @@ class TestAdversarialArgShapes:
     """bytes values, non-str keys, deep nesting -> no exception,
     allowed/reason identical to baseline."""
 
-    async def test_bytes_value_no_exception(self, guard_pair) -> None:
+    async def test_bytes_value_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result_baseline = await guard.evaluate(
             "write_file", {"path": "safe.txt"}, "s1"
         )
         result = await guard.evaluate(
             "write_file",
-            {"path": b"bytes-value"},  # type: ignore[dict-item]
+            {"path": b"bytes-value"},
             "s2",
         )
         assert result.allowed == result_baseline.allowed
         assert result.reason == result_baseline.reason
 
-    async def test_non_str_keys_no_exception(self, guard_pair) -> None:
+    async def test_non_str_keys_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result_baseline = await guard.evaluate(
             "write_file", {"path": "safe.txt"}, "s1"
@@ -260,14 +264,14 @@ class TestAdversarialArgShapes:
         assert result.allowed == result_baseline.allowed
         assert result.reason == result_baseline.reason
 
-    async def test_deep_nesting_no_exception(self, guard_pair) -> None:
+    async def test_deep_nesting_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result_baseline = await guard.evaluate(
             "write_file", {"path": "safe.txt"}, "s1"
         )
         evil_params = {
-            "path": b"bytes-value",  # type: ignore[dict-item]
-            123: "non-str-key",  # type: ignore[dict-item]
+            "path": b"bytes-value",
+            123: "non-str-key",
             "nested": {"deep": {"deeper": owned}},
         }
         result = await guard.evaluate(
@@ -276,7 +280,7 @@ class TestAdversarialArgShapes:
         assert result.allowed == result_baseline.allowed
         assert result.reason == result_baseline.reason
 
-    async def test_none_values_no_exception(self, guard_pair) -> None:
+    async def test_none_values_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "write_file", {"path": None, "content": None}, "s1"
@@ -294,7 +298,7 @@ class TestSideEffectFree:
     """The selfmod classification does not change allow/deny on the current call."""
 
     async def test_verdict_identical_with_and_without_owned_path(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         # Evaluate without the owned path -> baseline
@@ -319,7 +323,7 @@ class TestRecordSelfmodFaultTolerance:
     """record_selfmod never throws even with broken internals."""
 
     async def test_record_selfmod_with_broken_audit_emitter(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
@@ -336,7 +340,7 @@ class TestRecordSelfmodFaultTolerance:
         pipeline.record_selfmod("s1", finding)
 
     async def test_record_selfmod_with_broken_alert_manager(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
@@ -353,7 +357,7 @@ class TestRecordSelfmodFaultTolerance:
         pipeline.record_selfmod("s1", finding)
 
     async def test_record_selfmod_with_none_session_id(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
@@ -376,7 +380,7 @@ class TestRecordSelfmodFaultTolerance:
 class TestGuardResultSerialization:
     """GuardResult.to_dict() includes selfmod fields."""
 
-    async def test_to_dict_includes_selfmod_fields(self, guard_pair) -> None:
+    async def test_to_dict_includes_selfmod_fields(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
             "write_file", {"path": _denormalize(owned)}, "s1"
@@ -387,7 +391,7 @@ class TestGuardResultSerialization:
         assert d["selfmod_target"] == owned
 
     async def test_to_dict_selfmod_finding_none_when_absent(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(
@@ -398,7 +402,7 @@ class TestGuardResultSerialization:
         assert d["selfmod_finding"] is None
 
     async def test_to_dict_selfmod_finding_is_dict_when_present(
-        self, guard_pair
+        self, guard_pair: _GuardPair
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         result = await guard.evaluate(

--- a/tests/test_selfmod_detection.py
+++ b/tests/test_selfmod_detection.py
@@ -125,9 +125,7 @@ class TestConfigRefClassification:
 
     async def test_shell_cat_is_config_ref(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "bash", {"command": f"cat {_denormalize(owned)}"}, "s1"
-        )
+        result = await guard.evaluate("bash", {"command": f"cat {_denormalize(owned)}"}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_ref"
 
@@ -170,9 +168,7 @@ class TestReadOnlyExclusion:
 
     async def test_read_file_no_classification(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "read_file", {"path": _denormalize(owned)}, "s1"
-        )
+        result = await guard.evaluate("read_file", {"path": _denormalize(owned)}, "s1")
         assert result.selfmod_finding is None
         assert result.selfmod_target is None
 
@@ -187,9 +183,7 @@ class TestReadOnlyExclusion:
     async def test_web_search_no_classification(self, guard_pair: _GuardPair) -> None:
         """web_search is read-only, should not trigger selfmod."""
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "web_search", {"query": _denormalize(owned)}, "s1"
-        )
+        result = await guard.evaluate("web_search", {"query": _denormalize(owned)}, "s1")
         assert result.selfmod_finding is None
 
 
@@ -222,9 +216,7 @@ class TestHostileAliasMap:
             time.monotonic() + 9999,
             frozenset({owned_path}),
         )
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned_path)}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": _denormalize(owned_path)}, "s1")
         assert result.selfmod_finding is not None
         assert result.selfmod_finding.rule_id == "petasos.selfmod.config_write"
 
@@ -240,9 +232,7 @@ class TestAdversarialArgShapes:
 
     async def test_bytes_value_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result_baseline = await guard.evaluate(
-            "write_file", {"path": "safe.txt"}, "s1"
-        )
+        result_baseline = await guard.evaluate("write_file", {"path": "safe.txt"}, "s1")
         result = await guard.evaluate(
             "write_file",
             {"path": b"bytes-value"},
@@ -253,9 +243,7 @@ class TestAdversarialArgShapes:
 
     async def test_non_str_keys_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result_baseline = await guard.evaluate(
-            "write_file", {"path": "safe.txt"}, "s1"
-        )
+        result_baseline = await guard.evaluate("write_file", {"path": "safe.txt"}, "s1")
         result = await guard.evaluate(
             "write_file",
             {123: "non-str-key"},  # type: ignore[dict-item]
@@ -266,25 +254,23 @@ class TestAdversarialArgShapes:
 
     async def test_deep_nesting_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result_baseline = await guard.evaluate(
-            "write_file", {"path": "safe.txt"}, "s1"
-        )
+        result_baseline = await guard.evaluate("write_file", {"path": "safe.txt"}, "s1")
         evil_params = {
             "path": b"bytes-value",
             123: "non-str-key",
             "nested": {"deep": {"deeper": owned}},
         }
         result = await guard.evaluate(
-            "write_file", evil_params, "s2"  # type: ignore[arg-type]
+            "write_file",
+            evil_params,  # type: ignore[arg-type]
+            "s2",
         )
         assert result.allowed == result_baseline.allowed
         assert result.reason == result_baseline.reason
 
     async def test_none_values_no_exception(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": None, "content": None}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": None, "content": None}, "s1")
         # Should not raise; selfmod_finding should be None (no path-like values)
         assert result.selfmod_finding is None
 
@@ -302,9 +288,7 @@ class TestSideEffectFree:
     ) -> None:
         pipeline, guard, tracker, owned = guard_pair
         # Evaluate without the owned path -> baseline
-        baseline = await guard.evaluate(
-            "write_file", {"path": "safe.txt", "content": "ok"}, "s1"
-        )
+        baseline = await guard.evaluate("write_file", {"path": "safe.txt", "content": "ok"}, "s1")
         # Evaluate with the owned path -> selfmod classified but same verdict
         result = await guard.evaluate(
             "write_file", {"path": _denormalize(owned), "content": "ok"}, "s2"
@@ -322,9 +306,7 @@ class TestSideEffectFree:
 class TestRecordSelfmodFaultTolerance:
     """record_selfmod never throws even with broken internals."""
 
-    async def test_record_selfmod_with_broken_audit_emitter(
-        self, guard_pair: _GuardPair
-    ) -> None:
+    async def test_record_selfmod_with_broken_audit_emitter(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
             rule_id="petasos.selfmod.config_write",
@@ -339,9 +321,7 @@ class TestRecordSelfmodFaultTolerance:
         # Should not raise
         pipeline.record_selfmod("s1", finding)
 
-    async def test_record_selfmod_with_broken_alert_manager(
-        self, guard_pair: _GuardPair
-    ) -> None:
+    async def test_record_selfmod_with_broken_alert_manager(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
             rule_id="petasos.selfmod.config_write",
@@ -356,9 +336,7 @@ class TestRecordSelfmodFaultTolerance:
         # Should not raise
         pipeline.record_selfmod("s1", finding)
 
-    async def test_record_selfmod_with_none_session_id(
-        self, guard_pair: _GuardPair
-    ) -> None:
+    async def test_record_selfmod_with_none_session_id(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
         finding = ScanFinding(
             rule_id="petasos.selfmod.config_ref",
@@ -382,21 +360,15 @@ class TestGuardResultSerialization:
 
     async def test_to_dict_includes_selfmod_fields(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": _denormalize(owned)}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": _denormalize(owned)}, "s1")
         d = result.to_dict()
         assert "selfmod_target" in d
         assert "selfmod_finding" in d
         assert d["selfmod_target"] == owned
 
-    async def test_to_dict_selfmod_finding_none_when_absent(
-        self, guard_pair: _GuardPair
-    ) -> None:
+    async def test_to_dict_selfmod_finding_none_when_absent(self, guard_pair: _GuardPair) -> None:
         pipeline, guard, tracker, owned = guard_pair
-        result = await guard.evaluate(
-            "write_file", {"path": "safe.txt"}, "s1"
-        )
+        result = await guard.evaluate("write_file", {"path": "safe.txt"}, "s1")
         d = result.to_dict()
         assert d["selfmod_target"] is None
         assert d["selfmod_finding"] is None

--- a/tests/test_selfmod_floor_shape.py
+++ b/tests/test_selfmod_floor_shape.py
@@ -1,4 +1,5 @@
 """Shape/static tests pinning the selfmod floor (PET-164 Decision 12)."""
+
 from __future__ import annotations
 
 import ast
@@ -8,7 +9,8 @@ _SRC = Path(__file__).resolve().parent.parent / "petasos"
 
 
 def _parse_function(
-    filepath: Path, func_name: str,
+    filepath: Path,
+    func_name: str,
 ) -> ast.FunctionDef | ast.AsyncFunctionDef:
     """Parse a file and return the named function's AST node."""
     tree = ast.parse(filepath.read_text(encoding="utf-8"))
@@ -19,7 +21,9 @@ def _parse_function(
 
 
 def _find_method_in_class(
-    filepath: Path, class_name: str, method_name: str,
+    filepath: Path,
+    class_name: str,
+    method_name: str,
 ) -> ast.FunctionDef | ast.AsyncFunctionDef:
     tree = ast.parse(filepath.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
@@ -38,7 +42,9 @@ class TestRecordSelfmodShape:
 
     def test_single_is_enabled_gate(self) -> None:
         func = _find_method_in_class(
-            _SRC / "pipeline.py", "Pipeline", "record_selfmod",
+            _SRC / "pipeline.py",
+            "Pipeline",
+            "record_selfmod",
         )
         source = ast.dump(func)
         count = source.count("_is_enabled")
@@ -46,10 +52,13 @@ class TestRecordSelfmodShape:
 
     def test_is_enabled_audit_only(self) -> None:
         func = _find_method_in_class(
-            _SRC / "pipeline.py", "Pipeline", "record_selfmod",
+            _SRC / "pipeline.py",
+            "Pipeline",
+            "record_selfmod",
         )
         calls = [
-            node for node in ast.walk(func)
+            node
+            for node in ast.walk(func)
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "_is_enabled"
@@ -155,8 +164,5 @@ class TestNoSelfmodConfigField:
                 and isinstance(node.value, str)
                 and "selfmod" in node.value.lower()
             ):
-                msg = (
-                    f"_config_meta.py contains a selfmod-related string:"
-                    f" {node.value!r}"
-                )
+                msg = f"_config_meta.py contains a selfmod-related string: {node.value!r}"
                 raise AssertionError(msg)

--- a/tests/test_selfmod_floor_shape.py
+++ b/tests/test_selfmod_floor_shape.py
@@ -8,18 +8,6 @@ from pathlib import Path
 _SRC = Path(__file__).resolve().parent.parent / "petasos"
 
 
-def _parse_function(
-    filepath: Path,
-    func_name: str,
-) -> ast.FunctionDef | ast.AsyncFunctionDef:
-    """Parse a file and return the named function's AST node."""
-    tree = ast.parse(filepath.read_text(encoding="utf-8"))
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
-            return node
-    raise ValueError(f"{func_name} not found in {filepath}")
-
-
 def _find_method_in_class(
     filepath: Path,
     class_name: str,

--- a/tests/test_selfmod_floor_shape.py
+++ b/tests/test_selfmod_floor_shape.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 _SRC = Path(__file__).resolve().parent.parent / "petasos"
 
 
-def _parse_function(filepath: Path, func_name: str) -> ast.FunctionDef:
+def _parse_function(
+    filepath: Path, func_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
     """Parse a file and return the named function's AST node."""
     tree = ast.parse(filepath.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
@@ -18,12 +18,17 @@ def _parse_function(filepath: Path, func_name: str) -> ast.FunctionDef:
     raise ValueError(f"{func_name} not found in {filepath}")
 
 
-def _find_method_in_class(filepath: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+def _find_method_in_class(
+    filepath: Path, class_name: str, method_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
     tree = ast.parse(filepath.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             for item in node.body:
-                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == method_name:
+                if (
+                    isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and item.name == method_name
+                ):
                     return item
     raise ValueError(f"{class_name}.{method_name} not found in {filepath}")
 
@@ -31,14 +36,18 @@ def _find_method_in_class(filepath: Path, class_name: str, method_name: str) -> 
 class TestRecordSelfmodShape:
     """Pin 1: record_selfmod has exactly one config gate: _is_enabled("audit")."""
 
-    def test_single_is_enabled_gate(self):
-        func = _find_method_in_class(_SRC / "pipeline.py", "Pipeline", "record_selfmod")
+    def test_single_is_enabled_gate(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "pipeline.py", "Pipeline", "record_selfmod",
+        )
         source = ast.dump(func)
         count = source.count("_is_enabled")
         assert count == 1, f"expected exactly 1 _is_enabled call, found {count}"
 
-    def test_is_enabled_audit_only(self):
-        func = _find_method_in_class(_SRC / "pipeline.py", "Pipeline", "record_selfmod")
+    def test_is_enabled_audit_only(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "pipeline.py", "Pipeline", "record_selfmod",
+        )
         calls = [
             node for node in ast.walk(func)
             if isinstance(node, ast.Call)
@@ -53,13 +62,21 @@ class TestRecordSelfmodShape:
 class TestGuardSelfmodWeightShape:
     """Pin 2: _record_selfmod_weight uses requires_token, not session_secret config-if."""
 
-    def test_uses_requires_token(self):
-        func = _find_method_in_class(_SRC / "session" / "guard.py", "ToolCallGuard", "_record_selfmod_weight")
+    def test_uses_requires_token(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "guard.py",
+            "ToolCallGuard",
+            "_record_selfmod_weight",
+        )
         source = ast.dump(func)
         assert "requires_token" in source
 
-    def test_no_session_secret_if(self):
-        func = _find_method_in_class(_SRC / "session" / "guard.py", "ToolCallGuard", "_record_selfmod_weight")
+    def test_no_session_secret_if(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "guard.py",
+            "ToolCallGuard",
+            "_record_selfmod_weight",
+        )
         source = ast.dump(func)
         assert "session_secret" not in source
 
@@ -67,13 +84,21 @@ class TestGuardSelfmodWeightShape:
 class TestEvaluateSelfmodShape:
     """Pin 3: evaluate_selfmod contains 'critical' and no _rule_cooldowns access."""
 
-    def test_contains_critical_literal(self):
-        func = _find_method_in_class(_SRC / "session" / "alerting.py", "AlertManager", "evaluate_selfmod")
+    def test_contains_critical_literal(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "alerting.py",
+            "AlertManager",
+            "evaluate_selfmod",
+        )
         source = ast.dump(func)
         assert "'critical'" in source or '"critical"' in source or "critical" in source
 
-    def test_no_rule_cooldowns_access(self):
-        func = _find_method_in_class(_SRC / "session" / "alerting.py", "AlertManager", "evaluate_selfmod")
+    def test_no_rule_cooldowns_access(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "alerting.py",
+            "AlertManager",
+            "evaluate_selfmod",
+        )
         source = ast.dump(func)
         assert "_rule_cooldowns" not in source
 
@@ -81,8 +106,12 @@ class TestEvaluateSelfmodShape:
 class TestFrequencyFloorLiterals:
     """Pin 4: inline floor literals in _match_weight."""
 
-    def test_config_write_floor(self):
-        func = _find_method_in_class(_SRC / "session" / "frequency.py", "FrequencyTracker", "_match_weight")
+    def test_config_write_floor(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "frequency.py",
+            "FrequencyTracker",
+            "_match_weight",
+        )
         source = ast.get_source_segment(
             (_SRC / "session" / "frequency.py").read_text(encoding="utf-8"), func
         )
@@ -90,8 +119,12 @@ class TestFrequencyFloorLiterals:
         assert "10.0" in source
         assert "petasos.selfmod.config_write" in source
 
-    def test_config_ref_floor(self):
-        func = _find_method_in_class(_SRC / "session" / "frequency.py", "FrequencyTracker", "_match_weight")
+    def test_config_ref_floor(self) -> None:
+        func = _find_method_in_class(
+            _SRC / "session" / "frequency.py",
+            "FrequencyTracker",
+            "_match_weight",
+        )
         source = ast.get_source_segment(
             (_SRC / "session" / "frequency.py").read_text(encoding="utf-8"), func
         )
@@ -103,7 +136,7 @@ class TestFrequencyFloorLiterals:
 class TestNoSelfmodConfigField:
     """Pin 5: no field containing 'selfmod' in PetasosConfig."""
 
-    def test_no_selfmod_in_config(self):
+    def test_no_selfmod_in_config(self) -> None:
         tree = ast.parse((_SRC / "config.py").read_text(encoding="utf-8"))
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef) and node.name == "PetasosConfig":
@@ -113,10 +146,17 @@ class TestNoSelfmodConfigField:
                             f"PetasosConfig has a field containing 'selfmod': {item.target.id}"
                         )
 
-    def test_no_selfmod_in_field_meta(self):
+    def test_no_selfmod_in_field_meta(self) -> None:
         source = (_SRC / "console" / "_config_meta.py").read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.walk(tree):
-            if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                if "selfmod" in node.value.lower():
-                    assert False, f"_config_meta.py contains a selfmod-related string: {node.value!r}"
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and "selfmod" in node.value.lower()
+            ):
+                msg = (
+                    f"_config_meta.py contains a selfmod-related string:"
+                    f" {node.value!r}"
+                )
+                raise AssertionError(msg)

--- a/tests/test_selfmod_floor_shape.py
+++ b/tests/test_selfmod_floor_shape.py
@@ -1,0 +1,122 @@
+"""Shape/static tests pinning the selfmod floor (PET-164 Decision 12)."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "petasos"
+
+
+def _parse_function(filepath: Path, func_name: str) -> ast.FunctionDef:
+    """Parse a file and return the named function's AST node."""
+    tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return node
+    raise ValueError(f"{func_name} not found in {filepath}")
+
+
+def _find_method_in_class(filepath: Path, class_name: str, method_name: str) -> ast.FunctionDef:
+    tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == method_name:
+                    return item
+    raise ValueError(f"{class_name}.{method_name} not found in {filepath}")
+
+
+class TestRecordSelfmodShape:
+    """Pin 1: record_selfmod has exactly one config gate: _is_enabled("audit")."""
+
+    def test_single_is_enabled_gate(self):
+        func = _find_method_in_class(_SRC / "pipeline.py", "Pipeline", "record_selfmod")
+        source = ast.dump(func)
+        count = source.count("_is_enabled")
+        assert count == 1, f"expected exactly 1 _is_enabled call, found {count}"
+
+    def test_is_enabled_audit_only(self):
+        func = _find_method_in_class(_SRC / "pipeline.py", "Pipeline", "record_selfmod")
+        calls = [
+            node for node in ast.walk(func)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_is_enabled"
+        ]
+        assert len(calls) == 1
+        arg = calls[0].args[0]
+        assert isinstance(arg, ast.Constant) and arg.value == "audit"
+
+
+class TestGuardSelfmodWeightShape:
+    """Pin 2: _record_selfmod_weight uses requires_token, not session_secret config-if."""
+
+    def test_uses_requires_token(self):
+        func = _find_method_in_class(_SRC / "session" / "guard.py", "ToolCallGuard", "_record_selfmod_weight")
+        source = ast.dump(func)
+        assert "requires_token" in source
+
+    def test_no_session_secret_if(self):
+        func = _find_method_in_class(_SRC / "session" / "guard.py", "ToolCallGuard", "_record_selfmod_weight")
+        source = ast.dump(func)
+        assert "session_secret" not in source
+
+
+class TestEvaluateSelfmodShape:
+    """Pin 3: evaluate_selfmod contains 'critical' and no _rule_cooldowns access."""
+
+    def test_contains_critical_literal(self):
+        func = _find_method_in_class(_SRC / "session" / "alerting.py", "AlertManager", "evaluate_selfmod")
+        source = ast.dump(func)
+        assert "'critical'" in source or '"critical"' in source or "critical" in source
+
+    def test_no_rule_cooldowns_access(self):
+        func = _find_method_in_class(_SRC / "session" / "alerting.py", "AlertManager", "evaluate_selfmod")
+        source = ast.dump(func)
+        assert "_rule_cooldowns" not in source
+
+
+class TestFrequencyFloorLiterals:
+    """Pin 4: inline floor literals in _match_weight."""
+
+    def test_config_write_floor(self):
+        func = _find_method_in_class(_SRC / "session" / "frequency.py", "FrequencyTracker", "_match_weight")
+        source = ast.get_source_segment(
+            (_SRC / "session" / "frequency.py").read_text(encoding="utf-8"), func
+        )
+        assert source is not None
+        assert "10.0" in source
+        assert "petasos.selfmod.config_write" in source
+
+    def test_config_ref_floor(self):
+        func = _find_method_in_class(_SRC / "session" / "frequency.py", "FrequencyTracker", "_match_weight")
+        source = ast.get_source_segment(
+            (_SRC / "session" / "frequency.py").read_text(encoding="utf-8"), func
+        )
+        assert source is not None
+        assert "3.0" in source
+        assert "petasos.selfmod.config_ref" in source
+
+
+class TestNoSelfmodConfigField:
+    """Pin 5: no field containing 'selfmod' in PetasosConfig."""
+
+    def test_no_selfmod_in_config(self):
+        tree = ast.parse((_SRC / "config.py").read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "PetasosConfig":
+                for item in node.body:
+                    if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                        assert "selfmod" not in item.target.id.lower(), (
+                            f"PetasosConfig has a field containing 'selfmod': {item.target.id}"
+                        )
+
+    def test_no_selfmod_in_field_meta(self):
+        source = (_SRC / "console" / "_config_meta.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if "selfmod" in node.value.lower():
+                    assert False, f"_config_meta.py contains a selfmod-related string: {node.value!r}"

--- a/tests/test_selfmod_floor_shape.py
+++ b/tests/test_selfmod_floor_shape.py
@@ -99,8 +99,12 @@ class TestEvaluateSelfmodShape:
             "AlertManager",
             "evaluate_selfmod",
         )
-        source = ast.dump(func)
-        assert "'critical'" in source or '"critical"' in source or "critical" in source
+        constants = {
+            node.value
+            for node in ast.walk(func)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        assert "critical" in constants
 
     def test_no_rule_cooldowns_access(self) -> None:
         func = _find_method_in_class(

--- a/tests/test_subagent_plugin_wiring.py
+++ b/tests/test_subagent_plugin_wiring.py
@@ -171,6 +171,8 @@ class _FakeGuardResult:
     reason = "blocked"
     param_scan_unsafe = False
     findings: list[Any] = []
+    selfmod_target = None
+    selfmod_finding = None
 
 
 class TestArmDisarmGate:


### PR DESCRIPTION
## Summary
- Add `petasos.selfmod.*` finding family: detection-only classification of agent tool calls targeting Petasos-owned config surfaces (config.yaml, profile homes, enforcement spool, console token API)
- Side-effect-free on allow/deny (PET-125 intact); escalation via floor-protected frequency weights (10.0/3.0) through the ordinary tier channel
- Dedicated cooldown-exempt alert delivery, unsuppressible by any config toggle except the documented master switches

## Two-layer detection

| Rule id | Trigger | Severity | Weight floor |
|---------|---------|----------|-------------|
| `petasos.selfmod.config_write` | Non-read-only tool, top-level arg value *equals* an owned path | CRITICAL | 10.0 |
| `petasos.selfmod.config_ref` | Non-read-only tool, owned path *contained* in any arg part | HIGH | 3.0 |
| `petasos.selfmod.console_probe` | Console `/api/*` 401 (token armed) | CRITICAL | n/a |

## Files changed

| File | Change |
|------|--------|
| `petasos/session/guard.py` | `READ_ONLY_TOOLS` frozenset (promoted); `_classify_selfmod()` detector; `GuardResult.selfmod_target/selfmod_finding` fields; post-verdict frequency update |
| `petasos/pipeline.py` | `record_selfmod()` (alert + audit only); `_is_floor_rule()` gains selfmod prefix |
| `petasos/session/frequency.py` | `DEFAULT_FREQUENCY_WEIGHTS` entries + inline floor literals in `_match_weight()` |
| `petasos/session/alerting.py` | `evaluate_selfmod()` delivery path (per-rule_id critical cap) |
| `petasos/session/profiles/__init__.py` | `_validate_suppress_rules()` strips `petasos.selfmod.*` |
| `docs/deployment/reference_plugin/__init__.py` | Import `READ_ONLY_TOOLS` from guard; emit spool `selfmod_attempt` |
| `petasos/console/_paths.py` | `display_path()`, `spool_path()`, `spool_rot_path()` hoisted |
| `petasos/console/_events.py` | Delegates spool override to `_paths` |
| `petasos/console/server.py` | `_maybe_fire_console_probe()` on 401 seam |
| `docs/deployment/hardening.md` | Self-tamper detection limits paragraph |
| `tests/conftest.py` | Retarget `_SPOOL_PATH_OVERRIDE` to `_paths` |
| `tests/test_selfmod_detection.py` | New: 27 behavioral tests |
| `tests/test_selfmod_floor_shape.py` | New: 10 static/AST shape tests |
| `tests/adversarial/selfmod/test_selfmod_suppression_bypass.py` | New: adversarial suppression bypass suite |

## Test plan

- [x] `C:\python310\python.exe -m pytest tests/ -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` -- 2211/2211 pass (full output: docs/specs/TODO/PET-164.test-output.txt)
- [x] Shape/static tests pin all five floor invariants (Decision 12)
- [x] Adversarial tests: weight zeroing, alert_enabled: false, frequency_enabled: false, inflated thresholds, profile suppress_rules, severity_overrides, all built-in profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection-only self-tamper classification for tool calls targeting protected configuration paths, including critical/high severity, rate-limited alerting, and frequency “floor” escalation.
  * Added console access probing on failed authentication attempts (does not affect access outcomes).
  * Added enforcement spool path override support and improved user-friendly path display.
* **Documentation**
  * Documented self-tamper behavior, operator tuning knobs, known detection misses/tripwires, and false-positive guidance.
* **UI Updates**
  * Updated console event rendering for self-tamper attempts with an amber badge and dedicated “Self-tamper attempt” detection-only details.
* **Tests**
  * Expanded self-tamper, suppression, frequency-weight, and console UI rendering coverage (including edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->