### PR TITLE
feat(pet-165): console self-tamper tile, history filter, severity badges

### DIFF
--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -368,7 +368,10 @@ path was matched in that case. The OS boundary remains the containment
 mechanism; this layer is a
 tripwire. An unlisted read-only tool whose top-level arg *is* the owned path
 classifies as `config_write` even when the tool only reads (accepted FP
-direction; widen `READ_ONLY_TOOLS` as needed).
+direction; widen `READ_ONLY_TOOLS` as needed). Console 401 probe attempts
+(`petasos.selfmod.console_probe`) surface via alerts and the audit trail only:
+they write no enforcement-spool event, so they do not appear in the console
+scan history, its self-tamper filter, or the self-tamper tile.
 
 **Operator note (legitimate config edits escalate).** The frequency weights do
 not distinguish an operator-directed edit session from an attack: rapid

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -574,6 +574,10 @@ class ConsoleHandlers:
         # (mirrors the PET-131/138 tally pattern): monotonic, in-memory, resets on a
         # dashboard restart by design. A single scalar, so no per-session bound.
         self._scans_total = 0
+        # PET-165: eviction-proof lifetime count of surfaced self-tamper attempts, feeding
+        # the console tile. Same lifecycle as _scans_total (in-memory, resets on a dashboard
+        # restart by design); see the ingest seam for the not-integrity-gated rationale.
+        self._selfmod_total = 0
         # One-shot guard so the first ring overflow logs exactly once per run, not per scan.
         self._ring_overflow_warned = False
         # PET-157: self-diagnosing integrity state. `_integrity_recent` is a bounded window of
@@ -818,6 +822,14 @@ class ConsoleHandlers:
             cnt = ev.get("bypassed_count")
             if isinstance(sid, str) and sid and type(cnt) is int and cnt > 0:
                 self._set_bypass_tally(sid, max(self.bypass_tally_for(sid), cnt))
+        elif ev.get("event_type") == "selfmod_attempt":
+            # PET-165: eviction-proof lifetime tally for the console tile. Not
+            # integrity-gated (detection-only surfacing, same posture as the bypass
+            # tally above, never a trusted-block claim); exactly-once comes from the
+            # shared forward-offset / .rot drain discipline. Residual: a forged spool
+            # row can inflate the tile, so the per-row provenance flag and the audit
+            # trail remain the trusted record.
+            self._selfmod_total += 1
         await self.sse.broadcast("scan_result", summary)
 
     async def _drain_and_clear_rot(self, rot_path: str) -> None:
@@ -1333,6 +1345,9 @@ class ConsoleHandlers:
                 "config_hash": config_hash,
                 "uptime_seconds": round(time.monotonic() - self._start_time, 1),
                 "scans_total": self._scans_total,  # PET-144: eviction-proof lifetime count
+                # PET-165: eviction-proof lifetime self-tamper count feeding the console
+                # tile. Additive key; existing consumers ignore unknown keys (PET-157 D5).
+                "selfmod_total": self._selfmod_total,
                 # PET-148 (D-DRIFT): single source of truth for the ring window size so the
                 # frontend never hardcodes a second 500 that could drift from the backend.
                 "scan_history_capacity": _SCAN_HISTORY_RING_CAPACITY,

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -218,9 +218,17 @@
 .pet .seg { display: inline-flex; background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--r-card); padding: 2px; gap: 2px; }
 .pet .seg button { height: 26px; padding: 0 14px; border: none; background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--tx-mut); border-radius: 5px; transition: background .12s, color .12s; }
 .pet .seg button.on { background: var(--acc); color: var(--color-primary-foreground, #fff); }
-/* PET-165: size modifier only, so a .seg can ride in the 38px panel head (scan-history filter). */
+/* PET-165: a .seg sized to ride in the 38px panel head (scan-history filter), with a
+   restrained on-state. The default resting state of that control is "all", so the shared
+   full-accent fill would make the brightest element in the whole panel head mean "nothing
+   is filtered" — a permanent false positive competing with the severity badges below it.
+   The neutral on-state reads as current-selection; seg-alert fires only while the filter
+   is actually withholding rows, in the same amber as the self-tamper tile and badges. */
 .pet .seg.seg-sm { padding: 1px; }
 .pet .seg.seg-sm button { height: 22px; padding: 0 9px; font-size: 10px; }
+.pet .seg.seg-sm button:hover { color: var(--tx-bright); background: var(--bg-hover); }
+.pet .seg.seg-sm button.on { background: var(--bg-active); color: var(--tx-bright); }
+.pet .seg.seg-sm button.on.seg-alert { background: var(--amber-soft); color: var(--amber-bright); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--amber) 45%, transparent); }
 
 /* ── PET-124: strength-preset "tuning dial" (Config Editor) ── */
 .pet .pet-dial-host { flex: 0 0 auto; }

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -218,6 +218,9 @@
 .pet .seg { display: inline-flex; background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--r-card); padding: 2px; gap: 2px; }
 .pet .seg button { height: 26px; padding: 0 14px; border: none; background: transparent; cursor: pointer; font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--tx-mut); border-radius: 5px; transition: background .12s, color .12s; }
 .pet .seg button.on { background: var(--acc); color: var(--color-primary-foreground, #fff); }
+/* PET-165: size modifier only, so a .seg can ride in the 38px panel head (scan-history filter). */
+.pet .seg.seg-sm { padding: 1px; }
+.pet .seg.seg-sm button { height: 22px; padding: 0 9px; font-size: 10px; }
 
 /* ── PET-124: strength-preset "tuning dial" (Config Editor) ── */
 .pet .pet-dial-host { flex: 0 0 auto; }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -347,6 +347,15 @@
     // Dedicated, eviction-proof state (the count rides a single rate-limited
     // heartbeat row that ages out of scanHistory); fed by Pet.accrueBypass.
     bypassBySession: {},
+    // PET-165: server-authoritative lifetime count of surfaced self-tamper attempts,
+    // feeding the "self-tamper" metric tile. Seeded from /health (pipeline.selfmod_total)
+    // and incremented per SSE selfmod frame, so the tile never decays when the 500-entry
+    // ring evicts the underlying rows. Lifetime-since-console-start, not persisted.
+    selfmodTotal: 0,
+    // PET-165: scan-history row filter, "all" or "selfmod". Filters RENDERED rows only,
+    // never the buffer and never a tile value. Live-head only (paged views render
+    // unfiltered); per-page-load, not persisted.
+    historyFilter: "all",
     // PET-137: scan_id of the scan-history row whose detail panel is open (or null).
     // Persisted in state (not local DOM) so the panel survives renderDashboard's
     // per-SSE-frame rebuild; re-opened by scan_id, so an evicted row closes cleanly.
@@ -504,6 +513,7 @@
             Pet.state.scannerHealth = h.scanners || [];
             Pet.state.pipelineHealth = h.pipeline || null;
             Pet.state.integrityHealth = h.integrity || null; // PET-157: mirror pipelineHealth
+            Pet.adoptSelfmodTotal(Pet.state.pipelineHealth); // PET-165: re-sync the tile count
           }
           startPolling();
           if (Pet.sse && Pet.sse.connect) Pet.sse.connect();
@@ -763,6 +773,10 @@
         if (d && typeof d === "object") {
           Pet.state.scanHistory.unshift(d);
           Pet.accrueBypass([d]); // PET-138: fold this frame's bypass count into state
+          // PET-165: live-increment the self-tamper tile (the arm already guarantees d is
+          // an object). The next /health adoption re-syncs against the server counter, so
+          // a frame seen either side of the seed snapshot self-heals within one poll.
+          if (d.event_type === "selfmod_attempt") Pet.state.selfmodTotal += 1;
           // PET-13: announce the newest verdict to AT; the wholesale re-render below
           // is not screen-reader-followable on its own.
           var _v = d.safe === false ? "blocked" : "allowed";
@@ -833,6 +847,7 @@
           Pet.state.scannerHealth = d.scanners || [];
           Pet.state.pipelineHealth = d.pipeline || null;
           Pet.state.integrityHealth = d.integrity || null; // PET-157: mirror pipelineHealth (recurring poll)
+          Pet.adoptSelfmodTotal(Pet.state.pipelineHealth); // PET-165: re-sync the tile count
           if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
         }
       });
