### PR TITLE
feat(pet-167): bounded init wait + durable cold-start visibility

### DIFF
--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -29,6 +29,7 @@ import asyncio
 import base64
 import contextlib
 import logging
+import math  # PET-167: dep-light (stdlib; isfinite guard on the raw init-wait budget)
 import os
 import threading
 import time
@@ -61,6 +62,57 @@ _init_lock = threading.Lock()
 _initialized = False
 _init_error: str | None = None
 _session_ids: dict[int, str] = {}
+
+# PET-167: bounded cold-start wait. `_init_done` is set in a `finally` around the WHOLE
+# _deferred_init body, so every exit path (including its pre-try early return) signals
+# completion. It is a BEST-EFFORT signal, not a guarantee: the init thread is daemon=True
+# and CPython does not run `finally` in daemon threads killed at interpreter finalization.
+# That is safe precisely because the wait is bounded — an unset Event costs one budget,
+# not a hang. An Event rather than `_init_lock.acquire(timeout=...)` because _init_lock is
+# ALSO taken by _rebind_to_resolution for a config refresh unrelated to init completion,
+# so acquiring it proves only that no build is mid-flight.
+#
+# The deadline is process-wide, not per-call: a naive per-call budget would charge N calls
+# N budgets inside one cold window, a latency regression on exactly the short-lived
+# unattended surfaces this targets. `_init_wait_deadline` is captured at the FIRST wait and
+# `_init_wait_expired` latches; total added wait across the process is one budget.
+_init_done = threading.Event()
+_init_wait_deadline: float | None = None
+_init_wait_expired = False
+_DEFAULT_INIT_WAIT_S = 2.0
+
+# PET-167: the scan-outcome channel out of _fallback_pre_tool_call. The fallback's
+# signature and return type are UNCHANGED (three distinct outcomes collapse to None in its
+# return value, and existing callers/tests depend on that contract, e.g.
+# tests/test_reference_plugin_egress.py:444-453); it additionally records
+# clean/errored/skipped/blocked here. Thread-local, not a plain global: _pre_tool_call runs
+# concurrently on a multi-threaded gateway and a shared flag would cross-talk between
+# sessions. The read side treats a missing OR unrecognized value as "errored" (fail-secure)
+# and clears the attribute on every exit so a pooled thread carries no residue.
+_fallback_state = threading.local()
+
+# PET-167: at-most-once-per-(session, event_type) latch for the cold-start markers. Keyed on
+# the PAIR, not the session: a session can legitimately record cold_start_degraded and then
+# init_failed, and a session-only key would silently swallow the more severe second state.
+# Insertion-ordered dict used as a set with drop-oldest at _MAX_COLD_START_KEYS, mirroring
+# _bypass_counts/_MAX_DISARM_SESSIONS. `_KEYS` not `_SESSIONS`: it holds up to two entries
+# per session. The two booleans cover the uncorrelatable shape (no task_id, no _agent), where
+# _derive_session_id mints a fresh anon-<uuid> per call that would defeat the latch entirely
+# (the PET-134 D1b discriminator); they are mutated under the same lock. The lock is
+# dedicated and non-reentrant, acquired independently and NEVER held across
+# _derive_session_id, _emit_enforcement_event, or _init_done.wait() (PET-138 Decision 4).
+_cold_start_lock = threading.Lock()
+_cold_start_records: dict[tuple[str, str], None] = {}
+_MAX_COLD_START_KEYS = 10_000
+_cold_start_anon_degraded = False
+_cold_start_anon_init_failed = False
+# Dedicated rate-limit clock for the failed-spool-write warning (the PET-126
+# _last_reload_fail_log idiom). The retry itself is deliberately unbounded — a later call may
+# find the spool writable again — but on a persistently dead spool an init_failed process
+# qualifies for its whole lifetime, so an unconditional warning would mean one log line per
+# tool call on the hook path exactly when the operator's disk is already the problem.
+_cold_start_log_lock = threading.Lock()
+_last_cold_start_fail_log = 0.0
 
 # PET-130: the gateway's session-bound config resolution, captured once at the top
 # of register() from the operator-trusted boot environment and pinned for the
@@ -137,10 +189,36 @@ def _reset_hooks_registered() -> None:
     _hooks_registered = False
 
 
-def _reset_init_thread_started() -> None:
-    """Test seam — clear the one-shot init-thread-spawn flag (Decision 3)."""
-    global _init_thread_started
+def _reset_init_state() -> None:
+    """Test seam — reset the whole init + bounded-wait latch family (PET-167).
+
+    Subsumes and replaces the former ``_reset_init_thread_started`` (PET-132 Decision 3),
+    which had zero callers. ``_init_done`` is REPLACED with a fresh Event rather than
+    cleared: clearing is insufficient if a waiter is still parked on the old one. Resetting
+    ``_init_wait_deadline`` matters as much as the flags — a stale non-None deadline makes
+    ``remaining <= 0``, skipping the wait entirely, which would let a bounded-wait test pass
+    against an implementation that never waits.
+    """
+    global _initialized, _init_error, _init_thread_started, _init_done
+    global _init_wait_deadline, _init_wait_expired
+    _initialized = False
+    _init_error = None
     _init_thread_started = False
+    _init_wait_deadline = None
+    _init_wait_expired = False
+    _init_done = threading.Event()
+
+
+def _reset_cold_start_records() -> None:
+    """Test seam — clear the PET-167 per-session marker latch, both process-wide
+    uncorrelatable booleans, and the failed-write warning clock."""
+    global _cold_start_anon_degraded, _cold_start_anon_init_failed, _last_cold_start_fail_log
+    with _cold_start_lock:
+        _cold_start_records.clear()
+        _cold_start_anon_degraded = False
+        _cold_start_anon_init_failed = False
+    with _cold_start_log_lock:
+        _last_cold_start_fail_log = 0.0
 
 
 def _reset_rebind_log() -> None:
@@ -378,261 +456,281 @@ def _build_config_from_section(section: dict[str, Any]) -> PetasosConfig:
 def _deferred_init() -> None:
     global _pipeline, _guard, _initialized, _init_error
 
-    with _init_lock:
-        if _initialized or _init_error:
-            return
+    # PET-167: the `finally` wraps the ENTIRE body, including the pre-`try` early return
+    # below. Wrapping only the inner `try` would leave that path with `_init_done` unset,
+    # charging a waiter a full budget for an init that had already finished.
+    try:
+        with _init_lock:
+            if _initialized or _init_error:
+                return
 
-        try:
-            from petasos import PetasosConfig, Pipeline, ToolCallGuard
-            from petasos.scanners import MinimalScanner
+            try:
+                from petasos import PetasosConfig, Pipeline, ToolCallGuard
+                from petasos.scanners import MinimalScanner
 
-            raw_config = _config or {}
+                raw_config = _config or {}
 
-            host_id = raw_config.pop("host_id", "hermes-gavin-01")
-            # PET-111 (Option A): build the pipeline regardless of the boot-time
-            # `enabled` value; enforcement is gated per-call by _is_armed() so a
-            # re-arm mid-session pays no cold-start penalty. The "disabled"
-            # _init_error sentinel is retired — _init_error now latches only a
-            # genuine init exception.
-            enabled = raw_config.pop("enabled", True)
-            logger.info(
-                "Petasos starting %s (petasos.enabled=%s)",
-                "armed" if enabled else "disarmed",
-                enabled,
-            )
+                host_id = raw_config.pop("host_id", "hermes-gavin-01")
+                # PET-111 (Option A): build the pipeline regardless of the boot-time
+                # `enabled` value; enforcement is gated per-call by _is_armed() so a
+                # re-arm mid-session pays no cold-start penalty. The "disabled"
+                # _init_error sentinel is retired — _init_error now latches only a
+                # genuine init exception.
+                enabled = raw_config.pop("enabled", True)
+                logger.info(
+                    "Petasos starting %s (petasos.enabled=%s)",
+                    "armed" if enabled else "disarmed",
+                    enabled,
+                )
 
-            # Boot-time operator guidance. The actual env overlay + validation is
-            # the shared _build_config_from_section (also used by the live reload,
-            # PET-126 Decision 10), so a boot config and a live-reload config are
-            # equivalent. The warnings stay here so the reload path does not re-emit
-            # them on every applied change.
-            session_secret_b64 = os.environ.get("PETASOS_SESSION_SECRET")
-            if session_secret_b64:
+                # Boot-time operator guidance. The actual env overlay + validation is
+                # the shared _build_config_from_section (also used by the live reload,
+                # PET-126 Decision 10), so a boot config and a live-reload config are
+                # equivalent. The warnings stay here so the reload path does not re-emit
+                # them on every applied change.
+                session_secret_b64 = os.environ.get("PETASOS_SESSION_SECRET")
+                if session_secret_b64:
+                    try:
+                        base64.b64decode(session_secret_b64)
+                    except Exception:
+                        logger.warning(
+                            "PETASOS_SESSION_SECRET is not valid base64"
+                            " — HMAC session binding disabled"
+                        )
+                else:
+                    logger.warning(
+                        "PETASOS_SESSION_SECRET not set — HMAC session binding disabled"
+                    )
+
+                if (
+                    not os.environ.get("PETASOS_HASH_KEY")
+                    and raw_config.get("redaction_mode") == "hash"
+                ):
+                    logger.warning(
+                        "PETASOS_HASH_KEY not set but redaction_mode=hash "
+                        "— PII anonymization will fail. Set PETASOS_HASH_KEY "
+                        "or change redaction_mode."
+                    )
+
                 try:
-                    base64.b64decode(session_secret_b64)
-                except Exception:
-                    logger.warning(
-                        "PETASOS_SESSION_SECRET is not valid base64"
-                        " — HMAC session binding disabled"
-                    )
-            else:
-                logger.warning("PETASOS_SESSION_SECRET not set — HMAC session binding disabled")
+                    config = _build_config_from_section(raw_config)
+                except (TypeError, ValueError) as exc:
+                    logger.error("PetasosConfig validation failed: %s — using defaults", exc)
+                    config = PetasosConfig()
 
-            if (
-                not os.environ.get("PETASOS_HASH_KEY")
-                and raw_config.get("redaction_mode") == "hash"
-            ):
-                logger.warning(
-                    "PETASOS_HASH_KEY not set but redaction_mode=hash "
-                    "— PII anonymization will fail. Set PETASOS_HASH_KEY "
-                    "or change redaction_mode."
-                )
+                scanners = [MinimalScanner()]
+                unavailable: list[str] = []
+                try:
+                    from petasos.scanners import LlmGuardScanner
 
-            try:
-                config = _build_config_from_section(raw_config)
-            except (TypeError, ValueError) as exc:
-                logger.error("PetasosConfig validation failed: %s — using defaults", exc)
-                config = PetasosConfig()
-
-            scanners = [MinimalScanner()]
-            unavailable: list[str] = []
-            try:
-                from petasos.scanners import LlmGuardScanner
-
-                instance = LlmGuardScanner()
-                scanners.append(instance)
-                avail, reason, _cause = instance.availability()
-                if avail:
-                    logger.info("LLM Guard backend verified — scanner active")
-                else:
+                    instance = LlmGuardScanner()
+                    scanners.append(instance)
+                    avail, reason, _cause = instance.availability()
+                    if avail:
+                        logger.info("LLM Guard backend verified — scanner active")
+                    else:
+                        unavailable.append("llm_guard")
+                        logger.warning(
+                            "LLM Guard backend missing — scanner registered degraded "
+                            "(every scan will error): %s",
+                            reason,
+                        )
+                except ImportError:
                     unavailable.append("llm_guard")
-                    logger.warning(
-                        "LLM Guard backend missing — scanner registered degraded "
-                        "(every scan will error): %s",
-                        reason,
-                    )
-            except ImportError:
-                unavailable.append("llm_guard")
-                logger.info("LLM Guard not installed — syntactic-only for that backend")
-            except Exception as exc:
-                unavailable.append("llm_guard")
-                logger.warning("LLM Guard failed to load: %s", exc)
+                    logger.info("LLM Guard not installed — syntactic-only for that backend")
+                except Exception as exc:
+                    unavailable.append("llm_guard")
+                    logger.warning("LLM Guard failed to load: %s", exc)
 
-            try:
-                from petasos.scanners import LlamaFirewallScanner
+                try:
+                    from petasos.scanners import LlamaFirewallScanner
 
-                instance = LlamaFirewallScanner()
-                scanners.append(instance)
-                avail, reason, _cause = instance.availability()
-                if avail:
-                    logger.info("LlamaFirewall backend verified — scanner active")
-                else:
+                    instance = LlamaFirewallScanner()
+                    scanners.append(instance)
+                    avail, reason, _cause = instance.availability()
+                    if avail:
+                        logger.info("LlamaFirewall backend verified — scanner active")
+                    else:
+                        unavailable.append("llama_firewall")
+                        logger.warning(
+                            "LlamaFirewall backend missing — scanner registered degraded "
+                            "(every scan will error): %s",
+                            reason,
+                        )
+                except ImportError:
                     unavailable.append("llama_firewall")
