### PR TITLE
chore(ci): pin ruff and scope the formatter to source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - run: pip install ruff
+      # Pinned deliberately. An unpinned install silently adopts new formatter
+      # behavior on release day and breaks every open branch at once (0.16.0
+      # began formatting Python code blocks inside Markdown). Bump in its own PR.
+      - run: pip install ruff==0.16.0
       - run: ruff check .
       - run: ruff format --check .
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,3 +7,7 @@ ignore = ["UP017"]
 
 [format]
 quote-style = "double"
+# ruff >= 0.16 formats Python code blocks inside Markdown. Doc snippets are
+# hand-laid out for readability (grouped config examples, aligned comments),
+# so the formatter is scoped to source files only.
+exclude = ["*.md"]


### PR DESCRIPTION
## Why

The `lint` lane ran an unpinned `pip install ruff`, so a ruff release could flip CI's verdict on every branch with no commit behind it. That is exactly what happened: **ruff 0.16.0** began formatting Python code blocks inside Markdown, and master's lint lane went red on `CLAUDE.md` and `README.md`.

Discovered while triaging a red lint check on #153, which touches neither file.

## What

- **Pin `ruff==0.16.0`** in the lint lane, so the formatter version is a reviewed input rather than whatever PyPI serves that morning. Bump in a dedicated PR.
- **Add `format.exclude = ["*.md"]`** to `ruff.toml`. Doc snippets are hand-laid out for readability, and applying 0.16's Markdown formatting is a regression: it flattens the blank-line grouping in the README `PetasosConfig` example, un-aligns trailing comments, and splits `print(result.findings)` across three lines.

## Verification

`ruff check .` and `ruff format --check .` both clean under **0.15.14** and **0.16.0** (162 files). No source files change.

## Overlap with #153

The `ruff.toml` hunk is identical to the one already pushed to #153 to unblock its CI. Whichever merges second drops the duplicate on rebase.

## Not in scope

`pyproject.toml` still declares `ruff>=0.4` in the dev extra, so a contributor's local ruff can still differ from the lane. Tightening that is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Ruff tool version used in automated checks for more consistent results.
  * Updated formatting configuration to leave Markdown files unchanged, including embedded code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->