@@ -1267,8 +1282,23 @@
       var isSelfmodRow = isEnforcement && et === "selfmod_attempt";
       var isBlocked = (e.safe === false); // strict ===false; truthy-but-not-false is not "blocked"
 
-      var badgeText = isBypass ? "bypassed (disarmed)" : (isSelfmodRow ? "self-tamper" : (isBlocked ? "blocked" : "safe"));
-      var badgeClass = (isBypass || isSelfmodRow) ? "warn" : (isBlocked ? "err" : "ok");
+      // PET-165: severity-differentiated self-tamper badge. Severity rides the badge TEXT
+      // as well as the class, so the critical/high distinction never depends on color
+      // alone. Keys on the row's `severity` field (already in the spool summary), not on
+      // rule_id, so a future selfmod rule renders correctly with no frontend change.
+      // Anything other than the two known severities (missing, null, nonsense, a non-string)
+      // falls back to the pre-PET-165 plain amber "self-tamper" — never throws, never
+      // renders "undefined".
+      var selfmodSev = "";
+      if (isSelfmodRow && (e.severity === "critical" || e.severity === "high")) selfmodSev = e.severity;
+      var badgeText = isBypass
+        ? "bypassed (disarmed)"
+        : (isSelfmodRow
+            ? ("self-tamper" + (selfmodSev ? (" (" + selfmodSev + ")") : ""))
+            : (isBlocked ? "blocked" : "safe"));
+      var badgeClass = isBypass
+        ? "warn"
+        : (isSelfmodRow ? (selfmodSev === "critical" ? "err" : "warn") : (isBlocked ? "err" : "ok"));
       var badge = Pet.h("span", { className: "pill " + badgeClass, style: { justifyContent: "center" } }, badgeText);
 
       var rowEls = [];
@@ -1314,7 +1344,9 @@
         rowAttrs.role = "button";
         rowAttrs.tabIndex = 0;
         rowAttrs.ariaExpanded = isOpen;
-        rowAttrs.ariaLabel = (isSelfmodRow ? "self-tamper detection" : (isEnforcement ? "enforcement" : "playground")
+        // PET-165: AT hears the severity too (spoken, not parenthesized), so the
+        // critical/high split is not a purely visual distinction.
+        rowAttrs.ariaLabel = (isSelfmodRow ? ("self-tamper detection" + (selfmodSev ? (", " + selfmodSev) : "")) : (isEnforcement ? "enforcement" : "playground")
           + " scan") + " row, " + (isOpen ? "expanded" : "collapsed") + ", activate to toggle detail";
         rowAttrs.onClick = toggle;
         rowAttrs.onKeydown = makeKey(toggle);
@@ -1393,6 +1425,66 @@
     var total = 0;
     for (var i = 0; i < keys.length; i++) total += (Number(map[keys[i]]) || 0);
     return total;
+  };
+
+  // PET-165: the single adoption seam for the server-authoritative self-tamper lifetime
+  // count. Every site that assigns Pet.state.pipelineHealth calls this with the same
+  // payload, so the three health-settle paths (auth resume, the 10s poll, the cold-mount
+  // in-render fetch) cannot diverge. Strict number gate first (mirrors accrueBypass): a
+  // missing/null/boolean/string/NaN/negative value LEAVES the current count rather than
+  // writing NaN or a false zero into the tile. Adoption is a plain overwrite, never a
+  // monotonic max: overwrite is what makes a console restart honestly reset the tile
+  // (lifetime-since-start semantics). The cost is a <=10s downward flicker when a health
+  // snapshot taken before an SSE-counted event lands after the client increment; it
+  // self-heals on the next poll, and the tile is glanceability, not the audit record.
+  Pet.adoptSelfmodTotal = function (pipeline) {
+    if (!pipeline || typeof pipeline !== "object") return;
+    var n = pipeline.selfmod_total;
+    if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return;
+    Pet.state.selfmodTotal = n;
+  };
+
+  // PET-165: pure row-filter seam for the scan-history pane (testable like
+  // Pet.mergeScanHistory / Pet.bypassTotal). Only the "selfmod" filter narrows; every
+  // other value (including "all") returns the input UNCHANGED, so the default path is
+  // byte-identical to pre-PET-165 rendering. Malformed entries are dropped by the
+  // narrowing branch rather than thrown on (matches the scanHistoryRows shape guard).
+  // Never mutates the buffer and never feeds a tile.
+  Pet.filterHistoryRows = function (entries, filter) {
+    if (filter !== "selfmod") return entries;
+    var out = [];
+    if (!entries || typeof entries.length !== "number") return out;
+    for (var i = 0; i < entries.length; i++) {
+      var e = entries[i];
+      if (e && typeof e === "object" && e.event_type === "selfmod_attempt") out.push(e);
+    }
+    return out;
+  };
+
+  // PET-165: filter-toggle handler. The filter is a LIVE-HEAD view: selecting
+  // "self-tamper" from a paged-back view snaps to the head first (via the existing
+  // historyPagingView "head" transition), because a filtered slice of one older page
+  // would read as "these are the self-tamper events" when it is only the events in that
+  // page. Paged views therefore always render unfiltered. Announces for AT, then
+  // re-renders through the normal renderDashboard path.
+  Pet.setHistoryFilter = function (filter) {
+    var next = (filter === "selfmod") ? "selfmod" : "all";
+    var atHead = Pet.state.historyAtHead !== false;
+    if (next === Pet.state.historyFilter && atHead) return; // nothing to change
+    Pet.state.historyFilter = next;
+    if (next === "selfmod" && !atHead) {
+      var plan = Pet.historyPagingView(
+        { atHead: Pet.state.historyAtHead, stack: Pet.state.historyStack }, "head"
+      );
+      Pet.state.historyAtHead = plan.atHead;
+      Pet.state.historyStack = plan.stack;
+    }
+    if (Pet.announce) {
+      Pet.announce(next === "selfmod"
+        ? "Scan history filtered to self-tamper events"
+        : "Scan history filter cleared, showing all rows");
+    }
+    if (_container) Pet.renderDashboard(_container);
   };
 
   // PET-144: honest scan-history subtitle. The ≤500 ring evicts silently; when the