-                    logger.warning(
-                        "LlamaFirewall backend missing — scanner registered degraded "
-                        "(every scan will error): %s",
-                        reason,
-                    )
-            except ImportError:
-                unavailable.append("llama_firewall")
-                logger.info("LlamaFirewall not installed — skipped")
-            except Exception as exc:
-                unavailable.append("llama_firewall")
-                logger.warning("LlamaFirewall failed to load: %s", exc)
+                    logger.info("LlamaFirewall not installed — skipped")
+                except Exception as exc:
+                    unavailable.append("llama_firewall")
+                    logger.warning("LlamaFirewall failed to load: %s", exc)
 
-            try:
-                from petasos.scanners import PresidioScanner
+                try:
+                    from petasos.scanners import PresidioScanner
 
-                instance = PresidioScanner()
-                scanners.append(instance)
-                avail, reason, _cause = instance.availability()
-                if avail:
-                    logger.info("Presidio backend verified — scanner active")
-                else:
+                    instance = PresidioScanner()
+                    scanners.append(instance)
+                    avail, reason, _cause = instance.availability()
+                    if avail:
+                        logger.info("Presidio backend verified — scanner active")
+                    else:
+                        unavailable.append("presidio")
+                        logger.warning(
+                            "Presidio backend missing — scanner registered degraded "
+                            "(every scan will error): %s",
+                            reason,
+                        )
+                except ImportError:
                     unavailable.append("presidio")
+                    logger.info("Presidio not installed — PII detection unavailable")
+                except Exception as exc:
+                    unavailable.append("presidio")
+                    logger.warning("Presidio failed to load: %s", exc)
+
+                _pipeline = Pipeline(
+                    config=config,
+                    scanners=scanners,
+                    host_id=host_id,
+                    on_audit=_handle_audit,
+                    on_alert=_handle_alert,
+                )
+
+                # PET-139: install the enforcement-spool HMAC key (D3) so writer-side events are
+                # signed. Sourced from the `session_secret` already decoded by
+                # `_build_config_from_section` (no new env read). The reader (dashboard process)
+                # derives the same key from the same `PETASOS_SESSION_SECRET` under one documented
+                # env contract, so writer and reader agree. Wrapped fail-safe: a failure degrades
+                # to integrity-off (no `sig`), never breaks boot.
+                try:
+                    from petasos.console._events import set_spool_key
+
+                    set_spool_key(config.session_secret)
+                except Exception as exc:  # pragma: no cover - defensive; integrity is best-effort
                     logger.warning(
-                        "Presidio backend missing — scanner registered degraded "
-                        "(every scan will error): %s",
-                        reason,
+                        "PETASOS_INTEGRITY spool-key install failed at boot: %s — integrity off",
+                        exc,
                     )
-            except ImportError:
-                unavailable.append("presidio")
-                logger.info("Presidio not installed — PII detection unavailable")
-            except Exception as exc:
-                unavailable.append("presidio")
-                logger.warning("Presidio failed to load: %s", exc)
 
-            _pipeline = Pipeline(
-                config=config,
-                scanners=scanners,
-                host_id=host_id,
-                on_audit=_handle_audit,
-                on_alert=_handle_alert,
-            )
+                license_key = os.environ.get("PETASOS_LICENSE_KEY")
+                if license_key:
+                    from petasos import LicenseState
 
-            # PET-139: install the enforcement-spool HMAC key (D3) so writer-side events are
-            # signed. Sourced from the `session_secret` already decoded by
-            # `_build_config_from_section` (no new env read). The reader (dashboard process)
-            # derives the same key from the same `PETASOS_SESSION_SECRET` under one documented
-            # env contract, so writer and reader agree. Wrapped fail-safe: a failure degrades
-            # to integrity-off (no `sig`), never breaks boot.
-            try:
-                from petasos.console._events import set_spool_key
-
-                set_spool_key(config.session_secret)
-            except Exception as exc:  # pragma: no cover - defensive; integrity is best-effort
-                logger.warning(
-                    "PETASOS_INTEGRITY spool-key install failed at boot: %s — integrity off", exc
-                )
-
-            license_key = os.environ.get("PETASOS_LICENSE_KEY")
-            if license_key:
-                from petasos import LicenseState
-
-                state = _pipeline.activate(license_key)
-                if state == LicenseState.VALID:
-                    logger.info("Petasos license validated (enterprise)")
-                    for feat in (
-                        "frequency",
-                        "escalation",
-                        "tool_guard",
-                        "audit",
-                        "alerting",
-                    ):
-                        if not _pipeline.is_feature_enabled(feat):
-                            logger.warning(
-                                "Premium feature '%s' not available despite valid license",
-                                feat,
-                            )
+                    state = _pipeline.activate(license_key)
+                    if state == LicenseState.VALID:
+                        logger.info("Petasos license validated (enterprise)")
+                        for feat in (
+                            "frequency",
+                            "escalation",
+                            "tool_guard",
+                            "audit",
+                            "alerting",
+                        ):
+                            if not _pipeline.is_feature_enabled(feat):
+                                logger.warning(
+                                    "Premium feature '%s' not available despite valid license",
+                                    feat,
+                                )
+                    else:
+                        logger.warning(
+                            "Petasos license invalid (state=%s) — running OSS-only", state
+                        )
                 else:
-                    logger.warning("Petasos license invalid (state=%s) — running OSS-only", state)
-            else:
+                    logger.info(
+                        "PETASOS_LICENSE_KEY not set — all features available "
+                        "(license is optional)"
+                    )
+
+                from petasos import FrequencyTracker, LineageRegistry, SessionTaintStore
+
+                global _lineage_registry
+                if _subagent_hooks_available:
+                    # A + C: construct ONE registry before the tracker, wire the
+                    # tracker's pin/unpin callbacks to it, and hand it to the guard.
+                    # Hooks carry raw session_ids; the registry keys on raw ids
+                    # (matching is_terminated); the guard mints per-ancestor tokens
+                    # for get_state.
+                    registry = LineageRegistry(config)
+                    _lineage_registry = registry
+                    tracker = FrequencyTracker(
+                        config,
+                        is_pinned=registry.is_pinned,
+                        on_terminate=registry.unregister,
+                    )
+                    _guard = ToolCallGuard(_pipeline, tracker, config, lineage=registry)
+                    logger.info(
+                        "Petasos sub-agent lineage (A) + delegation fan-out gate (C) active"
+                    )
+                else:
+                    # C only: no sub-agent hooks, so lineage no-ops (no chain walk,
+                    # no pinning). The fan-out gate still rate-limits delegate spawns.
+                    tracker = FrequencyTracker(config)
+                    _guard = ToolCallGuard(_pipeline, tracker, config, lineage=None)
+                    logger.info(
+                        "Petasos delegation fan-out gate (C) active; sub-agent lineage (A) "
+                        "inactive (sub-agent hooks unavailable)"
+                    )
+
+                # PET-112: publish the egress-sink set under the same happens-before as
+                # _pipeline/_guard (written before _initialized flips; read lock-free in the
+                # post-init hot path). The `global` is MANDATORY — without it the assignment
+                # binds a function-local and leaves the module frozenset empty forever,
+                # silently disabling egress PII blocking.
+                global _egress_sink_tools
+                # PET-118: canonicalize once here through the SAME shared primitive the guard
+                # uses, mirroring the delegate_tool_names template (canonicalize, drop names
+                # that normalize away via `if c`, warn when the resolved set is empty). A name
+                # that is purely a namespace prefix (e.g. "mcp__acme__") passes config
+                # validation but canonicalizes to "" — the `if c` filter drops it so the set
+                # never contains "" (no false match in _is_egress_sink).
+                _egress_sink_tools = frozenset(
+                    c for c in (canonicalize_tool_name(t) for t in config.egress_sink_tools) if c
+                )
+                if not _egress_sink_tools:
+                    logger.warning(
+                        "egress_sink_tools is empty (or all names canonicalized away) — "
+                        "PII will not be blocked on any egress tool"
+                    )
+
+                # PET-134: build the source-taint set + store under the SAME happens-before as
+                # _egress_sink_tools (written before _initialized flips; read lock-free in the
+                # hot path). The `global` is MANDATORY — without it the assignments bind
+                # function-locals and leave the module set frozen empty / the store None forever,
+                # silently disabling the fence (the exact footgun the egress comment warns of).
+                # _source_taint_namespaces uses the identical canonicalize-drop-empty-warn idiom;
+                # the prefixes are canonicalized so a variant-named source tool still matches
+                # (PET-118 on the source side).
+                global _taint_store, _source_taint_namespaces
+                _source_taint_namespaces = frozenset(
+                    c
+                    for c in (canonicalize_tool_name(t) for t in config.source_taint_namespaces)
+                    if c
+                )
+                _taint_store = SessionTaintStore(config)
+                if config.source_taint_namespaces and not _source_taint_namespaces:
+                    logger.warning(
+                        "source_taint_namespaces is set but all names canonicalized away — "
+                        "the source-taint egress fence will match no producing tool"
+                    )
+
+                scanner_names = [s.name for s in scanners]
                 logger.info(
-                    "PETASOS_LICENSE_KEY not set — all features available (license is optional)"
+                    "Petasos initialized: scanners=%s, unavailable=%s, fail_mode=%s, host_id=%s",
+                    scanner_names,
+                    unavailable,
+                    config.fail_mode,
+                    host_id,
                 )
 
-            from petasos import FrequencyTracker, LineageRegistry, SessionTaintStore
+                _initialized = True
 
-            global _lineage_registry
-            if _subagent_hooks_available:
-                # A + C: construct ONE registry before the tracker, wire the
-                # tracker's pin/unpin callbacks to it, and hand it to the guard.
-                # Hooks carry raw session_ids; the registry keys on raw ids
-                # (matching is_terminated); the guard mints per-ancestor tokens
-                # for get_state.
-                registry = LineageRegistry(config)
-                _lineage_registry = registry
-                tracker = FrequencyTracker(
-                    config,
-                    is_pinned=registry.is_pinned,
-                    on_terminate=registry.unregister,
-                )
-                _guard = ToolCallGuard(_pipeline, tracker, config, lineage=registry)
-                logger.info("Petasos sub-agent lineage (A) + delegation fan-out gate (C) active")
-            else:
-                # C only: no sub-agent hooks, so lineage no-ops (no chain walk,
-                # no pinning). The fan-out gate still rate-limits delegate spawns.
-                tracker = FrequencyTracker(config)
-                _guard = ToolCallGuard(_pipeline, tracker, config, lineage=None)
-                logger.info(
-                    "Petasos delegation fan-out gate (C) active; sub-agent lineage (A) "
-                    "inactive (sub-agent hooks unavailable)"
-                )
-
-            # PET-112: publish the egress-sink set under the same happens-before as
-            # _pipeline/_guard (written before _initialized flips; read lock-free in the
-            # post-init hot path). The `global` is MANDATORY — without it the assignment
-            # binds a function-local and leaves the module frozenset empty forever,
-            # silently disabling egress PII blocking.
-            global _egress_sink_tools
-            # PET-118: canonicalize once here through the SAME shared primitive the guard
-            # uses, mirroring the delegate_tool_names template (canonicalize, drop names
-            # that normalize away via `if c`, warn when the resolved set is empty). A name
-            # that is purely a namespace prefix (e.g. "mcp__acme__") passes config
-            # validation but canonicalizes to "" — the `if c` filter drops it so the set
-            # never contains "" (no false match in _is_egress_sink).
-            _egress_sink_tools = frozenset(
-                c for c in (canonicalize_tool_name(t) for t in config.egress_sink_tools) if c
-            )
-            if not _egress_sink_tools:
-                logger.warning(
-                    "egress_sink_tools is empty (or all names canonicalized away) — "
-                    "PII will not be blocked on any egress tool"
-                )
-
-            # PET-134: build the source-taint set + store under the SAME happens-before as
-            # _egress_sink_tools (written before _initialized flips; read lock-free in the
-            # hot path). The `global` is MANDATORY — without it the assignments bind
-            # function-locals and leave the module set frozen empty / the store None forever,
-            # silently disabling the fence (the exact footgun the egress comment warns of).
-            # _source_taint_namespaces uses the identical canonicalize-drop-empty-warn idiom;
-            # the prefixes are canonicalized so a variant-named source tool still matches
-            # (PET-118 on the source side).
-            global _taint_store, _source_taint_namespaces
-            _source_taint_namespaces = frozenset(
-                c for c in (canonicalize_tool_name(t) for t in config.source_taint_namespaces) if c
-            )
-            _taint_store = SessionTaintStore(config)
-            if config.source_taint_namespaces and not _source_taint_namespaces:
-                logger.warning(
-                    "source_taint_namespaces is set but all names canonicalized away — "
-                    "the source-taint egress fence will match no producing tool"
-                )
-
-            scanner_names = [s.name for s in scanners]
-            logger.info(
-                "Petasos initialized: scanners=%s, unavailable=%s, fail_mode=%s, host_id=%s",
-                scanner_names,
-                unavailable,
-                config.fail_mode,
-                host_id,
-            )
-
-            _initialized = True
-
-        except Exception as exc:
-            _init_error = str(exc)
-            logger.error("Petasos initialization failed: %s", exc, exc_info=True)
+            except Exception as exc:
+                # PET-167: `str(exc)` is "" for a bare `raise ImportError()`, and an empty
+                # string is falsy — a truthiness test would then read the latch as "still
+                # initializing" forever, mis-bucketing a permanently failed process as
+                # cold-starting. Fall back to the class name so the latch is never invisible.
+                _init_error = str(exc) or type(exc).__name__
+                logger.error("Petasos initialization failed: %s", exc, exc_info=True)
+    finally:
+        _init_done.set()
 
 
 _fallback_scanner = None
@@ -650,12 +748,62 @@ def _get_fallback_scanner():
     return _fallback_scanner
 
 
+def _init_wait_budget() -> float:
+    """PET-167: the cold-start wait budget, read and sanitized from the RAW config dict.
+
+    Deliberately not routed through ``PetasosConfig``: there is no validated config in the
+    cold window. The ``PetasosConfig`` ``_deferred_init`` builds is a local, never stored on
+    a module global, ``_pipeline`` is None until ``_initialized`` flips, and a validation
+    failure is swallowed to ``PetasosConfig()`` defaults while the raw dict keeps the bad
+    value. ``_config`` itself may be None (``_load_config`` returns {} at best).
+
+    The clamp is load-bearing, not belt-and-braces: ``threading.Event.wait`` raises
+    ``OverflowError`` on ``inf`` / ``1e300`` and ``TypeError`` on a str, and this value
+    reaches it directly. Non-finite is rejected BEFORE clamping rather than relying on
+    argument order (``max(nan, 0.05)`` is nan while ``min(60.0, max(0.05, nan))`` is 0.05).
+    A non-positive or non-finite value falls back to the DEFAULT, not to the 0.05 floor.
+    """
+    raw = (_config or {}).get("init_wait_timeout_seconds", _DEFAULT_INIT_WAIT_S)
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_INIT_WAIT_S
+    if not math.isfinite(v) or v <= 0:
+        return _DEFAULT_INIT_WAIT_S
+    return min(60.0, max(0.05, v))
+
+
 def _ensure_initialized() -> bool:
+    """True iff the full pipeline is live. Bounded wait during cold start (PET-167).
+
+    The ``_initialized`` check MUST stay the first statement: hoisting the
+    ``_init_wait_expired`` latch above it would permanently pin the process to the
+    syntactic fallback even after every ML scanner came up — an indefinite silent
+    enforcement downgrade on long-lived gateway and dashboard processes.
+    """
+    global _init_wait_deadline, _init_wait_expired
     if _initialized:
         return True
-    if _init_error:
+    if _init_error is not None:
         return False
-    _deferred_init()
+    if not _init_thread_started:
+        # No background init in flight (a host that never called register(), or a
+        # rolled-back thread start). Preserve today's synchronous behavior rather than
+        # waiting on an Event nobody will ever set.
+        _deferred_init()
+        return _initialized
+    if _init_wait_expired:
+        return False  # the process-wide budget is already spent
+    now = time.monotonic()
+    d = _init_wait_deadline  # read ONCE into a local
+    if d is None:
+        d = now + _init_wait_budget()
+        _init_wait_deadline = d  # monotone commit: a late writer cannot extend an
+    remaining = d - now  # earlier wait, so two threads racing the first wait
+    if remaining > 0:  # cannot compose into more than one budget
+        _init_done.wait(remaining)
+    if not _initialized and _init_error is None:
+        _init_wait_expired = True
     return _initialized
 
 
@@ -752,8 +900,16 @@ def _fallback_pre_tool_call(
     tool_name: str, args: dict, task_id: str, **kwargs
 ) -> dict[str, str] | None:
     """Syntactic-only guard during init window. Scans tool params through
-    MinimalScanner. Blocks if injection patterns found in dangerous tools."""
+    MinimalScanner. Blocks if injection patterns found in dangerous tools.
+
+    PET-167: the signature and return type are UNCHANGED — three distinct outcomes still
+    collapse to ``None`` here, and existing callers depend on that. The outcome is recorded
+    out-of-band on ``_fallback_state`` instead, so the cold-window branch in
+    ``_pre_tool_call`` can tell "scanned clean" from "scan errored" from "read-only, never
+    scanned". Every return path writes it.
+    """
     if not _is_dangerous(tool_name):
+        _fallback_state.outcome = "skipped"
         return None
     try:
         import json
@@ -781,6 +937,7 @@ def _fallback_pre_tool_call(
                     rule_id=worst.rule_id,
                     reason=worst.message,
                 )
+                _fallback_state.outcome = "blocked"
                 return {
                     "action": "block",
                     # PET-77: route through the library formatter (contract: [BLOCKED by Petasos]
@@ -789,6 +946,9 @@ def _fallback_pre_tool_call(
                 }
     except Exception as exc:
         logger.debug("Fallback scan failed: %s — allowing", exc)
+        _fallback_state.outcome = "errored"
+        return None
+    _fallback_state.outcome = "clean"
     return None
 
 
@@ -848,7 +1008,7 @@ def _emit_enforcement_event(
     param_scan_degraded: bool = False,
     armed: bool = True,
     bypassed_count: int | None = None,
-) -> None:
+) -> bool:
     """PET-131: emit a structured enforcement event onto the cross-process spool the
     dashboard drains, beside the existing decision-point log line (one emit per log
     line — log and surface share one source of truth, spec D1/D4).