@@ -1722,6 +1814,11 @@
     // PET-138: "bypassed (disarmed)" total — sum of the dedicated per-session
     // accumulator (NOT recomputed from the buffer, so it survives row eviction).
     var bypassed = Pet.bypassTotal();
+    // PET-165: "self-tamper" total — the server-authoritative lifetime count adopted from
+    // /health and live-incremented over SSE, NOT recomputed from the buffer. A buffer-scoped
+    // count would silently decay to 0 once 500 ordinary scans evicted the tamper rows, and
+    // the highest-stakes signal is precisely the one that must not decay.
+    var selfmodTotal = Number(Pet.state.selfmodTotal) || 0;
 
     var metricsRow = Pet.h("div", { style: { display: "flex", gap: "10px" } });
     // Lean metric cells (not four identical icon-panels): an eyebrow label over a
@@ -1744,6 +1841,8 @@
     metricsRow.appendChild(valueTile("avg latency", avgLatency, false));
     metricsRow.appendChild(valueTile("sessions", sessions, false));
     metricsRow.appendChild(valueTile("bypassed (disarmed)", bypassed, false));
+    // PET-165: alert styling whenever nonzero (like `blocked`); an honest literal 0 otherwise.
+    metricsRow.appendChild(valueTile("self-tamper", selfmodTotal, selfmodTotal > 0));
     wrapper.appendChild(metricsRow);
 
     // Scanner health
@@ -1784,9 +1883,15 @@
     var histAtHead = Pet.state.historyAtHead !== false;
     var histStack = Pet.state.historyStack || [];
     var histPaged = (!histAtHead && histStack.length) ? histStack[histStack.length - 1] : null;
+    // PET-165: the row filter narrows the LIVE HEAD only. A paged-back view is a slice of
+    // older history, so filtering it would present "the self-tamper events in this page" as
+    // "the self-tamper events"; paged views therefore always render unfiltered and the
+    // control reads its on-state from the effective filter below.
+    var histFilter = (Pet.state.historyFilter === "selfmod") ? "selfmod" : "all";
+    var histEffFilter = histPaged ? "all" : histFilter;
     var histRowsData = histPaged
       ? (Array.isArray(histPaged.entries) ? histPaged.entries : [])
-      : hist;
+      : Pet.filterHistoryRows(hist, histEffFilter);
     var histSubtitle = histPaged
       ? Pet.historyPageLabel(histPaged)
       : Pet.scanHistorySubtitle(
@@ -1822,14 +1927,40 @@
     }
     // Body: rows for the active view, or the retention-honest empty state when a paged-back
     // view came back empty (never "no scans yet" — that is the live-head empty state).
-    var histBody = (histPaged && histRowsData.length === 0)
-      ? Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, Pet.historyPageLabel(histPaged))
-      : Pet.scanHistoryRows(histRowsData);
+    var histBody;
+    if (histPaged && histRowsData.length === 0) {
+      histBody = Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, Pet.historyPageLabel(histPaged));
+    } else if (histEffFilter === "selfmod" && histRowsData.length === 0) {
+      // PET-165: filtered-empty is its own honest state, distinct from the loading skeleton
+      // and from "no scans yet". Phrased against the WINDOW because the PET-144 eviction
+      // subtitle still applies: this is a view of the <=500-row buffer, not of all history.
+      histBody = Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, "No self-tamper events in the buffered window.");
+    } else {
+      histBody = Pet.scanHistoryRows(histRowsData);
+    }
+
+    // PET-165: the one history filter dimension (no filter framework). Reuses the existing
+    // .seg segmented primitive (PET-122/PET-124) so it inherits the shipped focus-visible and
+    // on-state styling; seg-sm is the only new CSS, sizing it for the 38px panel head.
+    var histFilterSeg = Pet.h("div", { className: "seg seg-sm", role: "radiogroup", ariaLabel: "Scan history filter" });
+    histFilterSeg.appendChild(Pet.h("button", {
+      className: histEffFilter === "all" ? "on" : "", type: "button", role: "radio",
+      ariaChecked: histEffFilter === "all",
+      onClick: function () { Pet.setHistoryFilter("all"); },
+    }, "all"));
+    histFilterSeg.appendChild(Pet.h("button", {
+      className: histEffFilter === "selfmod" ? "on" : "", type: "button", role: "radio",
+      ariaChecked: histEffFilter === "selfmod",
+      onClick: function () { Pet.setHistoryFilter("selfmod"); },
+    }, "self-tamper"));
 
     var historyPanel = Pet.Panel({
       icon: "list", title: "scan history", flush: true,
       // PET-144/PET-148: lifetime "last N of M" at the head; a positional label when paged.
+      // PET-165: the subtitle reads the UNFILTERED buffered length, so filtering never
+      // rewrites the eviction headline into a false "showing last 3 of N".
       place: histSubtitle,
+      right: histFilterSeg,
       help: Pet.HelpTip("<b>Scan History</b>: recent pipeline scans with severity, direction, and timing. Each row is one <code>Pipeline.evaluate()</code> call. <b>Older</b>/<b>Newer</b> page through retained history beyond the live window."),
       content: Pet.h("div", { style: { padding: "12px" } }, histBody, histControls),
     });
@@ -1865,6 +1996,7 @@
         Pet.state.scannerHealth = d.scanners || [];
         Pet.state.pipelineHealth = d.pipeline || null;
         Pet.state.integrityHealth = d.integrity || null; // PET-157: mirror pipelineHealth (cold-mount settle)
+        Pet.adoptSelfmodTotal(Pet.state.pipelineHealth); // PET-165: seed the tile count on cold mount
         var rows = Pet.scannerHealthRows(Pet.state.scannerHealth);
         var contentEl = healthPanel.querySelector("[style*='padding: 12px']") || healthPanel.querySelector("div > div");
         if (contentEl) { contentEl.innerHTML = ""; contentEl.appendChild(rows); }

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1820,20 +1820,38 @@
     // the highest-stakes signal is precisely the one that must not decay.
     var selfmodTotal = Number(Pet.state.selfmodTotal) || 0;
 
-    var metricsRow = Pet.h("div", { style: { display: "flex", gap: "10px" } });
+    // PET-165: wrap instead of crushing. Six tiles at flex:"1" squeezed the eyebrow
+    // labels until "BYPASSED (DISARMED)" wrapped and its value dropped out of line with
+    // its neighbours below ~1000px. A 170px basis is wide enough for the longest label
+    // on one line, so the row reflows into two tidy rows rather than degrading in place.
+    var metricsRow = Pet.h("div", { style: { display: "flex", gap: "10px", flexWrap: "wrap" } });
     // Lean metric cells (not four identical icon-panels): an eyebrow label over a
     // value. `blocked` carries severity weight when > 0 so the one security-load-
     // bearing number stands out instead of looking like `sessions`.
-    var valueTile = function (label, value, alert) {
+    // PET-165: `opts.tone` selects WHICH alert palette. `blocked` keeps crit red;
+    // self-tamper takes amber, because PET-164 fixed amber as the self-tamper channel
+    // colour precisely so red stays reserved for actual blocks. Two identically-red
+    // tiles would read as the same severity when they are not: `blocked` is routine
+    // enforcement over the buffered window, self-tamper is the guarded thing attacking
+    // the guard. `opts.help` hangs a HelpTip off the label for tiles whose counting
+    // scale is not obvious from the number alone.
+    var valueTile = function (label, value, alert, opts) {
+      opts = opts || {};
+      var hue = opts.tone === "amber" ? "var(--amber)" : "var(--crit)";
+      var soft = opts.tone === "amber" ? "var(--amber-soft)" : "var(--crit-soft)";
+      var head = Pet.h("div", { style: { display: "flex", alignItems: "center", gap: "5px", minHeight: "15px" } },
+        Pet.h("div", { className: "eyebrow" }, label)
+      );
+      if (opts.help) head.appendChild(opts.help);
       return Pet.h("div", {
         style: {
-          flex: "1", minWidth: "0", borderRadius: "var(--r-panel)", padding: "12px 14px",
-          background: alert ? "var(--crit-soft)" : "var(--bg-panel)",
-          border: "1px solid " + (alert ? "var(--crit)" : "var(--border)")
+          flex: "1 1 170px", minWidth: "0", borderRadius: "var(--r-panel)", padding: "12px 14px",
+          background: alert ? soft : "var(--bg-panel)",
+          border: "1px solid " + (alert ? hue : "var(--border)")
         }
       },
-        Pet.h("div", { className: "eyebrow" }, label),
-        Pet.h("div", { className: "num", style: { fontSize: "26px", marginTop: "4px", color: alert ? "var(--crit)" : "var(--tx-bright)" } }, String(value))
+        head,
+        Pet.h("div", { className: "num", style: { fontSize: "26px", marginTop: "4px", color: alert ? hue : "var(--tx-bright)" } }, String(value))
       );
     };
     metricsRow.appendChild(valueTile("scans", scans, false));
@@ -1841,8 +1859,15 @@
     metricsRow.appendChild(valueTile("avg latency", avgLatency, false));
     metricsRow.appendChild(valueTile("sessions", sessions, false));
     metricsRow.appendChild(valueTile("bypassed (disarmed)", bypassed, false));
-    // PET-165: alert styling whenever nonzero (like `blocked`); an honest literal 0 otherwise.
-    metricsRow.appendChild(valueTile("self-tamper", selfmodTotal, selfmodTotal > 0));
+    // PET-165: alert styling whenever nonzero, in amber (see valueTile). Sits last,
+    // beside `bypassed (disarmed)`: those two are the only lifetime, eviction-proof
+    // counters in the row, so the buffer-scoped four read as a block and the two
+    // differently-scaled ones are neighbours rather than scattered among them. The
+    // HelpTip carries the scale, since a bare number cannot say which window it counts.
+    metricsRow.appendChild(valueTile("self-tamper", selfmodTotal, selfmodTotal > 0, {
+      tone: "amber",
+      help: Pet.HelpTip("<b>Self-tamper</b>: tool calls that tried to write or read Petasos's own config, profile homes, or enforcement spool. Counted since this console started, so it does not fall when older rows age out of the scan history below. Detection only: these calls were not blocked."),
+    }));
     wrapper.appendChild(metricsRow);
 
     // Scanner health
@@ -1898,6 +1923,12 @@
           hist.length,
           Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
         );
+    // PET-165: the filter APPENDS to the subtitle, never rewrites it. The counts stay the
+    // unfiltered window's (so "showing last 500 of 1200" keeps meaning what PET-144 made
+    // it mean), but a list showing 2 of 500 buffered rows under a bare "recent evaluations"
+    // would misdescribe itself. One trailing clause fixes that without minting a second,
+    // filter-scoped total the operator would have to reconcile against the tile.
+    if (histEffFilter === "selfmod") histSubtitle = histSubtitle + " · self-tamper only";
     // PET-152: "Older" is offered when an older cursor exists (the paged view's next_before) or,
     // off the live head, when scanHistoryHasOlder reports retained rows older than the live window
     // — gated on the SAME lifetime scans_total the subtitle reads (:1631), never a cached seed
@@ -1948,8 +1979,10 @@
       ariaChecked: histEffFilter === "all",
       onClick: function () { Pet.setHistoryFilter("all"); },
     }, "all"));
+    // The active self-tamper segment takes the amber alert treatment (seg-alert), so the
+    // one moment this control is loud is the one moment it is actually withholding rows.
     histFilterSeg.appendChild(Pet.h("button", {
-      className: histEffFilter === "selfmod" ? "on" : "", type: "button", role: "radio",
+      className: histEffFilter === "selfmod" ? "on seg-alert" : "", type: "button", role: "radio",
       ariaChecked: histEffFilter === "selfmod",
       onClick: function () { Pet.setHistoryFilter("selfmod"); },
     }, "self-tamper"));

--- a/tests/js/selfmod-row.test.mjs
+++ b/tests/js/selfmod-row.test.mjs
@@ -1,12 +1,16 @@
-// Unit tests for selfmod_attempt rendering (petasos.js), PET-164.
+// Unit tests for selfmod_attempt rendering (petasos.js), PET-164 + PET-165.
 //
 // A self-tamper classification row (event_type === "selfmod_attempt") is
 // detection-only: the summary carries safe=true, but the row must never wear
-// the green "safe" badge (amber "self-tamper" instead; red stays reserved for
-// actual blocks). The drill-down must render rule/severity/reason and the
-// detection-only explainer, never the "Unknown row kind" fallback, and the
+// the green "safe" badge. The drill-down must render rule/severity/reason and
+// the detection-only explainer, never the "Unknown row kind" fallback, and the
 // provenance line must not claim a content scan ran. Labels carry no banned
 // dash (em / en / double-hyphen) per house style.
+//
+// PET-165 differentiates the badge by severity: config_write (critical) takes
+// the red `err` class, config_ref (high) stays amber `warn`, and the severity
+// rides the badge TEXT as well as the class so the distinction never depends on
+// color alone. Anything else falls back to the pre-PET-165 plain amber badge.
 //
 // Zero npm deps: Node's built-in test runner + a DOM shim + node:vm over the
 // real shipped petasos.js. Run with: node --test tests/js/selfmod-row.test.mjs