@@ -863,11 +1023,16 @@ def _emit_enforcement_event(
     The write itself is an O(1) local append (``petasos.console._events``), the same
     hot-path cost class as the per-call ``read_armed`` file read — not a network
     call and not a blocking ``await`` on the decision path.
+
+    PET-167: returns the spool writer's boolean instead of discarding it, so the
+    at-most-once cold-start latch can release a claim whose row never landed. The `except`
+    arm returns False (not True): on a hard emission failure there is no writer boolean to
+    return, and claiming the key there would consume the latch with no durable row.
     """
     try:
         from petasos.console._events import emit_enforcement_event
 
-        emit_enforcement_event(
+        return emit_enforcement_event(
             {
                 "session_id": session_id,
                 "tool": tool,
@@ -883,7 +1048,125 @@ def _emit_enforcement_event(
             }
         )
     except Exception:
-        pass
+        return False
+
+
+# ---------------------------------------------------------------------------
+# PET-167: durable cold-start visibility — the at-most-once marker latch
+# ---------------------------------------------------------------------------
+
+_COLD_START_REASON = (
+    "scanners not up; tool results unscanned (warm path too); syntactic only,"
+    " dangerous tools only, params only (100k cap)"
+)
+# The escape-hatch variant names its trigger: no wait ever ran there, so the cause-neutral
+# opener alone would send an operator chasing a timeout that never happened.
+_COLD_START_REASON_NO_INIT = (
+    "scanners not up (no init in flight); tool results unscanned (warm path too);"
+    " syntactic only, dangerous tools only, params only (100k cap)"
+)
+_INIT_FAILED_REASON_PREFIX = (
+    "scanner init failed; enforcement disabled for this session; calls allowed unscanned: "
+)
+_COLD_BLOCK_REASON = "cold-window block: scanners not up, no finding; blocked by fail-mode policy"
+_MAX_INIT_ERROR_CHARS = 60
+
+
+def _note_cold_start_session(session_id: str | None, event_type: str) -> bool:
+    """RESERVE the ``(session_id, event_type)`` marker key; True iff this call won it.
+
+    Claim-then-release, not claim-after-emit: the spool writer returns False on any write
+    failure (locked or full disk, handle contention during rotation, a permission fault
+    after a profile switch), and a plain claim-then-emit would consume the key, land no row,
+    and deduplicate every later call in that session away — a session that ran degraded with
+    zero durable evidence, the exact silent failure this record class exists to prevent.
+    Check-then-commit is not an option either: it would let two concurrent same-session calls
+    both emit, and the lock cannot be held across the emit.
+
+    ``session_id`` is None for the uncorrelatable shape (no task_id, no _agent), which
+    ``_derive_session_id`` answers with a fresh ``anon-<uuid>`` per call; those latch on a
+    pair of process-wide booleans instead, mutated under this same lock so two concurrent
+    uncorrelatable calls cannot both emit.
+    """
+    global _cold_start_anon_degraded, _cold_start_anon_init_failed
+    with _cold_start_lock:
+        if session_id is None:
+            if event_type == "init_failed":
+                if _cold_start_anon_init_failed:
+                    return False
+                _cold_start_anon_init_failed = True
+            else:
+                if _cold_start_anon_degraded:
+                    return False
+                _cold_start_anon_degraded = True
+            return True
+        key = (session_id, event_type)
+        if key in _cold_start_records:
+            return False
+        _cold_start_records[key] = None
+        # Drop-oldest by insertion order, mirroring _bump_bypass_count's bound. Above the
+        # cap this can evict one member of a live session's pair while keeping the other,
+        # so "at most one of each per session" holds below the cap; above it, duplication
+        # (never suppression) is the accepted direction.
+        if len(_cold_start_records) > _MAX_COLD_START_KEYS:
+            _cold_start_records.pop(next(iter(_cold_start_records)), None)
+        return True
+
+
+def _release_cold_start_claim(session_id: str | None, event_type: str) -> None:
+    """Give the key back after a failed spool write, so a later call retries.
+
+    ``pop(key, None)``, never ``del``: drop-oldest eviction can remove a reserved key before
+    its write fails, and a KeyError here would propagate — the call sites sit in a region of
+    ``_pre_tool_call`` with no ``try`` around it, and the fail-open rule forbids adding one.
+    The uncorrelatable branch releases its boolean symmetrically; without that, one failed
+    write would latch the process out of ever recording the marker again.
+    """
+    global _cold_start_anon_degraded, _cold_start_anon_init_failed
+    with _cold_start_lock:
+        if session_id is None:
+            if event_type == "init_failed":
+                _cold_start_anon_init_failed = False
+            else:
+                _cold_start_anon_degraded = False
+            return
+        _cold_start_records.pop((session_id, event_type), None)
+
+
+def _log_cold_start_emit_failure(event_type: str, session_id: str, reason: str) -> None:
+    """Rate-limited WARNING carrying the record the spool could not take. The retry is
+    unbounded (a later call may find the spool writable again); the LOG is not."""
+    global _last_cold_start_fail_log
+    now = time.monotonic()
+    with _cold_start_log_lock:
+        if now - _last_cold_start_fail_log < _DISARM_LOG_EVERY_S:
+            return
+        _last_cold_start_fail_log = now
+    logger.warning(
+        "PETASOS_COLD_START_UNRECORDED type=%s session=%s: enforcement spool write failed; %s",
+        event_type,
+        session_id,
+        reason,
+    )
+
+
+def _emit_cold_start_marker(
+    *, latch_key: str | None, session_id: str, tool: str, event_type: str, reason: str
+) -> None:
+    """Emit one per-session, non-blocking cold-start marker (at most once per
+    ``(session, type)``). Placed so an emission failure can never alter the allow/block
+    decision, and adds no ``try`` of its own — ``_emit_enforcement_event`` is self-guarded."""
+    if not _note_cold_start_session(latch_key, event_type):
+        return
+    if not _emit_enforcement_event(
+        session_id=session_id,
+        tool=tool,
+        event_type=event_type,
+        param_scan_degraded=True,
+        reason=reason,
+    ):
+        _release_cold_start_claim(latch_key, event_type)
+        _log_cold_start_emit_failure(event_type, session_id, reason)
 
 
 def _reset_reload_logs() -> None:
@@ -1224,13 +1507,104 @@ def _pre_tool_call(
             )
         return None
     if not _ensure_initialized():
-        if _init_error:
+        # PET-167: the cold window now has two real outcomes instead of one, and every call
+        # that reaches here leaves a durable record of which. `is not None`, not truthiness:
+        # an empty _init_error would otherwise read as "still initializing" forever.
+        cold_session_id = _derive_session_id(task_id, kwargs)
+        # PET-134 D1b discriminator, applied to the latch: with no task_id and no _agent,
+        # _derive_session_id mints a fresh anon-<uuid> per call, so key the marker on the
+        # process instead. The INPUTS decide, not the derived string.
+        latch_key: str | None = (
+            None if (not task_id and kwargs.get("_agent") is None) else cold_session_id
+        )
+        if _init_error is not None:
             logger.debug("Petasos init failed — allowing tool call")
+            # Allow/deny behavior on this branch is deliberately UNCHANGED; the record makes
+            # a total, silent enforcement loss visible, it does not start blocking.
+            _emit_cold_start_marker(
+                latch_key=latch_key,
+                session_id=cold_session_id,
+                tool=tool_name,
+                event_type="init_failed",
+                reason=(_INIT_FAILED_REASON_PREFIX + (_init_error or "")[:_MAX_INIT_ERROR_CHARS]),
+            )
             return None
+
+        # Marker first, BEFORE the dispatch and independent of _is_dangerous — the fallback
+        # returns early for read-only tools, so a read_file-only cold session would
+        # otherwise leave no record at all. Emitted on every call that reaches here
+        # (including the no-init-in-flight escape hatch, where no wait ever ran); the latch
+        # makes that one record per session, not one per call. The _initialized re-read is
+        # the TOCTOU guard: init can complete while this branch runs.
+        if not _initialized:
+            _emit_cold_start_marker(
+                latch_key=latch_key,
+                session_id=cold_session_id,
+                tool=tool_name,
+                event_type="cold_start_degraded",
+                reason=(
+                    _COLD_START_REASON if _init_thread_started else _COLD_START_REASON_NO_INIT
+                ),
+            )
+
         # Init still in progress — use MinimalScanner fallback so we don't
         # silently allow during the cold-start window (fail_mode=closed
         # means we should be blocking, not passing through).
-        return _fallback_pre_tool_call(tool_name, args, task_id, **kwargs)
+        out = _fallback_pre_tool_call(tool_name, args, task_id, **kwargs)
+        # Read the out-of-band outcome, then CLEAR it on every exit: a stale value surviving
+        # on a pooled gateway thread would route the next cold-window call around the
+        # fail-secure default (a leftover "skipped" maps to allow).
+        outcome = getattr(_fallback_state, "outcome", None)
+        _fallback_state.outcome = None
+        if out is not None:
+            # A finding-driven block is returned UNCONDITIONALLY, even if init completed
+            # mid-scan: it is justified by a real syntactic finding regardless of init
+            # state, and _fallback_pre_tool_call has already written its quarantine event.
+            # Falling through here would discard the block while leaving a block-class row
+            # on the console for a call that was allowed.
+            return out
+        if _initialized:
+            pass  # init landed mid-scan: fall through to the main path rather than block
+        elif not _is_dangerous(tool_name):
+            # Read-only tools are allowed in the window exactly as the warm path allows
+            # them. This gate sits AHEAD of the outcome read, so the fail-secure default
+            # below can never mass-block read_file / search / web_search / list_directory.
+            return None
+        elif outcome == "clean" and (_config or {}).get("fail_mode") == "open":
+            # Only `open` can allow a dangerous call, and only when the syntactic scan
+            # actually ran and came back clean. Any fail_mode value that is not exactly
+            # "open" is treated as degraded, mirroring _compute_safe's invalid-value
+            # fallback — garbage fails secure by construction. An unreadable outcome
+            # (None or unrecognized) is treated as errored and blocks under every fail_mode.
+            return None
+        else:
+            logger.warning(
+                "PETASOS_QUARANTINE tool=%s session=%s — cold window, scan outcome=%s",
+                tool_name,
+                cold_session_id,
+                outcome if outcome in ("clean", "errored") else "unreadable",
+            )
+            # Block-class so the operator surface counts it: _BLOCK_EVENT_TYPES drives the
+            # blocked tile, the per-session tally and the red badge. Without it a real
+            # enforcement block renders as a green "safe" row. NOT emitted on the
+            # finding-driven path above, which already emitted its own.
+            _emit_enforcement_event(
+                session_id=cold_session_id,
+                tool=tool_name,
+                event_type="quarantine",
+                param_scan_degraded=True,
+                reason=_COLD_BLOCK_REASON,
+            )
+            return {
+                "action": "block",
+                # No finding to format on this sub-path. "degraded" is an existing
+                # ContentBlockPath whose reason is exactly this branch's semantics; a new
+                # token would encode a distinction that does not exist (the warm-path
+                # param_scan_degraded block at the bottom of this function is the same
+                # decision under the same policy). The operator-facing distinction rides
+                # the enforcement event instead.
+                "message": format_content_block("degraded", tool_name, ()),
+            }
 
     # PET-126: initialized here — pick up any live config.yaml change before this
     # call is evaluated. Self-guarded and fail-safe; never blocks the tool call.
@@ -1579,8 +1953,21 @@ def register(ctx) -> None:
             daemon=True,
             name="petasos-init",
         )
-        init_thread.start()
-        logger.info("Petasos plugin registered — hooks active, scanner init in background")
+        # PET-167: roll the flag back if the thread never starts. Otherwise it latches with
+        # no _deferred_init behind it, _init_done is never set, and every cold call spends
+        # the wait budget on an init that will never happen — where today the process
+        # self-heals by initializing in-line on the next call.
+        try:
+            init_thread.start()
+        except Exception as exc:
+            _init_thread_started = False
+            logger.error(
+                "Petasos init thread failed to start: %s — falling back to in-line init "
+                "on the first tool call",
+                exc,
+            )
+        else:
+            logger.info("Petasos plugin registered — hooks active, scanner init in background")
     elif _session_resolution is not None:
         # Forced-rediscovery re-register of an already-started process: re-bind the live
         # pipeline to the freshly-captured resolution (re-pin, reset the (mtime,size)-keyed

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -31,9 +31,9 @@ The editor shows 11 sections, in this render order:
 10. Alerting
 11. Session Management
 
-Together these cover 60 editable fields.
+Together these cover 61 editable fields.
 
-<!-- petasos-doc-assert: config_field_count=60 -->
+<!-- petasos-doc-assert: config_field_count=61 -->
 
 Each field below is named exactly as it appears in config files and the editor.
 Where a field has a safe range or a fixed set of choices, it is given.
@@ -152,6 +152,12 @@ when to stop calling one that keeps failing.*
   before another chance (minimum 0.01). While benched it is skipped instantly but
   still counts as failed, so the fail mode decides whether content is blocked
   meanwhile; the zero-dependency syntactic check keeps running regardless.
+- `init_wait_timeout_seconds`: how many seconds a tool call waits for the
+  scanners to finish starting up before falling back to the fast pattern scan
+  (0.05 to 60 seconds). Applies to the Hermes plugin's startup window only; it
+  has no effect when Petasos is embedded directly as a library. Values below
+  0.05 are raised to 0.05, and 0 or a negative value falls back to the default
+  of 2. What happens after the wait expires is decided by the fail mode setting.
 - `presidio_entities`: replace the PII scanner's detected entity list wholesale.
   Leave unset to use the curated default (the security-relevant types), which
   deliberately omits noisier types that misfire on file paths and code.
@@ -332,4 +338,4 @@ editor, so do not conclude this page is incomplete if you cannot find them:
 <!-- Drift-guard index: the full set of editor-surfaced field names documented
      above. Kept in sync with petasos.console._config_meta._FIELD_META by
      tests/test_docs_usage_consistency.py. -->
-<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,audit_emit_findings,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones,source_taint_namespaces,taint_min_span_length -->
+<!-- petasos-doc-assert: config_fields=profile_name,anonymize,pii_entities,redaction_mode,hash_key,fail_mode,tool_guard_enabled,subagent_lineage_enabled,delegate_fanout_enabled,lineage_max_depth,lineage_max_edges,lineage_edge_ttl_seconds,delegate_max_fanout_per_window,delegate_fanout_window_seconds,delegate_tool_names,egress_sink_tools,direction,scanner_timeout_seconds,scanner_circuit_breaker_threshold,scanner_circuit_breaker_cooldown_seconds,presidio_entities,presidio_entities_extra,presidio_score_threshold,normalize_nfkc,strip_zero_width,map_homoglyphs,decode_encoded_payloads,escalation_enabled,tier1_threshold,tier2_threshold,tier3_threshold,frequency_enabled,frequency_half_life_seconds,frequency_weights,rolling_window_seconds,rolling_threshold,audit_enabled,audit_verbosity,audit_emit_findings,alert_enabled,alert_cooldown_seconds,alert_per_minute_cap,alert_per_hour_cap,alert_critical_per_minute_cap,alert_high_severity_threshold,alert_rapid_fire_count,alert_rapid_fire_window_seconds,alert_cross_session_burst_count,alert_cross_session_burst_window_seconds,alert_pii_volume_threshold,alert_pii_volume_window_seconds,alert_ring_buffer_capacity,alert_per_session_contribution_cap,alert_max_session_contribution_entries,max_sessions,session_ttl_seconds,max_new_sessions_per_minute,max_terminated_tombstones,source_taint_namespaces,taint_min_span_length,init_wait_timeout_seconds -->

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -82,6 +82,16 @@ class PetasosConfig:
     scanner_circuit_breaker_threshold: int = 3
     scanner_circuit_breaker_cooldown_seconds: float = 30.0
 
+    # PET-167: how long a tool call waits for scanner init to finish before falling back to
+    # the syntactic-only scan. Consumed ONLY by the Hermes deployment shim's cold-start
+    # window (docs/deployment/reference_plugin/__init__.py); nothing in petasos/ reads it, so
+    # a library embedder who sets it gets no behavior change — help_plain says so. 2.0 is
+    # long enough to absorb a warm-ish start, short enough not to visibly stall a one-shot
+    # invocation, and well under a measured ~12s full init so the timeout branch is genuinely
+    # exercised in the field. The shim re-clamps the raw value itself (this validation
+    # protects the pipeline's copy and the Config Editor, not the hook thread).
+    init_wait_timeout_seconds: float = 2.0
+
     # Anonymization
     anonymize: bool = False
     pii_entities: tuple[str, ...] = ()
@@ -310,6 +320,17 @@ class PetasosConfig:
         if self.scanner_timeout_seconds > 60.0:
             raise ValueError(
                 f"scanner_timeout_seconds must be <= 60, got {self.scanner_timeout_seconds!r}"
+            )
+        # PET-167: mirrors the scanner_timeout_seconds idiom (finite, > 0, <= 60).
+        init_wait = self.init_wait_timeout_seconds
+        if init_wait <= 0 or not math.isfinite(init_wait):
+            raise ValueError(
+                f"init_wait_timeout_seconds must be positive and finite, "
+                f"got {self.init_wait_timeout_seconds!r}"
+            )
+        if self.init_wait_timeout_seconds > 60.0:
+            raise ValueError(
+                f"init_wait_timeout_seconds must be <= 60, got {self.init_wait_timeout_seconds!r}"
             )
         if (
             not isinstance(self.scanner_circuit_breaker_threshold, int)

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -119,6 +119,21 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "section": "scanning",
         "constraints": {"min": 0.01, "max": 60},
     },
+    "init_wait_timeout_seconds": {
+        "description": "How long a tool call waits for scanners to finish starting up.",
+        "help_plain": (
+            "How many seconds a tool call waits for the security scanners to finish"
+            " loading before giving up and falling back to the fast pattern scan."
+            " Applies to the Hermes plugin's startup window; it has no effect when"
+            " Petasos is embedded directly as a library. Lower keeps short sessions"
+            " snappy; higher gives the full scanners more time to come up, up to 60"
+            " seconds. Values below 0.05 are raised to 0.05, and 0 or a negative"
+            " value falls back to the default of 2. What happens after the wait"
+            " expires is decided by the fail mode setting."
+        ),
+        "section": "scanning",
+        "constraints": {"min": 0.05, "max": 60},
+    },
     "scanner_circuit_breaker_threshold": {
         "description": "Consecutive timeouts before a scanner is temporarily benched.",
         "help_plain": (

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1103,6 +1103,11 @@
     var isBypass = isEnf && et === "bypassed_disarmed";
     // PET-164: self-tamper classification rows (detection only, never a block).
     var isSelfmod = isEnf && et === "selfmod_attempt";
+    // PET-167: cold-start markers are enforcement rows that are NOT enforcement decisions,
+    // so without their own arm every branch below misses and the panel falls to the
+    // terminal "Unknown row kind" else, where `reason` (the whole payload) is never
+    // rendered at all.
+    var isColdStart = isEnf && (et === "cold_start_degraded" || et === "init_failed");
     var isEnfDecision = isEnf && !!ENF_KINDS[et];
     var isPlayground = (e.source == null || e.source === "" || e.source === "playground");
 
@@ -1117,6 +1122,11 @@
     var scanRan;
     if (isBypass) scanRan = "no (bypassed while Unequipped)";
     else if (isSelfmod) scanRan = "n/a (tool argument classification, not a content scan)";
+    // PET-167: this chain is separate from the body branches below, so a body-only edit
+    // would leave a row whose entire purpose is to state scan coverage reading "unknown".
+    else if (isColdStart) scanRan = (et === "init_failed")
+      ? "no (enforcement disabled; init failed)"
+      : "partial (syntactic scan only; ML scanners still starting)";
     else if (isEnfDecision || isPlayground) scanRan = "yes";
     else scanRan = "unknown";
     var armedStr;
@@ -1171,6 +1181,17 @@
       wrap.appendChild(fld("tool", e.tool));
       wrap.appendChild(fld("rule", e.rule_id));
       wrap.appendChild(fld("severity", e.severity));
+      wrap.appendChild(fld("reason", e.reason));
+      wrap.appendChild(fld("session", e.session_id));
+    } else if (isColdStart) {
+      // PET-167: cold-start marker drill-down. Non-blocking by design: the record says what
+      // coverage this session actually got, it is not itself a decision.
+      wrap.appendChild(Pet.h("div", { className: "sd-heartbeat" },
+        Pet.h("div", {}, (et === "init_failed")
+          ? "Scanner startup failed: enforcement was disabled for this session and calls ran unscanned."
+          : "Scanners were still starting: this session ran on the fast pattern scan only."),
+        Pet.h("div", { className: "sd-sub" }, "One record per session, not per call. It marks coverage; blocks made during the window appear as their own rows.")));
+      wrap.appendChild(fld("tool", e.tool));
       wrap.appendChild(fld("reason", e.reason));
       wrap.appendChild(fld("session", e.session_id));
     } else if (isEnfDecision) {
@@ -1280,6 +1301,11 @@
       // summary), but it must never wear the green "safe" badge; amber "self-tamper"
       // keeps red reserved for actual blocks.
       var isSelfmodRow = isEnforcement && et === "selfmod_attempt";
+      // PET-167: cold-start markers. The summary carries safe=true (they block nothing and
+      // stay out of _BLOCK_EVENT_TYPES, so they never inflate the blocked tile), but a row
+      // meaning "we did not scan" must never wear the green safe pill. Amber for both:
+      // never green ok, never red err.
+      var isColdStart = isEnforcement && (et === "cold_start_degraded" || et === "init_failed");
       var isBlocked = (e.safe === false); // strict ===false; truthy-but-not-false is not "blocked"
 
       // PET-165: severity-differentiated self-tamper badge. Severity rides the badge TEXT
@@ -1295,10 +1321,14 @@
         ? "bypassed (disarmed)"
         : (isSelfmodRow
             ? ("self-tamper" + (selfmodSev ? (" (" + selfmodSev + ")") : ""))
-            : (isBlocked ? "blocked" : "safe"));
+            : (isColdStart
+                ? (et === "init_failed" ? "unenforced" : "degraded")
+                : (isBlocked ? "blocked" : "safe")));
       var badgeClass = isBypass
         ? "warn"
-        : (isSelfmodRow ? (selfmodSev === "critical" ? "err" : "warn") : (isBlocked ? "err" : "ok"));
+        : (isSelfmodRow
+            ? (selfmodSev === "critical" ? "err" : "warn")
+            : (isColdStart ? "warn" : (isBlocked ? "err" : "ok")));
       var badge = Pet.h("span", { className: "pill " + badgeClass, style: { justifyContent: "center" } }, badgeText);
 
       var rowEls = [];

--- a/tests/js/cold-start-row.test.mjs
+++ b/tests/js/cold-start-row.test.mjs
@@ -1,0 +1,202 @@
+// Unit tests for cold-start marker rendering (petasos.js), PET-167.
+//
+// `cold_start_degraded` and `init_failed` are per-session, non-blocking markers: the
+// summary carries safe=true and finding_count=0, and they stay out of the block-class
+// set so they never inflate the blocked tile. But a row whose entire meaning is "we did
+// not scan" must not render as if everything was fine. Three surfaces are pinned:
+//
+//   - the row badge, which fell through to the green "safe" pill;
+//   - the provenance line's `scan ran:` value, computed in a chain SEPARATE from the
+//     body branches, which read "unknown";
+//   - the drill-down body, which fell to the terminal "Unknown row kind" branch and so
+//     never rendered `reason` at all.
+//
+// Modelled case-for-case on selfmod-row.test.mjs. Zero npm deps: Node's built-in test
+// runner + a DOM shim + node:vm over the real shipped petasos.js.
+// Run with: node --test tests/js/cold-start-row.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+// ── DOM shim (same as selfmod-row.test.mjs) ─────────────────────────────────
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    title: "",
+    dataset: {},
+    _text: "",
+    setAttribute() {},
+    addEventListener() {},
+    appendChild(child) {
+      this.childNodes.push(child);
+      return child;
+    },
+    get textContent() {
+      if (this.nodeType === 3) return this.nodeValue;
+      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
+    },
+    set textContent(v) {
+      this._text = String(v);
+      this.childNodes = [];
+    },
+  };
+}
+
+const document = {
+  createDocumentFragment() {
+    return makeNode(11);
+  },
+  createElement(tag) {
+    const el = makeNode(1);
+    el.tagName = tag.toUpperCase();
+    el.localName = tag;
+    return el;
+  },
+  createTextNode(t) {
+    const node = makeNode(3);
+    node.nodeValue = String(t);
+    return node;
+  },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = { window: {}, document };
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+function findEl(node, pred) {
+  for (const child of node.childNodes || []) {
+    if (child.nodeType === 1) {
+      if (pred(child)) return child;
+      const found = findEl(child, pred);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+const hasClass = (cls) => (el) => typeof el.className === "string" && el.className.split(/\s+/).includes(cls);
+function text(tree) {
+  return tree.textContent;
+}
+
+const ENF_DEGRADED = {
+  source: "enforcement",
+  safe: true, // non-blocking marker: not counted as a block
+  event_type: "cold_start_degraded",
+  tool: "write_file",
+  reason:
+    "scanners not up; tool results unscanned (warm path too); syntactic only, dangerous tools only, params only (100k cap)",
+  armed: true,
+  session_id: "sess-cold",
+  duration_ms: 0,
+  finding_count: 0,
+  timestamp: 1700000000,
+  scan_id: "e-cs1",
+};
+
+const ENF_INIT_FAILED = {
+  ...ENF_DEGRADED,
+  event_type: "init_failed",
+  reason:
+    "scanner init failed; enforcement disabled for this session; calls allowed unscanned: No module named 'x'",
+  scan_id: "e-cs2",
+};
+
+// ── a. badge ────────────────────────────────────────────────────────────────
+
+test("cold-start badges are amber and never the green safe pill", () => {
+  for (const [row, label] of [
+    [ENF_DEGRADED, "degraded"],
+    [ENF_INIT_FAILED, "unenforced"],
+  ]) {
+    const tree = Pet.scanHistoryRows([row]);
+    assert.equal(
+      findEl(tree, (el) => hasClass("ok")(el) && el.textContent === "safe"),
+      null,
+      `${row.event_type} must not wear the green 'safe' badge`
+    );
+    const badge = findEl(tree, (el) => el.textContent === label);
+    assert.ok(badge, `${label} badge present`);
+    assert.ok(hasClass("warn")(badge), `${label} rides the amber warn class`);
+    assert.ok(!hasClass("err")(badge), `${label} is not red: it blocks nothing`);
+    assert.equal(
+      findEl(tree, (el) => el.textContent === "blocked"),
+      null,
+      "a marker is never rendered as a block"
+    );
+    const enfPill = findEl(tree, hasClass("blue"));
+    assert.ok(enfPill && enfPill.textContent === "enf", "enf source pill present");
+  }
+});
+
+// ── b. provenance ───────────────────────────────────────────────────────────
+
+test("cold-start provenance states coverage, never 'unknown'", () => {
+  const degraded = text(Pet.scanDetailPanel(ENF_DEGRADED));
+  assert.ok(
+    degraded.includes("scan ran: partial (syntactic scan only; ML scanners still starting)"),
+    "cold_start_degraded states partial coverage"
+  );
+  assert.ok(!degraded.includes("scan ran: unknown"), "never falls through to 'unknown'");
+
+  const failed = text(Pet.scanDetailPanel(ENF_INIT_FAILED));
+  assert.ok(
+    failed.includes("scan ran: no (enforcement disabled; init failed)"),
+    "init_failed states that nothing was scanned"
+  );
+  assert.ok(!failed.includes("scan ran: unknown"), "never falls through to 'unknown'");
+});
+
+// ── c. drill-down body ──────────────────────────────────────────────────────
+
+test("cold-start detail renders the reason, not the unknown-row fallback", () => {
+  for (const row of [ENF_DEGRADED, ENF_INIT_FAILED]) {
+    const t = text(Pet.scanDetailPanel(row));
+    assert.ok(!t.includes("Unknown row kind"), `${row.event_type} must not hit the unknown branch`);
+    assert.ok(t.includes(row.reason), "reason rendered (it carries the whole payload)");
+    assert.ok(t.includes(row.tool), "tool rendered");
+    assert.ok(t.includes(row.session_id), "session rendered");
+  }
+  assert.ok(
+    text(Pet.scanDetailPanel(ENF_DEGRADED)).includes("fast pattern scan only"),
+    "degraded explainer rendered"
+  );
+  assert.ok(
+    text(Pet.scanDetailPanel(ENF_INIT_FAILED)).includes("enforcement was disabled"),
+    "init_failed explainer rendered"
+  );
+});
+
+// ── d. robustness ───────────────────────────────────────────────────────────
+
+test("cold-start row/detail never throw on missing fields; no 'undefined' text", () => {
+  const bare = { source: "enforcement", event_type: "init_failed", scan_id: "e-cs3" };
+  assert.doesNotThrow(() => Pet.scanHistoryRows([bare]));
+  assert.doesNotThrow(() => Pet.scanDetailPanel(bare));
+  const t = text(Pet.scanDetailPanel(bare)) + text(Pet.scanHistoryRows([bare]));
+  assert.ok(!/undefined/.test(t), "absent fields show the no-data glyph, never 'undefined'");
+  assert.ok(t.includes("—"), "absent fields render the no-data glyph");
+});
+
+// ── e. house style ──────────────────────────────────────────────────────────
+
+test("cold-start labels carry no banned dash (em / en / double-hyphen)", () => {
+  // Fully-populated rows only: the no-data glyph is a legitimate "—" and is exercised
+  // by the bare-row case above.
+  const t =
+    text(Pet.scanHistoryRows([ENF_DEGRADED, ENF_INIT_FAILED])) +
+    text(Pet.scanDetailPanel(ENF_DEGRADED)) +
+    text(Pet.scanDetailPanel(ENF_INIT_FAILED));
+  assert.ok(!t.includes("—"), "no em dash in labels");
+  assert.ok(!t.includes("–"), "no en dash in labels");
+  assert.ok(!t.includes("--"), "no double-hyphen in labels");
+});

--- a/tests/test_enforcement_events.py
+++ b/tests/test_enforcement_events.py
@@ -669,11 +669,18 @@ def test_fallback_init_window_block_emits_event(
     out = ref._pre_tool_call("send_email", {"text": "x"}, task_id="sess-F")
     assert out is not None and out["action"] == "block"
     events = _read_spool(spool)
-    assert len(events) == 1
-    assert events[0]["event_type"] == "quarantine"
-    assert events[0]["session_id"] == "sess-F"
-    assert events[0]["tool"] == "send_email"
-    assert events[0]["rule_id"] == "petasos.injection.x"
+    # PET-167: the same call now also emits a per-session cold_start_degraded marker, and it
+    # is written BEFORE the fallback's quarantine — so the raw spool order is
+    # [cold_start_degraded, quarantine] and every index-0 assertion below would read the
+    # wrong row. Filter to the block-class event instead of pinning the spool length.
+    quarantines = [e for e in events if e["event_type"] == "quarantine"]
+    assert len(quarantines) == 1
+    assert quarantines[0]["session_id"] == "sess-F"
+    assert quarantines[0]["tool"] == "send_email"
+    assert quarantines[0]["rule_id"] == "petasos.injection.x"
+    markers = [e for e in events if e["event_type"] == "cold_start_degraded"]
+    assert len(markers) == 1
+    assert markers[0]["session_id"] == "sess-F"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reference_plugin_block_messages.py
+++ b/tests/test_reference_plugin_block_messages.py
@@ -462,4 +462,4 @@ def test_shim_routes_every_block_site_through_formatter() -> None:
         and isinstance(node.func, ast.Name)
         and node.func.id in targets
     )
-    assert call_sites >= 8, f"expected >=8 formatter call sites in the shim, found {call_sites}"
+    assert call_sites == 8, f"expected 8 formatter call sites in the shim, found {call_sites}"

--- a/tests/test_reference_plugin_block_messages.py
+++ b/tests/test_reference_plugin_block_messages.py
@@ -133,6 +133,32 @@ def _drive(
     return ref._pre_tool_call(tool_name, args or {"text": "x"}, task_id="s1")
 
 
+def _drive_cold_window_no_finding(
+    monkeypatch: pytest.MonkeyPatch, tool_name: str = "write_file", fail_mode: str = "degraded"
+) -> Any:
+    """PET-167: drive ``_pre_tool_call`` down the cold-window NO-finding block — the wait
+    expired, the syntactic fallback scanned clean, and ``fail_mode`` blocks the dangerous
+    call. This is the eighth formatter site."""
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_ensure_initialized", lambda: False)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_initialized", False)
+    monkeypatch.setattr(ref, "_config", {"fail_mode": fail_mode})
+
+    class _Clean:
+        name = "minimal"
+
+        async def scan(
+            self, text: str, *, direction: str = "inbound", session_id: str | None = None
+        ) -> ScanResult:
+            return ScanResult(scanner_name="minimal", findings=())
+
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+    monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: _Clean())
+    return ref._pre_tool_call(tool_name, {"text": "x"}, task_id="s-cold")
+
+
 def _drive_fallback(
     monkeypatch: pytest.MonkeyPatch, tool_name: str, finding: ScanFinding | None
 ) -> Any:
@@ -269,6 +295,21 @@ def test_init_fallback_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Security scan (init in progress)" not in msg
 
 
+def test_cold_window_no_finding_block_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-167: the cold-window block that has NO syntactic finding behind it
+    # (clean or errored scan under degraded/closed) still carries the PET-77 contract. It
+    # reuses the existing "degraded" ContentBlockPath rather than minting a new token: this
+    # and the warm-path param_scan_degraded block are the same decision under the same
+    # policy. No "Top finding:" clause — there is no finding on this sub-path.
+    out = _drive_cold_window_no_finding(monkeypatch)
+    assert out is not None and out["action"] == "block"
+    msg = out["message"]
+    assert msg.startswith(_PREFIX)
+    assert "write_file" in msg and "NOT executed" in msg
+    assert "degraded" in msg.lower()
+    assert "Top finding:" not in msg
+
+
 def test_no_internal_reason_strings_leak(monkeypatch: pytest.MonkeyPatch) -> None:
     # Regression for PET-77: no internal reason string or raw block string reaches the
     # model across every enforcement path, AND a unique sentinel reason is never echoed
@@ -326,6 +367,8 @@ def test_no_internal_reason_strings_leak(monkeypatch: pytest.MonkeyPatch) -> Non
             "message"
         ]
     )
+    # PET-167: the cold-window no-finding block joins the catalogue.
+    messages.append(_drive_cold_window_no_finding(monkeypatch)["message"])
 
     forbidden = (
         "exempt-with-scan",
@@ -400,11 +443,16 @@ def test_shim_emits_branding() -> None:
 
 
 def test_shim_routes_every_block_site_through_formatter() -> None:
-    # Regression for PET-77: each of the six block sites must route through the formatter.
-    # Counting call sites closes the hole B2 leaves open (a NEW ad-hoc f-string at a single
-    # site would pass B2 but drop the count below six). Parse the AST and count real Call
-    # nodes so the names appearing in the import, comments, or string literals are not
-    # miscounted (a raw src.count() would inflate the total and could mask a removed site).
+    # Regression for PET-77: each block site must route through the formatter. Counting
+    # call sites closes the hole B2 leaves open (a NEW ad-hoc f-string at a single site
+    # would pass B2 but drop the count). Parse the AST and count real Call nodes so the
+    # names appearing in the import, comments, or string literals are not miscounted (a raw
+    # src.count() would inflate the total and could mask a removed site).
+    #
+    # Regression for PET-167: bumped 6 -> 8. The tree already had SEVEN sites — PET-134's
+    # taint_egress site was added without bumping the assertion, leaving it unguarded — and
+    # PET-167's cold-window no-finding block is the eighth. The reconciliation is done here
+    # so the number is exact rather than merely non-decreasing.
     tree = ast.parse(_shim_source())
     targets = {"format_block_message", "format_content_block"}
     call_sites = sum(
@@ -414,4 +462,4 @@ def test_shim_routes_every_block_site_through_formatter() -> None:
         and isinstance(node.func, ast.Name)
         and node.func.id in targets
     )
-    assert call_sites >= 6, f"expected >=6 formatter call sites in the shim, found {call_sites}"
+    assert call_sites >= 8, f"expected >=8 formatter call sites in the shim, found {call_sites}"

--- a/tests/test_reference_plugin_cold_start.py
+++ b/tests/test_reference_plugin_cold_start.py
@@ -1,0 +1,925 @@
+"""PET-167: bounded init wait + durable cold-start visibility in the deployment shim.
+
+Before this ticket the first tool call of a cold process queued on ``_init_lock`` for the
+full remaining backend verification (measured: unbounded, roughly 12s in production) and
+then took the main path. Two consequences, both load-bearing:
+
+  - ``_fallback_pre_tool_call`` was unreachable dead code, so the syntactic-only guard the
+    cold window advertises never ran;
+  - a one-shot invocation could start and finish inside that window having been enforced by
+    nothing, and leave no record saying so.
+
+The regression class guarded here is "a security control that reports itself active while
+its enforcement path is unreachable". Tests 1, 7, 18 and 24 fail against 3f17365.
+
+Backend-free: no ML pipeline. The reference plugin is not importable as a package, so each
+test loads a FRESH module via ``spec_from_file_location`` — ``_init_done`` is sticky and
+irreversible, so a shared module would leak state between tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import math
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import petasos.console._events as ev
+from petasos import GuardResult, PetasosConfig, ScanFinding, ScanResult, Severity
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterator
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+_FAIL_MODES = ("open", "degraded", "closed")
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet167", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PETASOS_LICENSE_KEY", "PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _set(ref: types.ModuleType, name: str, value: Any) -> None:
+    """Write a module global on the freshly imported shim.
+
+    Direct attribute assignment on a ModuleType is rejected by ``mypy --strict``, and a
+    setattr call with a literal attribute name by ruff's B010, so the name goes through a
+    parameter. Used from background threads too, where a monkeypatch undo record would be
+    the wrong shape anyway.
+    """
+    setattr(ref, name, value)
+
+
+def _read_spool() -> list[dict[str, Any]]:
+    """Every event on the (conftest-isolated) enforcement spool."""
+    out: list[dict[str, Any]] = []
+    try:
+        with open(ev._spool_path(), encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if s:
+                    out.append(json.loads(s))
+    except FileNotFoundError:
+        return []
+    return out
+
+
+def _of_type(event_type: str) -> list[dict[str, Any]]:
+    return [e for e in _read_spool() if e.get("event_type") == event_type]
+
+
+def _finding(severity: Severity = Severity.CRITICAL) -> ScanFinding:
+    return ScanFinding(
+        rule_id="petasos.injection.x",
+        finding_type="injection",
+        severity=severity,
+        confidence=0.9,
+        message="injection finding",
+        scanner_name="minimal",
+    )
+
+
+class _GuardSpy:
+    """Permissive guard double. Required by test 38: ``_pre_tool_call`` wraps
+    ``_guard.evaluate`` in an ``except Exception`` that logs and returns None, so a
+    fall-through that crashes on ``_guard is None`` looks identical to "not blocked"."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def evaluate(self, tool_name: str, args: dict[str, Any], session_id: str) -> GuardResult:
+        self.calls.append(tool_name)
+        return GuardResult(
+            allowed=True, reason="allowed", findings=(), tier="none", param_scan_unsafe=False
+        )
+
+
+def _open_window(
+    monkeypatch: pytest.MonkeyPatch,
+    ref: types.ModuleType,
+    *,
+    fail_mode: str | None = "degraded",
+    budget: float = 0.05,
+    thread_started: bool = True,
+) -> None:
+    """Put a freshly imported module into the cold window: init in flight, nothing done."""
+    ref._reset_init_state()
+    ref._reset_cold_start_records()
+    config: dict[str, Any] = {"init_wait_timeout_seconds": budget}
+    if fail_mode is not None:
+        config["fail_mode"] = fail_mode
+    monkeypatch.setattr(ref, "_is_armed", lambda: True)
+    monkeypatch.setattr(ref, "_maybe_reconfigure", lambda: None)
+    monkeypatch.setattr(ref, "_config", config)
+    monkeypatch.setattr(ref, "_init_thread_started", thread_started)
+
+
+def _install_fallback_scanner(
+    monkeypatch: pytest.MonkeyPatch,
+    ref: types.ModuleType,
+    *,
+    findings: tuple[ScanFinding, ...] = (),
+    raises: bool = False,
+    on_scan: Any = None,
+) -> None:
+    """Wire a stub MinimalScanner behind the fallback and run coroutines inline."""
+
+    class _Stub:
+        name = "minimal"
+
+        async def scan(
+            self, text: str, *, direction: str = "inbound", session_id: str | None = None
+        ) -> ScanResult:
+            if on_scan is not None:
+                on_scan()
+            if raises:
+                raise RuntimeError("scan boom")
+            return ScanResult(scanner_name="minimal", findings=findings)
+
+    monkeypatch.setattr(ref, "_get_fallback_scanner", lambda: _Stub())
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+
+
+def _spy_fallback(monkeypatch: pytest.MonkeyPatch, ref: types.ModuleType) -> list[str]:
+    """Record every ``_fallback_pre_tool_call`` invocation, delegating to the real one."""
+    seen: list[str] = []
+    real = ref._fallback_pre_tool_call
+
+    def spy(tool_name: str, args: dict[str, Any], task_id: str, **kwargs: Any) -> Any:
+        seen.append(tool_name)
+        return real(tool_name, args, task_id, **kwargs)
+
+    monkeypatch.setattr(ref, "_fallback_pre_tool_call", spy)
+    return seen
+
+
+def _complete_init_after(ref: types.ModuleType, delay: float) -> Iterator[threading.Thread]:
+    def worker() -> None:
+        time.sleep(delay)
+        _set(ref, "_initialized", True)
+        ref._init_done.set()
+
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    yield t
+
+
+# ---------------------------------------------------------------------------
+# Bounded wait (Decision 1)
+# ---------------------------------------------------------------------------
+
+
+def test_wait_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-167: the first cold call queued on _init_lock for the whole
+    # remaining init. `_deferred_init` is stubbed to a 5s block so the pre-PET-167
+    # implementation (which calls it synchronously) takes 5s where this one takes one
+    # budget. The wall time is asserted from BOTH sides: > 0 so a zero-wait implementation
+    # cannot pass, and well under the simulated init so an unbounded one cannot either.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, budget=0.2)
+    monkeypatch.setattr(ref, "_deferred_init", lambda: time.sleep(5.0))
+
+    t0 = time.monotonic()
+    assert ref._ensure_initialized() is False
+    elapsed = time.monotonic() - t0
+    assert elapsed >= 0.1, "a zero-wait implementation gives the scanners no chance at all"
+    assert elapsed < 2.0, f"wait was not bounded by the budget: {elapsed:.2f}s"
+
+
+def test_init_completing_inside_budget_takes_main_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, budget=5.0)
+    guard = _GuardSpy()
+    monkeypatch.setattr(ref, "_guard", guard)
+    monkeypatch.setattr(ref, "_run_async", lambda coro: asyncio.run(coro))
+    thread = next(_complete_init_after(ref, 0.05))
+
+    t0 = time.monotonic()
+    assert ref._ensure_initialized() is True
+    assert time.monotonic() - t0 < 4.0, "returned as soon as init signalled, not at the deadline"
+    thread.join(timeout=2.0)
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    assert guard.calls == ["write_file"], "the main path ran, not the fallback"
+    assert _of_type("cold_start_degraded") == []
+
+
+def test_no_init_thread_runs_synchronously(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The escape hatch: a host that never called register() (or a rolled-back thread start)
+    # has no background init to wait on, so today's synchronous in-line behavior is
+    # preserved rather than waiting on an Event nobody will ever set.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, thread_started=False)
+    ran: list[bool] = []
+
+    def fake_init() -> None:
+        ran.append(True)
+        _set(ref, "_initialized", True)
+
+    monkeypatch.setattr(ref, "_deferred_init", fake_init)
+
+    assert ref._ensure_initialized() is True
+    assert ran == [True]
+
+
+def test_budget_is_process_wide_not_per_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A naive per-call budget charges N calls N budgets inside one cold window — on the
+    # short-lived unattended surfaces this targets, a latency regression against today,
+    # where the process pays the remaining init once and zero thereafter.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, budget=0.3)
+
+    t0 = time.monotonic()
+    for _ in range(3):
+        assert ref._ensure_initialized() is False
+    elapsed = time.monotonic() - t0
+    assert elapsed < 0.9, f"three cold calls spent more than one budget: {elapsed:.2f}s"
+    assert ref._init_wait_expired is True
+
+
+def test_failed_thread_start_rolls_back_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    # register() sets _init_thread_started BEFORE start(). Unwrapped, a failed start latches
+    # the flag with no _deferred_init behind it: _init_done is never set and every cold call
+    # burns the budget on an init that will never happen.
+    ref = _import_reference_plugin()
+    ref._reset_init_state()
+    monkeypatch.setattr(ref, "_load_config", lambda res=None: {})
+
+    class _BoomThread:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            raise RuntimeError("can't start new thread")
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.hooks: list[str] = []
+
+        def register_hook(self, name: str, handler: Any) -> None:
+            self.hooks.append(name)
+
+    # A namespace, not the real threading module: patching threading.Thread globally would
+    # reach every other thread this process starts.
+    fake_threading = type("T", (), {"Thread": _BoomThread})
+    monkeypatch.setattr(ref, "threading", fake_threading)
+    ref.register(_Ctx())
+
+    assert ref._init_thread_started is False
+    ran: list[bool] = []
+
+    def fake_init() -> None:
+        ran.append(True)
+        _set(ref, "_initialized", True)
+
+    monkeypatch.setattr(ref, "_deferred_init", fake_init)
+    assert ref._ensure_initialized() is True
+    assert ran == [True], "the escape hatch must apply, so the process self-heals"
+
+
+def test_concurrent_first_callers_share_one_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The deadline is read ONCE into a local and `remaining` is computed from that local:
+    # re-reading the global after assignment lets two threads racing the first wait compose
+    # into a window of nearly two budgets.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, budget=0.3)
+    results: list[bool] = []
+    barrier = threading.Barrier(2)
+
+    def caller() -> None:
+        barrier.wait()
+        results.append(ref._ensure_initialized())
+
+    threads = [threading.Thread(target=caller) for _ in range(2)]
+    t0 = time.monotonic()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+    elapsed = time.monotonic() - t0
+
+    assert results == [False, False]
+    assert elapsed < 0.9, f"concurrent first callers composed past one budget: {elapsed:.2f}s"
+
+
+def test_late_init_success_upgrades_to_main_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The `_initialized` check must stay the FIRST statement in _ensure_initialized.
+    # Hoisting the expiry latch above it would pin the process to the syntactic fallback
+    # forever, even after every ML scanner came up — an indefinite silent enforcement
+    # downgrade on a long-lived gateway or dashboard process.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+    seen = _spy_fallback(monkeypatch, ref)
+    guard = _GuardSpy()
+    monkeypatch.setattr(ref, "_guard", guard)
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is not None
+    assert len(seen) == 1
+    assert len(_of_type("cold_start_degraded")) == 1
+
+    _set(ref, "_initialized", True)
+    ref._init_done.set()
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    assert len(seen) == 1, "the fallback must not run once init has landed"
+    assert guard.calls == ["write_file"]
+    assert len(_of_type("cold_start_degraded")) == 1, "no further marker after the upgrade"
+
+
+# ---------------------------------------------------------------------------
+# Fallback reachability (Decision 1)
+# ---------------------------------------------------------------------------
+
+
+def test_expired_wait_reaches_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-167: against 3f17365 this spy records ZERO calls — the fallback
+    # was unreachable dead code.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+    seen = _spy_fallback(monkeypatch, ref)
+
+    ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert seen == ["write_file"]
+
+
+# ---------------------------------------------------------------------------
+# fail_mode governance (Decision 2b) — one test per cell
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_tool_never_blocks_in_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The block decision is _is_dangerous-gated BEFORE fail_mode is consulted, mirroring
+    # the warm path. Without that gate the cold window would block read_file / search /
+    # web_search / list_directory for its whole duration under the DEFAULT fail_mode —
+    # strictly more aggressive than the warm path, on the tool class the warm path exempts
+    # by design, and on the very first call of a typical one-shot session.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+
+
+def test_open_allows_clean_dangerous_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="open")
+    _install_fallback_scanner(monkeypatch, ref)
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+
+
+@pytest.mark.parametrize("fail_mode", ["degraded", "closed"])
+def test_degraded_and_closed_block_clean_dangerous_call(
+    monkeypatch: pytest.MonkeyPatch, fail_mode: str
+) -> None:
+    # The clean-scan row is the all_ml_failure case: during the window all three ML
+    # scanners are unavailable, which _compute_safe maps to safe=False under
+    # degraded/closed. Cold-window blocking is CONSISTENT with the steady state, not
+    # harsher than it.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode=fail_mode)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+
+
+@pytest.mark.parametrize("fail_mode", _FAIL_MODES)
+def test_scan_error_blocks_under_every_fail_mode(
+    monkeypatch: pytest.MonkeyPatch, fail_mode: str
+) -> None:
+    # fail_mode-INDEPENDENT, `open` included. The warm-path analogue is guard.py's
+    # `if result.errors and not result.findings: return (), True, True` — reached via the
+    # inspect boundary in pipeline.py, which constructs errors with empty findings — a
+    # deliberate fail-safe per its own comment, NOT pipeline.py's fail_mode-dependent
+    # `syntactic_error` rule. Mirroring the latter would let the cold window allow a
+    # dangerous call whose parameters were never successfully scanned while the warm path
+    # on identical input blocks.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode=fail_mode)
+    _install_fallback_scanner(monkeypatch, ref, raises=True)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+
+
+@pytest.mark.parametrize("fail_mode", _FAIL_MODES)
+def test_syntactic_finding_blocks_under_every_fail_mode(
+    monkeypatch: pytest.MonkeyPatch, fail_mode: str
+) -> None:
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode=fail_mode)
+    _install_fallback_scanner(monkeypatch, ref, findings=(_finding(),))
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert "Top finding:" in out["message"], "a finding-driven block names its finding"
+
+
+@pytest.mark.parametrize("raw", [None, "Open", 0, "absent"])
+def test_fail_mode_normalization(monkeypatch: pytest.MonkeyPatch, raw: Any) -> None:
+    # fail_mode is read in the window from the RAW config dict, so it may be any YAML
+    # scalar (or absent — _load_config returns {}). Anything that is not exactly the
+    # string "open" is treated as degraded, mirroring _compute_safe's invalid-value
+    # fallback: garbage fails secure by construction.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode=None if raw == "absent" else raw)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+
+
+def test_fallback_state_outcomes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The fallback's signature and return type are unchanged — three distinct outcomes
+    # still collapse to None in its RETURN value — so the branch reads them out of band.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+
+    _install_fallback_scanner(monkeypatch, ref)
+    assert ref._fallback_pre_tool_call("read_file", {"p": "x"}, "s1") is None
+    assert ref._fallback_state.outcome == "skipped"
+
+    assert ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1") is None
+    assert ref._fallback_state.outcome == "clean"
+
+    _install_fallback_scanner(monkeypatch, ref, findings=(_finding(),))
+    assert ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1") is not None
+    assert ref._fallback_state.outcome == "blocked"
+
+    _install_fallback_scanner(monkeypatch, ref, raises=True)
+    assert ref._fallback_pre_tool_call("write_file", {"text": "x"}, "s1") is None
+    assert ref._fallback_state.outcome == "errored"
+
+
+def test_missing_fallback_outcome_fails_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A threading.local() has no attribute until written, so a bare read would raise
+    # AttributeError in a region of _pre_tool_call with no try around it and propagate into
+    # the host. The read defaults to "errored", not "skipped" or "clean": a patched-out
+    # fallback, a future unrecorded return path, or an escaping BaseException must not make
+    # the expired-wait branch silently behave like `open`.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    monkeypatch.setattr(ref, "_fallback_pre_tool_call", lambda *a, **k: None)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert getattr(ref._fallback_state, "outcome", None) is None
+
+    # ...but the read-only allow does NOT depend on the channel: _is_dangerous gates ahead
+    # of the outcome read, so the fail-secure default can never mass-block read-only tools.
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+    assert getattr(ref._fallback_state, "outcome", None) is None, (
+        "a stale 'skipped' on a pooled thread maps to ALLOW, routing a later dangerous "
+        "call around the fail-secure default"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Budget resolution (Decision 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("__missing__", 2.0),
+        (None, 2.0),
+        ("soon", 2.0),
+        ([2], 2.0),
+        (0, 2.0),
+        (-1, 2.0),
+        (float("nan"), 2.0),
+        (float("inf"), 2.0),
+        (1e300, 60.0),
+        (0.001, 0.05),
+        (120, 60.0),
+        ("2.0", 2.0),
+    ],
+)
+def test_init_wait_budget_sanitizes_raw_config(
+    monkeypatch: pytest.MonkeyPatch, raw: Any, expected: float
+) -> None:
+    # The clamp is load-bearing, not belt-and-braces: Event.wait raises OverflowError on
+    # inf / 1e300 and TypeError on a str, and this value reaches it directly. Note the
+    # asymmetry the surface documents: 0 or negative falls back to the DEFAULT (2.0), not
+    # to the 0.05 floor, so an operator writing 0 to mean "do not wait" gets the longest
+    # commonly-configured value instead.
+    ref = _import_reference_plugin()
+    config: dict[str, Any] = {} if raw == "__missing__" else {"init_wait_timeout_seconds": raw}
+    monkeypatch.setattr(ref, "_config", config)
+
+    got = ref._init_wait_budget()
+    assert got == expected
+    assert isinstance(got, float) and math.isfinite(got)
+    assert 0.05 <= got <= 60.0
+    # ...and nothing raises when the value reaches the wait. An UNCONTENDED
+    # Lock.acquire(True, timeout) runs the same _PyTime_t conversion Event.wait delegates
+    # to (it is what Condition.wait calls), so it raises OverflowError on inf / 1e300
+    # exactly as Event.wait does — but returns instantly instead of sleeping the budget.
+    lock = threading.Lock()
+    assert lock.acquire(True, got) is True
+    lock.release()
+
+
+def test_init_wait_budget_tolerates_none_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+    monkeypatch.setattr(ref, "_config", None)
+    assert ref._init_wait_budget() == 2.0
+
+
+@pytest.mark.parametrize("bad", [0, -1.0, 61.0, float("nan"), float("inf")])
+def test_init_wait_timeout_seconds_validation(bad: float) -> None:
+    with pytest.raises(ValueError, match="init_wait_timeout_seconds"):
+        PetasosConfig(init_wait_timeout_seconds=bad)
+
+
+def test_init_wait_timeout_seconds_default_accepted() -> None:
+    assert PetasosConfig().init_wait_timeout_seconds == 2.0
+    assert PetasosConfig(init_wait_timeout_seconds=60.0).init_wait_timeout_seconds == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Visibility (Decisions 4, 5)
+# ---------------------------------------------------------------------------
+
+
+def test_cold_start_degraded_emitted_once_per_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-167: against 3f17365 the spool stays empty — the session ran with
+    # no ML scanners and left no evidence of it.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    for _ in range(3):
+        ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert len(_of_type("cold_start_degraded")) == 1
+
+
+def test_read_only_only_session_still_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The marker is emitted BEFORE the dispatch and independent of _is_dangerous: the
+    # fallback returns early for read-only tools without scanning, so keying the record on
+    # the dispatch's outcome would leave a read_file-only cold session with no record.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+    assert len(_of_type("cold_start_degraded")) == 1
+
+
+def test_escape_hatch_path_still_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Keying on "the wait just expired" would miss the no-init-in-flight escape hatch,
+    # where a synchronous _deferred_init left _initialized False. That is a one-shot
+    # invocation that neither completed with full scanners nor left a record.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, thread_started=False)
+    _install_fallback_scanner(monkeypatch, ref)
+    monkeypatch.setattr(ref, "_deferred_init", lambda: None)
+
+    ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    markers = _of_type("cold_start_degraded")
+    assert len(markers) == 1
+    assert "no init in flight" in markers[0]["reason"], (
+        "the opener must name this trigger: no wait ever ran here, and a cause-neutral "
+        "opener alone sends an operator chasing a timeout that never happened"
+    )
+
+
+def test_uncorrelatable_session_emits_exactly_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With no task_id and no _agent, _derive_session_id mints a fresh anon-<uuid> per call,
+    # which would defeat the latch entirely. Asserted as == 1, not "does not scale with
+    # call count": the weaker phrasing is satisfied by ZERO, so it would go green against
+    # an implementation that never emits for the uncorrelatable shape at all.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    for _ in range(5):
+        ref._pre_tool_call("write_file", {"text": "x"})
+    assert len(_of_type("cold_start_degraded")) == 1
+
+
+def test_latch_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Driven through the helper directly: 10,001 full _pre_tool_call invocations through
+    # _run_async would be a multi-minute test.
+    ref = _import_reference_plugin()
+    ref._reset_cold_start_records()
+    cap = ref._MAX_COLD_START_KEYS
+
+    for i in range(cap + 5):
+        assert ref._note_cold_start_session(f"s{i}", "cold_start_degraded") is True
+    assert len(ref._cold_start_records) <= cap
+    assert ("s0", "cold_start_degraded") not in ref._cold_start_records, "oldest key evicted"
+    assert (f"s{cap + 4}", "cold_start_degraded") in ref._cold_start_records
+
+
+def test_degraded_then_init_failed_records_both(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Keyed on (session_id, event_type), not session_id: a single per-session key silently
+    # swallows the more severe state. The wait expires and records cold_start_degraded;
+    # init then FAILS; the session's next call wants init_failed and would be suppressed,
+    # leaving the operator with "ran without ML scanners" for a session that actually ran
+    # with no enforcement at all.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+
+    ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1")
+    _set(ref, "_init_error", "boom")
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+
+    assert len(_of_type("cold_start_degraded")) == 1
+    assert len(_of_type("init_failed")) == 1
+
+
+def test_blocking_cold_call_emits_block_class_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression for PET-167: block-class or the console renders a real enforcement block
+    # as a green "safe" row. _BLOCK_EVENT_TYPES drives the blocked tile, the per-session
+    # block tally and the red badge.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    quarantines = _of_type("quarantine")
+    assert len(quarantines) == 1
+    assert quarantines[0]["param_scan_degraded"] is True
+    assert quarantines[0]["tool"] == "write_file"
+
+
+def test_syntactic_finding_block_emits_exactly_one_quarantine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The finding-driven path already emits its own quarantine inside the fallback; adding
+    # the no-finding block's event there would double-count the block tally and the tile.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref, findings=(_finding(),))
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert len(_of_type("quarantine")) == 1
+
+
+def test_init_failed_emits_record_and_still_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The allow/deny behavior of this branch is UNCHANGED: this makes a total, silent
+    # enforcement loss visible, it does not start blocking.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _set(ref, "_init_error", "No module named 'x'")
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    records = _of_type("init_failed")
+    assert len(records) == 1
+    assert "No module named 'x'" in records[0]["reason"]
+
+
+def test_empty_exception_message_still_latches_visibly(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `str(exc)` is "" for a bare `raise ImportError()`, and an empty string is falsy: a
+    # truthiness test would read the latch as "still initializing" forever, recording
+    # cold_start_degraded for a session whose init has permanently failed and never
+    # recording init_failed.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+
+    class _BoomConfig(dict):  # type: ignore[type-arg]
+        def pop(self, *args: Any, **kwargs: Any) -> Any:
+            raise ImportError
+
+    monkeypatch.setattr(ref, "_config", _BoomConfig({"x": 1}))
+    ref._deferred_init()
+
+    assert ref._init_error == "ImportError"
+    assert ref._init_done.is_set(), "the finally wraps the WHOLE body, including this exit"
+
+    monkeypatch.setattr(ref, "_config", {})
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    assert len(_of_type("init_failed")) == 1
+    assert _of_type("cold_start_degraded") == [], "a failed init is not 'still starting'"
+
+
+def test_session_starting_and_ending_inside_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The ticket's explicit acceptance test: a whole one-shot session lives and dies inside
+    # the cold window. Asserts BEHAVIOR, not merely the absence of a crash.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+
+    assert ref._pre_tool_call("read_file", {"path": "a"}, task_id="one-shot") is None
+    blocked = ref._pre_tool_call("write_file", {"text": "x"}, task_id="one-shot")
+    assert blocked is not None and blocked["action"] == "block"
+    assert ref._pre_tool_call("search", {"q": "x"}, task_id="one-shot") is None
+
+    assert len(_of_type("cold_start_degraded")) == 1, "one durable record for the session"
+    assert len(_of_type("quarantine")) == 1, "the block is separately visible"
+
+
+def test_record_reason_fits_and_states_caveats(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Asserted against the DRAINED summary, not the raw emit, so the read path's 200-char
+    # hard slice is actually exercised. A naive rendering of all four caveats runs ~280-300
+    # characters, and a prefix slice amputates the LAST clause — exactly the one that says
+    # tool results go unscanned in the warm path too.
+    pytest.importorskip("fastapi")
+    from petasos.console.server import _enforcement_summary
+
+    ref = _import_reference_plugin()
+
+    # 1. cold_start_degraded, wait-expired variant + the 4a quarantine.
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+    ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    # 2. cold_start_degraded, escape-hatch variant (a fresh module: the latch is per key).
+    ref2 = _import_reference_plugin()
+    _open_window(monkeypatch, ref2, thread_started=False)
+    _install_fallback_scanner(monkeypatch, ref2)
+    monkeypatch.setattr(ref2, "_deferred_init", lambda: None)
+    ref2._pre_tool_call("read_file", {"path": "x"}, task_id="s2")
+    # 3. init_failed, with a long third-party error to exercise the 60-char truncation.
+    ref3 = _import_reference_plugin()
+    _open_window(monkeypatch, ref3)
+    _set(ref3, "_init_error", "Z" * 400)
+    ref3._pre_tool_call("read_file", {"path": "x"}, task_id="s3")
+
+    summaries = [_enforcement_summary(e) for e in _read_spool()]
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for s in summaries:
+        by_type.setdefault(str(s["event_type"]), []).append(s)
+    assert set(by_type) == {"cold_start_degraded", "init_failed", "quarantine"}
+    assert len(by_type["cold_start_degraded"]) == 2, "both variants present"
+
+    # All four classes: within the cap, and no em dash in the authored copy.
+    for rows in by_type.values():
+        for row in rows:
+            reason = str(row["reason"])
+            assert len(reason) <= 200
+            assert "—" not in reason
+
+    # The caveats are carried by the two cold_start_degraded variants only; init_failed and
+    # the 4a quarantine carry none by design.
+    for row in by_type["cold_start_degraded"]:
+        reason = str(row["reason"])
+        assert "tool results unscanned (warm path too)" in reason, (
+            "Done-when 8: recorded as unscanned WITHOUT implying the warm path scans it"
+        )
+        assert "syntactic only" in reason
+        assert "dangerous tools only" in reason
+        assert "100k cap" in reason
+
+
+# ---------------------------------------------------------------------------
+# Invariants (Decisions 1d, 4)
+# ---------------------------------------------------------------------------
+
+
+def test_emission_failure_does_not_change_decision(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The WRITER is forced to raise, not the shim's _emit_enforcement_event: monkeypatching
+    # the shim function replaces the very try/except the design relies on, and the new call
+    # sites sit in an unguarded region of _pre_tool_call, so the weaker version of this test
+    # would propagate into the host.
+    def boom(_rec: dict[str, Any]) -> bool:
+        raise OSError("spool is on fire")
+
+    monkeypatch.setattr(ev, "emit_enforcement_event", boom)
+
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+
+
+def test_disarmed_skips_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    # _is_armed() still gates ABOVE the init check, so a disarmed boot pays no wait, runs
+    # no fallback scan, and leaves no cold-start record.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    monkeypatch.setattr(ref, "_is_armed", lambda: False)
+    _install_fallback_scanner(monkeypatch, ref)
+    seen = _spy_fallback(monkeypatch, ref)
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    assert seen == []
+    assert ref._init_wait_deadline is None, "no wait was entered"
+    assert _of_type("cold_start_degraded") == []
+    assert _of_type("init_failed") == []
+
+
+def test_failed_spool_write_does_not_consume_the_latch(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Claim-then-release. A plain claim-then-emit would consume the key, land no row, and
+    # deduplicate every later call in that session away — the session ran degraded with
+    # zero durable evidence, the exact silent failure the record class exists to prevent.
+    monkeypatch.setattr(ev, "emit_enforcement_event", lambda _rec: False)
+
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref)
+    attempts: list[str] = []
+    real = ref._emit_enforcement_event
+
+    def spy(**kwargs: Any) -> bool:
+        attempts.append(str(kwargs.get("event_type")))
+        return bool(real(**kwargs))
+
+    monkeypatch.setattr(ref, "_emit_enforcement_event", spy)
+
+    # (a) a keyed session retries on the next call.
+    ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1")
+    ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1")
+    assert attempts.count("cold_start_degraded") == 2
+
+    # (b) the uncorrelatable shape must release its process-wide boolean too; without that,
+    # one failed write latches the process out of ever recording the marker again.
+    attempts.clear()
+    ref._pre_tool_call("read_file", {"path": "x"})
+    ref._pre_tool_call("read_file", {"path": "x"})
+    assert attempts.count("cold_start_degraded") == 2
+
+    # (c) a key the cap already evicted: the release must pop, never del, or the KeyError
+    # propagates through a region with no try around it.
+    assert ref._note_cold_start_session("gone", "cold_start_degraded") is True
+    ref._cold_start_records.clear()
+    ref._release_cold_start_claim("gone", "cold_start_degraded")
+
+
+def test_init_completing_during_fallback_scan_does_not_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The TOCTOU window spans the whole fallback scan (its _run_async carries a 15s
+    # timeout), not microseconds. Blocking a dangerous call on the grounds that scanners
+    # were not up, seconds after they came up, is a user-visible false block whose
+    # model-facing message is untrue when emitted.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    guard = _GuardSpy()
+    monkeypatch.setattr(ref, "_guard", guard)
+
+    def land_init() -> None:
+        _set(ref, "_initialized", True)
+        ref._init_done.set()
+
+    _install_fallback_scanner(monkeypatch, ref, on_scan=land_init)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is None, "init landed mid-scan; the block would be false"
+    # Required: _pre_tool_call wraps _guard.evaluate in an except Exception that logs and
+    # returns None, so a fall-through that crashes on `_guard is None` looks identical.
+    assert guard.calls == ["write_file"], "the main path actually ran"
+
+
+def test_finding_driven_block_survives_the_same_race(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Scoped to the 4a no-finding block only. The finding-driven path shares the return
+    # site but has already written its quarantine, so falling through there would discard
+    # the block while leaving a block-class row on the console for a call that was allowed.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    guard = _GuardSpy()
+    monkeypatch.setattr(ref, "_guard", guard)
+
+    def land_init() -> None:
+        _set(ref, "_initialized", True)
+        ref._init_done.set()
+
+    _install_fallback_scanner(monkeypatch, ref, findings=(_finding(),), on_scan=land_init)
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert len(_of_type("quarantine")) == 1
+    assert guard.calls == [], "a justified block is returned, not re-decided by the guard"


### PR DESCRIPTION
## Summary
- Bounds the cold-start wait with a `fail_mode`-governed timeout, so the first tool call of a cold process no longer blocks the host for the full remaining backend verification (measured: unbounded, roughly 12s).
- Resurrects `_fallback_pre_tool_call`, which was unreachable dead code: the old path always queued on `_init_lock` and then took the main path, so the syntactic-only guard the cold window advertises never ran.
- Adds durable enforcement-spool records so an operator can tell after the fact whether a session ran fully scanned, ran degraded because the wait expired, or ran with enforcement disabled because init failed.
- No new scanning capability, no change to what `fail_mode` means, no change to the allow behavior of the init-failed branch.

## The two-outcome cold window

`_ensure_initialized` waits on a completion `Event` against a **process-wide** deadline, not a per-call budget: a session making six calls inside a 12s init pays one budget total, where a naive per-call wait would charge six. The deadline is read once into a local, so two threads racing the first wait cannot compose into more than one budget. The `_initialized` check stays the first statement, so a late init success still upgrades the process back to the main path.

On expiry, for a **dangerous** tool:

| Cold-window outcome | `open` | `degraded` (default) | `closed` |
|---|---|---|---|
| Read-only tool (not scanned) | allow | allow | allow |
| Syntactic finding at/above the block floor | block | block | block |
| Scan errored (or outcome unreadable) | **block** | **block** | **block** |
| Clean scan, dangerous tool | allow | **block** | **block** |

The `_is_dangerous` gate is evaluated **before** `fail_mode` and before the scan outcome is read, mirroring the warm path: without it the cold window would block `read_file` / `search` / `web_search` / `list_directory` for its whole duration under the default `fail_mode`. The errored row is `fail_mode`-independent, matching `guard.py`'s deliberate fail-safe for a parameter scan that raised.

`_fallback_pre_tool_call` keeps its exact signature and return type (three outcomes still collapse to `None`); it records `clean` / `errored` / `skipped` / `blocked` on a thread-local instead. The read side defaults a missing or unrecognized value to `errored`, and clears the attribute on every exit so a pooled gateway thread carries no residue.

## Layered defense on the record path

Markers are latched per `(session_id, event_type)`, not per session, so a session that goes degraded and *then* hits an init failure records both. The claim is **reserved** before the emit and **released** if the spool write returns False, so a locked or full disk cannot consume the key and dedupe every later call in that session away, leaving a degraded session with zero evidence. The retry is unbounded; the failure warning is rate-limited.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/__init__.py` | Bounded wait, `_init_done`, budget resolution + clamp, cold-window branch, marker latch, `register()` rollback, test seams |
| `petasos/config.py` | New `init_wait_timeout_seconds` field (default 2.0) + range validation |
| `petasos/console/_config_meta.py` | Matching `_FIELD_META` entry; `help_plain` names the true consumer |
| `docs/usage/configuration.md` | Doc-assert count 60 to 61, field CSV, prose bullet, human prose line |
| `petasos/console/static/petasos.js` | One `isColdStart` classification: badge arm, `scanRan` arm, drill-down body |
| `tests/test_reference_plugin_cold_start.py` | New: 60 tests across wait bounding, `fail_mode` cells, budget sanitization, visibility, invariants |
| `tests/js/cold-start-row.test.mjs` | New: badge / provenance / drill-down / bare-row / house-style |
| `tests/test_reference_plugin_block_messages.py` | PET-77 call-site guard 6 to 8 (reconciles PET-134's unbumped site), contract test for the new site |
| `tests/test_enforcement_events.py` | Cold-window block test filtered to the quarantine row (the marker now precedes it) |

## Test plan
- [x] `C:/python310/python.exe -m pytest tests/test_reference_plugin_cold_start.py tests/test_reference_plugin_block_messages.py tests/test_reference_plugin_egress.py tests/test_enforcement_events.py tests/test_config_meta.py tests/test_config.py tests/test_docs_usage_consistency.py tests/test_plugin_init_logging.py tests/test_presets.py tests/test_profile_rebind.py -v` - 260/260 pass
- [x] `node --test tests/js/*.test.mjs` - 265/265 pass
- [x] `ruff check .` / `ruff format --check .` - clean
- [x] `mypy --strict petasos/ tests/test_reference_plugin_cold_start.py` - clean
- [x] Full suite: 2280 passed, 42 skipped, 1 xfailed (deselecting the pre-existing `test_default_ignorable_rejected`, Unicode 13 vs 14 on the pinned 3.10 interpreter)
- [x] `tests/test_reference_plugin_egress.py` stays unmodified as the witness that the fallback's contract did not change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable, bounded startup waiting with safe fallback behavior.
  - Added clear cold-start enforcement outcomes and recovery handling.
  - Dangerous actions are blocked or quarantined unless a clean scan completes in fail-open mode.
  - Added visible degraded and unenforced status indicators with scan details.

- **Bug Fixes**
  - Improved recovery from startup and event-recording failures.
  - Prevented duplicate cold-start and initialization-failure markers.

- **Documentation**
  - Documented startup wait-time configuration and validation rules.

- **Tests**
  - Expanded coverage for startup timing, fallback scanning, enforcement, event reporting, and dashboard display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->