@@ -101,20 +105,62 @@ const ENF_SELFMOD = {
 
 // ── row tests ───────────────────────────────────────────────────────────────
 
-test("selfmod row: amber self-tamper badge, never the green safe badge", () => {
+test("selfmod row: self-tamper badge, never the green safe badge", () => {
   const tree = Pet.scanHistoryRows([ENF_SELFMOD]);
-  const badge = findEl(tree, (el) => hasClass("warn")(el) && el.textContent === "self-tamper");
-  assert.ok(badge, "expected a 'self-tamper' (pill warn) badge");
   assert.equal(
     findEl(tree, (el) => hasClass("ok")(el) && el.textContent === "safe"),
     null,
     "selfmod row must not wear the green 'safe' badge"
   );
-  assert.equal(findEl(tree, hasClass("err")), null, "selfmod is detection only, not a blocked/err badge");
+  assert.ok(findEl(tree, (el) => /^self-tamper/.test(el.textContent)), "self-tamper badge present");
+  assert.equal(findEl(tree, (el) => el.textContent === "blocked"), null, "selfmod is detection only, never 'blocked'");
   const enfPill = findEl(tree, hasClass("blue"));
   assert.ok(enfPill && enfPill.textContent === "enf", "enf source pill present");
   assert.ok(text(tree).includes("selfmod_attempt"), "event_type rendered");
   assert.ok(text(tree).includes("write_file"), "tool rendered");
+});
+
+// ── PET-165: severity-differentiated badges ─────────────────────────────────
+
+const badgeOf = (row) =>
+  findEl(Pet.scanHistoryRows([row]), (el) => /^self-tamper/.test(el.textContent));
+
+test("PET-165 badge: critical severity takes the err class and says so in text", () => {
+  const badge = badgeOf(ENF_SELFMOD); // severity: "critical"
+  assert.ok(badge, "badge rendered");
+  assert.equal(badge.textContent, "self-tamper (critical)");
+  assert.ok(hasClass("err")(badge), "critical rides the red err class, not amber");
+});
+
+test("PET-165 badge: high severity stays amber and says so in text", () => {
+  const badge = badgeOf({
+    ...ENF_SELFMOD,
+    rule_id: "petasos.selfmod.config_ref",
+    severity: "high",
+  });
+  assert.ok(badge, "badge rendered");
+  assert.equal(badge.textContent, "self-tamper (high)");
+  assert.ok(hasClass("warn")(badge), "high stays on the amber warn class");
+});
+
+test("PET-165 badge: missing / nonsense severity falls back to the plain amber badge", () => {
+  // The exact pre-PET-165 rendering, so an unrecognized severity can never produce a
+  // half-formed label like "self-tamper (undefined)" or throw mid-render.
+  for (const severity of [undefined, null, "", "SEVERE", "Critical", 3, {}, ["high"], true]) {
+    const row = { ...ENF_SELFMOD, severity };
+    let badge;
+    assert.doesNotThrow(() => { badge = badgeOf(row); }, `severity ${JSON.stringify(severity)} threw`);
+    assert.equal(badge.textContent, "self-tamper", `severity ${JSON.stringify(severity)} must fall back`);
+    assert.ok(hasClass("warn")(badge), "fallback stays amber");
+  }
+});
+
+test("PET-165 badge: severity does not leak onto non-selfmod rows", () => {
+  // The mapping keys on the row's severity only WITHIN a selfmod row; an ordinary
+  // enforcement block row carrying a severity keeps its own badge text.
+  const block = { source: "enforcement", event_type: "block", safe: false, severity: "critical", scan_id: "e-b1" };
+  const badge = findEl(Pet.scanHistoryRows([block]), (el) => el.textContent === "blocked");
+  assert.ok(badge, "block row still reads 'blocked', not a severity-suffixed label");
 });
 
 // ── drill-down tests ────────────────────────────────────────────────────────

--- a/tests/js/selfmod-tile-filter.test.mjs
+++ b/tests/js/selfmod-tile-filter.test.mjs
@@ -1,0 +1,296 @@
+// Unit tests for the PET-165 self-tamper tile count and scan-history filter
+// (petasos.js).
+//
+// The tile reads a SERVER-AUTHORITATIVE lifetime count (`/health`
+// `pipeline.selfmod_total`), adopted through one seam and live-incremented over
+// SSE, rather than being derived from the <=500-entry scanHistory ring. That is
+// the whole point: a buffer-scoped tamper count decays to 0 once 500 ordinary
+// scans evict the tamper rows, and the highest-stakes signal is precisely the
+// one that must not decay silently.
+//
+// The filter is a pure client-side seam over the same buffer: it narrows
+// RENDERED rows only, never the buffer and never a tile value, and it applies to
+// the live head only (a filtered slice of one older page would read as the whole
+// truth).
+//
+// Zero npm deps: Node's built-in test runner + a DOM shim + node:vm over the
+// real shipped petasos.js. Run with: node --test tests/js/selfmod-tile-filter.test.mjs
+//
+// Harness pin (cross-realm trap): objects built inside the node:vm realm do NOT
+// share this realm's Object.prototype, so assert.deepEqual(x, {}) fails on a
+// Pet.state object even when it is empty. Assert emptiness via
+// Object.keys(x).length instead.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── DOM shim (same as selfmod-row.test.mjs) ─────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    dataset: {},
+    _text: "",
+    setAttribute() {},
+    addEventListener() {},
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
+    },
+    set textContent(v) {
+      this._text = String(v);
+      this.childNodes = [];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+const selfmodRow = (scan_id, severity = "critical") => ({
+  source: "enforcement",
+  safe: true,
+  event_type: "selfmod_attempt",
+  tool: "write_file",
+  rule_id: "petasos.selfmod.config_write",
+  severity,
+  session_id: "sess-sm",
+  scan_id,
+});
+const scanRow = (scan_id) => ({ source: "playground", safe: true, direction: "inbound", scan_id });
+const blockRow = (scan_id) => ({ source: "enforcement", safe: false, event_type: "block", scan_id });
+
+function resetState() {
+  Pet.state.selfmodTotal = 0;
+  Pet.state.historyFilter = "all";
+  Pet.state.historyAtHead = true;
+  Pet.state.historyStack = [];
+  Pet.state.scanHistory = [];
+  Pet.state.bypassBySession = {};
+}
+
+// ── tile: adoption from /health ─────────────────────────────────────────────
+
+test("adoptSelfmodTotal: adopts a valid non-negative count", () => {
+  resetState();
+  Pet.adoptSelfmodTotal({ scans_total: 12, selfmod_total: 4 });
+  assert.equal(Pet.state.selfmodTotal, 4);
+  Pet.adoptSelfmodTotal({ selfmod_total: 0 });
+  assert.equal(Pet.state.selfmodTotal, 0, "an honest zero is adoptable, not treated as absent");
+});
+
+test("adoptSelfmodTotal: ignores missing / negative / non-numeric, never writes NaN", () => {
+  // Leaving the current value is the honest failure mode: a health payload from an
+  // older server (no such key) or a malformed one must not blank or NaN the tile.
+  for (const pipeline of [
+    undefined, null, {}, "nope", 7,
+    { selfmod_total: undefined },
+    { selfmod_total: null },
+    { selfmod_total: -1 },
+    { selfmod_total: NaN },
+    { selfmod_total: Infinity },
+    { selfmod_total: "5" },
+    { selfmod_total: true },
+    { selfmod_total: [5] },
+  ]) {
+    resetState();
+    Pet.state.selfmodTotal = 3;
+    assert.doesNotThrow(() => Pet.adoptSelfmodTotal(pipeline), `threw on ${JSON.stringify(pipeline)}`);
+    assert.equal(Pet.state.selfmodTotal, 3, `${JSON.stringify(pipeline)} must leave the count alone`);
+  }
+});
+
+test("adoptSelfmodTotal: a LOWER server value overwrites (console-restart semantics)", () => {
+  // Deliberately overwrite, never monotonic-max. The counter is lifetime-since-console-
+  // start, so a restarted console honestly resets its tile instead of showing a total
+  // the running process cannot account for. The cost (a <=10s downward flicker when a
+  // pre-event health snapshot lands after a client increment) self-heals on the next poll.
+  resetState();
+  Pet.state.selfmodTotal = 9;
+  Pet.adoptSelfmodTotal({ selfmod_total: 1 });
+  assert.equal(Pet.state.selfmodTotal, 1);
+});
+
+// ── tile: SSE increment + eviction independence ─────────────────────────────
+
+const frame = (obj) => Pet.sse._dispatch("scan_result", JSON.stringify(obj));
+
+test("SSE: a selfmod frame increments the tile; other frames do not", () => {
+  resetState();
+  frame(scanRow("p1"));
+  frame(blockRow("b1"));
+  assert.equal(Pet.state.selfmodTotal, 0, "ordinary and block frames leave the tile at zero");
+
+  frame(selfmodRow("sm1"));
+  assert.equal(Pet.state.selfmodTotal, 1);
+  frame(selfmodRow("sm2", "high"));
+  assert.equal(Pet.state.selfmodTotal, 2);
+});
+
+test("SSE: malformed frames never increment and never throw", () => {
+  resetState();
+  for (const raw of ["null", "3", '"selfmod_attempt"', "[]", "{oops", ""]) {
+    assert.doesNotThrow(() => Pet.sse._dispatch("scan_result", raw), `threw on ${raw}`);
+  }
+  assert.equal(Pet.state.selfmodTotal, 0);
+});
+
+test("tile count survives ring eviction (the load-bearing PET-165 guarantee)", () => {
+  // One tamper attempt, then enough ordinary scans to push it out of the 500-entry
+  // buffer. The row is gone from the window; the count must not be.
+  resetState();
+  frame(selfmodRow("sm-evict"));
+  for (let i = 0; i < 600; i++) frame(scanRow("p" + i));
+
+  assert.equal(Pet.state.scanHistory.length, 500, "ring stays hard-capped");
+  assert.equal(
+    Pet.state.scanHistory.filter((e) => e.scan_id === "sm-evict").length,
+    0,
+    "precondition: the tamper row has been evicted from the live window"
+  );
+  assert.equal(Pet.state.selfmodTotal, 1, "the tile count must not decay with the buffer");
+});
+
+// ── filter seam ─────────────────────────────────────────────────────────────
+
+test("filterHistoryRows: the selfmod filter keeps only selfmod rows", () => {
+  const rows = [scanRow("p1"), selfmodRow("sm1"), blockRow("b1"), selfmodRow("sm2", "high")];
+  const out = Pet.filterHistoryRows(rows, "selfmod");
+  assert.equal(out.length, 2);
+  // Cross-realm pin (same trap as deepEqual({}) on Pet.state): the array comes back with
+  // the vm realm's Array.prototype, so deepStrictEqual against a host array fails on
+  // reference-equal prototypes. Compare a primitive projection instead.
+  assert.equal(out.map((e) => e.scan_id).join(","), "sm1,sm2");
+  assert.equal(rows.length, 4, "the input buffer is never mutated");
+});
+
+test("filterHistoryRows: any non-selfmod filter returns the input unchanged", () => {
+  // Same array reference, so the default path is byte-identical to pre-PET-165 rendering.
+  const rows = [scanRow("p1"), selfmodRow("sm1")];
+  for (const f of ["all", undefined, null, "", "SELFMOD", "bogus"]) {
+    assert.equal(Pet.filterHistoryRows(rows, f), rows, `filter ${JSON.stringify(f)} must pass through`);
+  }
+});
+
+test("filterHistoryRows: malformed entries are dropped, never thrown on", () => {
+  const rows = [null, undefined, 3, "selfmod_attempt", [], selfmodRow("sm1")];
+  let out;
+  assert.doesNotThrow(() => { out = Pet.filterHistoryRows(rows, "selfmod"); });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].scan_id, "sm1");
+
+  for (const bad of [null, undefined, 42, "rows", {}]) {
+    let r;
+    assert.doesNotThrow(() => { r = Pet.filterHistoryRows(bad, "selfmod"); }, `threw on ${JSON.stringify(bad)}`);
+    assert.equal(r.length, 0);
+  }
+});
+
+test("filterHistoryRows: an empty buffer under the filter yields an empty result", () => {
+  // Feeds the filtered-empty state ("No self-tamper events in the buffered window.")
+  // rather than the "no scans yet" live-head copy.
+  assert.equal(Pet.filterHistoryRows([], "selfmod").length, 0);
+  assert.equal(Pet.filterHistoryRows([scanRow("p1")], "selfmod").length, 0);
+});
+
+// ── filter control ──────────────────────────────────────────────────────────
+
+test("setHistoryFilter: toggles state and never touches tile values or the buffer", () => {
+  resetState();
+  Pet.state.selfmodTotal = 5;
+  Pet.state.bypassBySession = { s: 2 };
+  Pet.state.scanHistory = [scanRow("p1"), selfmodRow("sm1")];
+
+  Pet.setHistoryFilter("selfmod");
+  assert.equal(Pet.state.historyFilter, "selfmod");
+  Pet.setHistoryFilter("all");
+  assert.equal(Pet.state.historyFilter, "all");
+  Pet.setHistoryFilter("nonsense");
+  assert.equal(Pet.state.historyFilter, "all", "an unknown filter value normalizes to 'all'");
+
+  assert.equal(Pet.state.selfmodTotal, 5, "filtering never changes a tile value");
+  assert.equal(Pet.bypassTotal(), 2, "filtering never changes a tile value");
+  assert.equal(Pet.state.scanHistory.length, 2, "filtering never changes the buffer");
+});
+
+test("setHistoryFilter: activating the filter from a paged view snaps back to the head", () => {
+  // The filter is a live-head view. Filtering a single older page would present "the
+  // self-tamper events in this page" as "the self-tamper events"; paged views therefore
+  // always render unfiltered, and activating the filter returns to the head first.
+  resetState();
+  Pet.state.historyAtHead = false;
+  Pet.state.historyStack = [{ entries: [scanRow("old1")], nextBefore: "cur-1" }];
+
+  Pet.setHistoryFilter("selfmod");
+  assert.equal(Pet.state.historyFilter, "selfmod");
+  assert.equal(Pet.state.historyAtHead, true, "snapped back to the live head");
+  assert.equal(Pet.state.historyStack.length, 0, "paged stack cleared by the head transition");
+  // Harness pin: cross-realm prototypes break deepEqual({}) on vm-realm objects.
+  assert.equal(Object.keys(Pet.state.bypassBySession).length, 0);
+});
+
+test("setHistoryFilter: re-selecting an already-active filter still snaps to head", () => {
+  // Reachable state: filter, then page back (paged views render unfiltered). Clicking the
+  // already-lit chip must do the honest thing rather than no-op into a lying control.
+  resetState();
+  Pet.state.historyFilter = "selfmod";
+  Pet.state.historyAtHead = false;
+  Pet.state.historyStack = [{ entries: [], nextBefore: null }];
+
+  Pet.setHistoryFilter("selfmod");
+  assert.equal(Pet.state.historyAtHead, true);
+  assert.equal(Pet.state.historyStack.length, 0);
+});
+
+test("setHistoryFilter: selecting 'all' from a paged view leaves the page alone", () => {
+  resetState();
+  Pet.state.historyFilter = "selfmod";
+  Pet.state.historyAtHead = false;
+  Pet.state.historyStack = [{ entries: [scanRow("old1")], nextBefore: "cur-1" }];
+
+  Pet.setHistoryFilter("all");
+  assert.equal(Pet.state.historyFilter, "all");
+  assert.equal(Pet.state.historyAtHead, false, "clearing the filter is not a navigation");
+  assert.equal(Pet.state.historyStack.length, 1);
+});
+
+// ── house style ─────────────────────────────────────────────────────────────
+
+test("PET-165 copy carries no em dash", () => {
+  const src = readFileSync(petasosJsPath, "utf8");
+  const selfmodCopy = src.match(/"[^"\n]*self-tamper[^"\n]*"/g) || [];
+  assert.ok(selfmodCopy.length > 0, "expected self-tamper copy in the shipped console");
+  for (const s of selfmodCopy) assert.ok(!s.includes("—"), `em dash in shipped copy: ${s}`);
+});

--- a/tests/test_console_scans_total.py
+++ b/tests/test_console_scans_total.py
@@ -13,6 +13,14 @@ Regression for PET-144: the count must stay accurate after the ring has evicted,
 record paths must feed the same counter, and the first overflow must log exactly once
 (not per scan). The 500 ring stays a hard cap by design -- this makes it honest, not
 bigger.
+
+PET-165 extends the same pattern to ``_selfmod_total`` /
+``get_health()["pipeline"]["selfmod_total"]``, the eviction-proof lifetime count feeding
+the console's self-tamper tile. Regression for PET-165: a buffer-scoped tamper count
+would silently decay to 0 once 500 ordinary scans evicted the tamper rows, and the
+highest-stakes signal is precisely the one that must not decay. The ingest-seam
+increment semantics live in ``test_enforcement_events.py``; this module owns the
+``/health`` field contract the frontend reads.
 """
 
 from __future__ import annotations
@@ -73,6 +81,63 @@ async def test_scans_total_counts_both_record_paths(handlers: ConsoleHandlers) -
 
     health = await handlers.get_health()
     assert health["pipeline"]["scans_total"] == 2
+
+
+# ── PET-165: the self-tamper lifetime counter ────────────────────────────────────────
+
+
+def _selfmod_event(scan_id: str) -> dict[str, object]:
+    # Minimal well-formed selfmod_attempt spool row (the shape the reference plugin emits).
+    return {
+        "event_type": "selfmod_attempt",
+        "session_id": "s-selfmod",
+        "scan_id": scan_id,
+        "tool": "write_file",
+        "rule_id": "petasos.selfmod.config_write",
+        "severity": "critical",
+        "reason": "selfmod target: config.yaml",
+    }
+
+
+async def test_selfmod_total_contract(handlers: ConsoleHandlers) -> None:
+    # The /health field the console tile reads: present, an int (not a bool), and an honest
+    # zero on a fresh handler. Locks the NAME the frontend depends on.
+    health = await handlers.get_health()
+    total = health["pipeline"]["selfmod_total"]
+    assert type(total) is int  # noqa: E721 -- bool is an int subclass; the field must be a real int
+    assert total == 0
+
+
+async def test_selfmod_total_survives_ring_eviction(handlers: ConsoleHandlers) -> None:
+    # The load-bearing regression (PET-165): one self-tamper attempt, then enough ordinary
+    # scans to evict it from the 500-entry ring. The row is GONE from the live window but the
+    # tile count still reads 1 -- the whole reason the counter is server-side, not derived
+    # from the buffer.
+    await handlers._surface_enforcement_event(_selfmod_event("e-sm-evict"))
+    for i in range(600):
+        await handlers.run_scan(f"ordinary scan {i} evicting the tamper row")
+
+    history = await handlers.get_scan_history(limit=1000)
+    assert all(e.get("scan_id") != "e-sm-evict" for e in history["entries"]), (
+        "precondition: the selfmod row must have been evicted from the live window"
+    )
+
+    health = await handlers.get_health()
+    assert health["pipeline"]["selfmod_total"] == 1
+    assert health["pipeline"]["scans_total"] == 601  # the selfmod row is a recorded scan too
+
+
+async def test_selfmod_total_counts_unverifiable_rows(handlers: ConsoleHandlers) -> None:
+    # Decision 2 pin: unlike the block tally (D4, trusted-claim gated), the selfmod tally is
+    # intentionally NOT integrity-gated -- it is detection-only surfacing, never a trusted
+    # block claim, and the row renders regardless of provenance. With a spool key configured,
+    # an unsigned row verifies as `unverifiable` and must STILL count.
+    handlers._spool_key = b"a-console-spool-key"
+    await handlers._surface_enforcement_event(_selfmod_event("e-sm-unverified"))
+
+    assert handlers._integrity_recent[-1][0] == "unverifiable"  # precondition
+    health = await handlers.get_health()
+    assert health["pipeline"]["selfmod_total"] == 1
 
 
 async def test_ring_overflow_warns_once(

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -804,3 +804,66 @@ async def test_bypass_count_round_trips_in_process(
     rows = handlers.scan_history.to_list()
     assert rows[0]["bypassed_count"] == 1
     assert rows[0]["safe"] is True
+
+
+# ---------------------------------------------------------------------------
+# PET-165: the self-tamper ingest tally behind the console's self-tamper tile.
+# The counter rides the SAME drain seam as the block/bypass tallies, so it
+# inherits their exactly-once discipline (forward offset + .rot recovery). These
+# tests pin the increment semantics; the /health field contract and the
+# eviction-independence guarantee live in test_console_scans_total.py.
+# ---------------------------------------------------------------------------
+
+
+def _emit_selfmod(session_id: str, **kw: Any) -> None:
+    """Emit a selfmod_attempt event directly onto the spool (dashboard-side tests)."""
+    ev.emit_enforcement_event(
+        {
+            "session_id": session_id,
+            "tool": "write_file",
+            "event_type": "selfmod_attempt",
+            "rule_id": "petasos.selfmod.config_write",
+            "severity": "critical",
+            "reason": "selfmod target: config.yaml",
+            "armed": True,
+            **kw,
+        }
+    )
+
+
+async def test_selfmod_total_increments_exactly_once(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # One spool row, one increment -- and a re-drain over the same spool must not
+    # re-count it. The forward offset is what makes this true; asserting it here means a
+    # regression in the offset discipline shows up as an inflated tile, not just as a
+    # duplicate row.
+    _emit_selfmod("s-one")
+    await handlers._drain_enforcement_into_history()
+    assert handlers._selfmod_total == 1
+
+    await handlers._drain_enforcement_into_history()  # nothing new on the spool
+    assert handlers._selfmod_total == 1
+
+    _emit_selfmod("s-one", rule_id="petasos.selfmod.config_ref", severity="high")
+    await handlers._drain_enforcement_into_history()
+    assert handlers._selfmod_total == 2
+
+
+async def test_selfmod_total_isolated_from_other_event_types(
+    spool: str, handlers: ConsoleHandlers
+) -> None:
+    # Event-type isolation in both directions: block / bypass / an ordinary playground scan
+    # never touch the selfmod tally, and a selfmod row never touches the block or bypass
+    # tallies (it is detection-only, never a block claim).
+    ev.emit_enforcement_event({"session_id": "s", "tool": "t", "event_type": "block"})
+    _emit_bypass("s", bypassed_count=2)
+    await handlers._drain_enforcement_into_history()
+    await handlers.run_scan("an ordinary playground scan")
+    assert handlers._selfmod_total == 0
+
+    _emit_selfmod("s")
+    await handlers._drain_enforcement_into_history()
+    assert handlers._selfmod_total == 1
+    assert handlers.block_tally_for("s") == 1  # unchanged by the selfmod row
+    assert handlers.bypass_tally_for("s") == 2  # unchanged by the selfmod row


### PR DESCRIPTION
## Summary
- Adds a **self-tamper metric tile** backed by a server-side lifetime counter (`pipeline.selfmod_total` on `/health`), so the count does not decay when 500 ordinary scans evict the tamper rows from the 500-entry ring.
- Adds a **scan-history filter** (`all` / `self-tamper`) as a pure client-side seam over the same buffer: rendered rows only, never a tile value, never the buffer.
- **Severity-differentiates the row badge**: `config_write` (critical) takes the red `err` class, `config_ref` (high) stays amber, and the severity rides the badge text and aria-label so the distinction never depends on color alone.
- Follow-up to PET-164 (#152). Presentation plus one read-only counter: detection, floors, weights, alerting, spool format, and `petasos/session/*` are untouched.

## Why the counter is server-side

Every other metric tile except *bypassed (disarmed)* is buffer-scoped over the ≤500-entry `scanHistory` ring. For self-tamper that is the wrong shape: the tile would read a truthful `1`, then silently decay to `0` once 500 ordinary scans pushed the tamper row out, and the highest-stakes signal is precisely the one that must not decay. So it follows the PET-144 `scans_total` precedent instead: a lifetime counter bumped on the enforcement-ingest seam, which already carries exactly-once semantics from the forward-offset / `.rot` drain discipline.

Deliberately **not** integrity-gated, unlike the block tally (D4). This is detection-only surfacing, never a trusted-block claim, and the rows already render regardless of provenance, so it takes the PET-138 bypass-tally posture. Named residual: a forged spool row can inflate the tile; the per-row provenance flag and the audit trail remain the trusted record. Pinned by `test_selfmod_total_counts_unverifiable_rows`.

## Filter x paging

The filter is a **live-head view**. Filtering a single paged-back page would present "the self-tamper events in this page" as "the self-tamper events", so paged views always render unfiltered and activating the filter from one snaps back to the head via the existing `historyPagingView("head")` transition. The PET-144 eviction subtitle keeps reading the *unfiltered* buffered length, so filtering never rewrites the headline into a false "showing last 3 of N", and the filtered-empty state is phrased against the window: `No self-tamper events in the buffered window.`

## Files changed

| File | Change |
|------|--------|
| `petasos/console/server.py` | Adds `_selfmod_total`, one ingest-seam `elif` arm, and the `/health` field |
| `petasos/console/static/petasos.js` | Tile + `Pet.adoptSelfmodTotal` / `Pet.filterHistoryRows` / `Pet.setHistoryFilter` seams, SSE increment, severity badge mapping |
| `petasos/console/static/petasos.css` | Adds `.seg.seg-sm`, a size modifier so the reused `.seg` primitive fits the 38px panel head |
| `docs/deployment/hardening.md` | Documents that `console_probe` writes no spool event, so it cannot surface in history/filter/tile |
| `tests/test_console_scans_total.py` | Adds the `/health` contract, eviction-independence, and unverifiable-counts tests |
| `tests/test_enforcement_events.py` | Adds ingest exactly-once + event-type isolation tests |
| `tests/js/selfmod-row.test.mjs` | Extends for severity badge mapping and the fallback |
| `tests/js/selfmod-tile-filter.test.mjs` | New: tile adoption/increment/eviction independence, filter seam, filter x paging |

## Test plan
- [x] `C:\python310\python.exe -m pytest tests/ -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — **2219 passed**, 42 skipped, 1 deselected, 1 xfailed (the deselect is the standing pre-existing master failure: Unicode 13 vs 14)
- [x] `node --test tests/js/*.test.mjs` — **260/260 pass** (24 in the two selfmod suites)
- [x] `ruff check .` — clean; `ruff format --check .` — 162 files already formatted
- [x] `mypy --strict .` — no issues in 162 source files
- [x] Standalone smoke on port 8384: `/api/health` reports `selfmod_total` beside `scans_total`; emitting one `config_write` and one `config_ref` event onto the spool drains into the history with severities intact and moves the counter to `2`
- [x] Post-merge: hand-sync the gibson plugin copy per the runbook (outside the PR gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-tamper metrics tile with a persistent lifetime count.
  * Added live filtering for all scan history or self-tamper events.
  * Added severity-aware self-tamper badges, including critical and high indicators.
  * Added compact segmented controls for improved console layout.

* **Documentation**
  * Clarified self-tamper detection behavior and audit trail visibility in deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->