### PR TITLE
chore(pet-169): config-surface honesty audit, all 64 fields classified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [Unreleased]
 
+### Changed
+
+- **Config-surface honesty audit (PET-169).** Every one of the 64 `PetasosConfig`
+  fields now carries a recorded verdict and a resolving read-site anchor in
+  `tests/test_config_surface_honesty.py`, which is the tracked authority for the
+  sweep. No field was added, removed, retyped, or de-surfaced, and no enforcement
+  path changed, so every existing operator config keeps loading and behaving
+  exactly as before. The sweep found no dead key.
+- **Twelve Config Editor fields now disclose their real consumer.** The
+  anonymization group (`anonymize`, `pii_entities`, `redaction_mode`, `hash_key`)
+  needs the `presidio` extra and a registered PII-detecting scanner before it
+  changes anything. The scanner-timeout family (`scanner_timeout_seconds`,
+  `scanner_circuit_breaker_threshold`,
+  `scanner_circuit_breaker_cooldown_seconds`) has no effect until an ML scanner is
+  registered. The three Presidio detection-scope fields (`presidio_entities`,
+  `presidio_entities_extra`, `presidio_score_threshold`) apply only to the scanner
+  the console builds at startup, so installing the extra alone does not make them
+  reach a `PresidioScanner` an embedder constructs. `egress_sink_tools` and
+  `source_taint_namespaces` are enforced by the Hermes plugin, not by the Petasos
+  library alone. `taint_min_span_length` gained the same plugin note.
+- **Strength-dial descriptions qualified.** Steel and Titanium no longer assert
+  PII anonymization as an unconditional posture; both now scope the claim to
+  deployments where a PII scanner is running.
+
 ## [0.2.0] - 2026-06-30
 
 Headline release since 0.1.2: Hermes-agent profile/role awareness end to end,

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -118,14 +118,18 @@ system or the shell.*
   social posts, external web requests, webhooks, clipboard). Detected personal
   data is blocked only when an agent tries to send it through one of these;
   writing to local files or the terminal is never blocked for personal data. Set
-  these to your host's actual outbound tool names.
+  these to your host's actual outbound tool names. The block itself is enforced by
+  the Hermes plugin, not by the Petasos library alone: a program that embeds
+  Petasos directly gets no egress blocking from this list unless it drives the
+  tool-call guard itself.
 - `source_taint_namespaces`: tool namespaces (by name prefix, such as a banking or
   health connector) whose returned content must not leave again through an egress
   sink. Once a tool in one of these groups returns data, that exact text is blocked
   from any `egress_sink_tools` tool above, even when it is not flagged as personal
   data, which catches a plain account balance or amount the PII scanner would miss.
   Empty (the default) turns the fence off. Matching is exact-text only, so a
-  paraphrased or re-encoded copy is not caught.
+  paraphrased or re-encoded copy is not caught. Like `egress_sink_tools`, the fence
+  is enforced by the Hermes plugin, not by the Petasos library alone.
 - `taint_min_span_length`: the shortest piece of restricted-source content the fence
   will remember (minimum 1; default 12 characters). Short, common values (a price
   like $5.00, a year like 2026) fall below this and are ignored, so they cannot

--- a/petasos/config.py
+++ b/petasos/config.py
@@ -62,7 +62,16 @@ class PetasosConfig:
     # always-on syntactic posture (not threaded into the scanner by design, no
     # longer a console control); decode_encoded_payloads, by contrast, IS threaded
     # into MinimalScanner's constructor, so turning it off genuinely disables the
-    # decode stage in every pipeline build path.
+    # decode stage.
+    # PET-169 correction: that holds only where Pipeline BUILDS the scanner
+    # (pipeline.py:330-333). A caller-supplied MinimalScanner is adopted as-is
+    # without the flag (pipeline.py:321-328), and the config value first reaches
+    # the adopted instance at the first live rebind (reconfigure ->
+    # set_decode_encoded_payloads, pipeline.py:399). The Hermes shim passes a bare
+    # instance (docs/deployment/reference_plugin/__init__.py:521), so that
+    # deployment runs the decode stage at its default until the first rebind. The
+    # one-line shim fix is a detection-behavior change and is tracked as PET-173;
+    # the library verdict for this key is still live-library.
     decode_encoded_payloads: bool = True
 
     # Scanning

--- a/petasos/console/_config_meta.py
+++ b/petasos/console/_config_meta.py
@@ -112,9 +112,11 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "description": "How long to wait for a scanner before giving up.",
         "help_plain": (
             "How many seconds to wait for a slow scanner before giving up on it for that"
-            " scan. Lower keeps scans snappy but cuts off slow scanners more often — and a"
+            " scan. Lower keeps scans snappy but cuts off slow scanners more often, and a"
             " timeout counts as a scanner failure, so the fail mode setting decides what"
-            " happens next."
+            " happens next. This deadline bounds the optional ML scanners only, so it"
+            " has no effect until you add an ML scanner: the built-in zero-dependency"
+            " pattern check is never run under it."
         ),
         "section": "scanning",
         "constraints": {"min": 0.01, "max": 60},
@@ -139,7 +141,9 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "help_plain": (
             "How many times in a row a scanner must time out before it's temporarily"
             " benched so it stops slowing down every scan. Lower benches a misbehaving"
-            " scanner sooner; any scan that doesn't time out resets the count."
+            " scanner sooner; any scan that doesn't time out resets the count. Only the"
+            " optional ML scanners can be benched, so this has no effect until you add"
+            " an ML scanner."
         ),
         "section": "scanning",
         "constraints": {"min": 1},
@@ -148,9 +152,11 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "description": "How long a benched scanner stays out before retrying.",
         "help_plain": (
             "How many seconds a benched scanner sits out before it gets another chance."
-            " While benched it is skipped instantly but still counts as a failed scanner —"
+            " While benched it is skipped instantly but still counts as a failed scanner,"
             " so the fail mode setting decides whether content is blocked meanwhile; the"
-            " built-in zero-dependency pattern check keeps running regardless."
+            " built-in zero-dependency pattern check keeps running regardless. Only the"
+            " optional ML scanners can be benched, so this has no effect until you add"
+            " an ML scanner."
         ),
         "section": "scanning",
         "constraints": {"min": 0.01},
@@ -159,8 +165,12 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "description": "Replace detected personal info with typed placeholders like [EMAIL].",
         "help_plain": (
             "After scanning, replaces any personal information found (names, emails, and so"
-            " on) with placeholders so it doesn't travel further. Off by default — turn it"
-            " on when conversations may contain other people's data."
+            " on) with placeholders so it doesn't travel further. Off by default; turn it"
+            " on when conversations may contain other people's data. Anonymization only"
+            " runs on personal data a scanner actually reported, so it needs the presidio"
+            " extra and a registered PII-detecting scanner. On a plain"
+            " `pip install petasos` there is nothing for this step to hide and turning it"
+            " on changes nothing."
         ),
         "section": "anonymization",
     },
@@ -168,10 +178,12 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         "description": "Which detected PII entity types to anonymize (empty = all).",
         "help_plain": (
             "Narrows which kinds of detected personal information actually get hidden at the"
-            " anonymize step — for example, list only EMAIL_ADDRESS to redact emails while"
+            " anonymize step: for example, list only EMAIL_ADDRESS to redact emails while"
             " leaving other detected PII untouched. Leave empty to anonymize every detected"
             " type (the default). This filters only what is hidden, not what the scanner"
-            " looks for — detection scope is set by the Presidio entity settings."
+            " looks for; detection scope is set by the Presidio entity settings. Like the"
+            " rest of this section it needs the presidio extra and a registered"
+            " PII-detecting scanner before it can change anything."
         ),
         "section": "anonymization",
     },
@@ -183,20 +195,27 @@ _FIELD_META: dict[str, dict[str, Any]] = {
         ),
         "help_plain": (
             "Replaces the personal-info scanner's detected entity list wholesale. Leave unset"
-            " to use the curated default — the security-relevant types like credit cards,"
-            " SSNs, emails, and phone numbers — which deliberately omits noisier types (names,"
+            " to use the curated default: the security-relevant types like credit cards,"
+            " SSNs, emails, and phone numbers, which deliberately omits noisier types (names,"
             " locations, dates, URLs) that misfire on file paths and code. Set your own list"
-            " here only when you need a fully custom detection set."
+            " here only when you need a fully custom detection set. This applies only to the"
+            " scanner the console builds at startup. A program that imports Petasos as a"
+            " library and constructs its own Presidio scanner passes these settings to that"
+            " scanner directly; installing the presidio extra does not make this field reach"
+            " it."
         ),
         "section": "scanning",
     },
     "presidio_entities_extra": {
         "description": "Extra Presidio entity types to add on top of the default set.",
         "help_plain": (
-            "Adds entity types back on top of the curated default without replacing it — for"
+            "Adds entity types back on top of the curated default without replacing it: for"
             ' example, add "URL" to detect web addresses again. Use this to opt one of the'
             " noisier types back in while keeping the rest of the safe default. Entries are"
-            " uppercased automatically."
+            " uppercased automatically. This applies only to the scanner the console builds"
+            " at startup. A program that imports Petasos as a library and constructs its own"
+            " Presidio scanner passes these settings to that scanner directly; installing the"
+            " presidio extra does not make this field reach it."
         ),
         "section": "scanning",
     },
@@ -206,7 +225,11 @@ _FIELD_META: dict[str, dict[str, Any]] = {
             "How confident the personal-info scanner must be before it reports a match, from"
             " 0 to 1. Higher means fewer false alarms but more missed items; lower catches"
             " more but gets noisier. Setting it all the way to 0 reports every candidate and"
-            " brings back a lot of the noise this scoping is meant to remove."
+            " brings back a lot of the noise this scoping is meant to remove. This applies"
+            " only to the scanner the console builds at startup. A program that imports"
+            " Petasos as a library and constructs its own Presidio scanner passes this"
+            " threshold to that scanner directly; installing the presidio extra does not make"
+            " this field reach it."
         ),
         "section": "scanning",
         "constraints": {"min": 0, "max": 1},
@@ -217,7 +240,9 @@ _FIELD_META: dict[str, dict[str, Any]] = {
             'Chooses how found personal information is hidden: "redact" swaps it for a'
             ' typed placeholder, "replace" numbers each one, "hash" turns it into a'
             " scrambled code (useful for matching records without revealing them), and"
-            ' "mask" hides all but the last few characters.'
+            ' "mask" hides all but the last few characters. The choice only takes effect'
+            " once something is being anonymized, which needs the presidio extra and a"
+            " registered PII-detecting scanner."
         ),
         "section": "anonymization",
         "constraints": {"values": ["redact", "replace", "hash", "mask"]},
@@ -225,9 +250,11 @@ _FIELD_META: dict[str, dict[str, Any]] = {
     "hash_key": {
         "description": "Secret key for hash-mode redaction. Never shown in full.",
         "help_plain": (
-            'The secret key used when redaction mode is "hash" — it makes the scrambled'
+            'The secret key used when redaction mode is "hash": it makes the scrambled'
             " codes impossible to reverse without the key. Required for hash mode, ignored"
-            " otherwise, and never displayed in full."
+            " otherwise, and never displayed in full. Like the rest of this section it"
+            " needs the presidio extra and a registered PII-detecting scanner before it"
+            " can change anything."
         ),
         "section": "anonymization",
     },
@@ -639,11 +666,14 @@ _FIELD_META: dict[str, dict[str, Any]] = {
     "egress_sink_tools": {
         "description": "Tool names treated as egress sinks; the PII block applies only to these.",
         "help_plain": (
-            "The tools that send content OUT of the machine — email, social posts, external"
+            "The tools that send content OUT of the machine: email, social posts, external"
             " web requests, webhooks, clipboard. Detected personal data (cards, SSNs, emails)"
             " is blocked only when an agent tries to send it through one of these. Writing to"
             " local files or the terminal is never blocked for personal data. Set these to your"
-            " host's actual outbound tool names."
+            " host's actual outbound tool names. The block itself is enforced by the Hermes"
+            " plugin, not by the Petasos library alone, so a program embedding Petasos directly"
+            " gets no egress blocking from this list unless it drives the tool-call guard"
+            " itself."
         ),
         "section": "tool_guard",
     },
@@ -659,7 +689,9 @@ _FIELD_META: dict[str, dict[str, Any]] = {
             " messaging), even when it is not recognized as personal data. This catches a plain"
             " account balance or amount the personal-data scanner would miss. Leave empty (the"
             " default) to turn the fence off; matching is exact-text only, so paraphrased or"
-            " re-encoded copies are not caught."
+            " re-encoded copies are not caught. The fence is enforced by the Hermes plugin,"
+            " not by the Petasos library alone, so a program embedding Petasos directly gets"
+            " no blocking from these namespaces unless it drives the tool-call guard itself."
         ),
         "section": "tool_guard",
     },
@@ -671,7 +703,8 @@ _FIELD_META: dict[str, dict[str, Any]] = {
             " year like 2026) fall below this and are ignored, so they cannot block every later"
             " message that happens to contain them. Raise it if benign messages get blocked for"
             " sharing a common phrase; lower it to catch shorter sensitive values at the cost of"
-            " more false alarms. Only applies to the restricted-source fence above."
+            " more false alarms. Only applies to the restricted-source fence above, which the"
+            " Hermes plugin drives end to end."
         ),
         "section": "tool_guard",
         "constraints": {"min": 1},

--- a/petasos/console/_presets.py
+++ b/petasos/console/_presets.py
@@ -164,8 +164,9 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
         "steel",
         "Steel",
         3,
-        "Strict temper. Fail-closed, PII anonymization on, earlier escalation, "
-        "and tighter PII sensitivity. A safe posture for handling third-party data.",
+        "Strict temper. Fail-closed and earlier escalation, plus PII anonymization "
+        "and tighter PII sensitivity wherever a PII scanner is running. A safe "
+        "posture for handling third-party data.",
         {
             "fail_mode": "closed",
             "tier1_threshold": 10.0,
@@ -184,8 +185,9 @@ _PRESET_REGISTRY: Final[tuple[StrengthPreset, ...]] = (
         "titanium",
         "Titanium",
         4,
-        "Strictest temper. Fail-closed, anonymization on, earliest escalation, "
-        "and Tier-3 at the hard floor (30). Maximum teeth for high-stakes deployments.",
+        "Strictest temper. Fail-closed, earliest escalation, Tier-3 at the hard "
+        "floor (30), and anonymization on wherever a PII scanner is running. "
+        "Maximum teeth for high-stakes deployments.",
         {
             "fail_mode": "closed",
             "tier1_threshold": 8.0,

--- a/tests/adversarial/pipeline/test_config_surface_inertness.py
+++ b/tests/adversarial/pipeline/test_config_surface_inertness.py
@@ -1,0 +1,144 @@
+"""PET-169 test-8 inertness arms: the `live-shim` keys move no library outcome.
+
+Five keys the 2026-08-03 config-surface honesty audit newly classified
+`live-shim` are pinned here. Each is rendered as an operator control in the
+Config Editor, and each is inert for a program that imports `petasos` and drives
+`Pipeline` itself. That is an inertness claim, and PET-143 D-A says an inertness
+claim is discharged by an outcome diff, not by a code trace:
+
+    verify each toggle moves a detection *outcome* (an on/off diff test) before
+    treating it as a live control; if it cannot, retire the surface
+
+`init_wait_timeout_seconds` is the sixth `live-shim` key and is grandfathered by
+PET-167, which already disclosed its scope.
+
+**Every arm carries a positive control.** Without one, "two PipelineResults are
+equal" is true of all 64 config fields and pins nothing. The control is a stub
+Scanner emitting positioned `finding_type="pii"` findings plus `anonymize=True`
+and an extras-free `redaction_mode`, so `sanitized_content` is non-None on both
+arms: the pipeline demonstrably reaches the anonymization stage while the flipped
+key moves nothing. The stub is necessary because `MinimalScanner` emits only
+injection/command/encoding/structural findings, so the PII filter would otherwise
+be empty and the whole stage unreachable.
+
+The comparison is over the serialized `PipelineResult`, excluding only the
+run-to-run wall-clock `duration_ms`, following the shipped PET-151 idiom at
+`tests/adversarial/normalization/test_unicode_bypass.py:347`. Each arm builds
+fresh pipelines with no shared session, which keeps `session_score` and
+`escalation_tier` from diverging for a reason unrelated to the toggle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from petasos._types import (
+    Direction,
+    PipelineResult,
+    Position,
+    ScanFinding,
+    ScanResult,
+    Severity,
+)
+from petasos.config import PetasosConfig
+from petasos.pipeline import Pipeline
+
+_TEXT = "Alice met alice@example.com today"
+
+
+class _PiiStubScanner:
+    """An ML scanner reporting two typed PII spans. Extras-free: it fabricates
+    the findings a Presidio backend would produce, which is all the pipeline's
+    anonymization stage consumes."""
+
+    @property
+    def name(self) -> str:
+        return "pii-stub"
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        findings = tuple(
+            ScanFinding(
+                rule_id=f"petasos.presidio.{entity.lower()}",
+                finding_type="pii",
+                severity=Severity.MEDIUM,
+                confidence=0.9,
+                message=f"PII detected: {entity}",
+                scanner_name="pii-stub",
+                position=Position(start=text.index(needle), end=text.index(needle) + len(needle)),
+                matched_text=needle,
+            )
+            for needle, entity in (("Alice", "PERSON"), ("alice@example.com", "EMAIL_ADDRESS"))
+            if needle in text
+        )
+        return ScanResult(scanner_name="pii-stub", findings=findings)
+
+
+def _pipeline(field: str, value: object) -> Pipeline:
+    """A pipeline differing from the anonymizing baseline in exactly one field."""
+    base: dict[str, Any] = {"anonymize": True, "redaction_mode": "replace", field: value}
+    return Pipeline(scanners=[_PiiStubScanner()], config=PetasosConfig(**base))
+
+
+def _reduce(result: PipelineResult) -> dict[str, Any]:
+    as_dict = result.to_dict()
+    for scan_result in as_dict["scanner_results"]:
+        scan_result.pop("duration_ms", None)
+    return as_dict
+
+
+@pytest.mark.parametrize(
+    ("field", "on_value", "off_value"),
+    [
+        # The three PET-109 Presidio detection-scope keys. Their only reads are
+        # inside build_dashboard_pipeline (petasos/console/_standalone.py:109,
+        # :111), reachable only from the console entrypoints. Pipeline never
+        # constructs a PresidioScanner; it fans out over whatever the caller
+        # supplied. So an embedder running `pip install petasos[presidio]` and
+        # passing Pipeline(scanners=[PresidioScanner()]) gets nothing from these
+        # three: the extra is installed and they are still inert. That is why
+        # their caveat names the console bootstrap and not the extra.
+        ("presidio_entities", ("EMAIL_ADDRESS",), None),
+        ("presidio_entities_extra", ("URL",), ()),
+        ("presidio_score_threshold", 0.99, 0.01),
+        # The two PET-112 / PET-134 egress-fence keys. Their only behavior reads
+        # are the Hermes plugin's; inside petasos/ the names appear solely in
+        # config.py validation and coercion, their _FIELD_META entries, a scope
+        # comment, and a taint.py docstring mention, none of which is a read.
+        ("egress_sink_tools", ("send_email",), ()),
+        ("source_taint_namespaces", ("mcp_bank",), ()),
+    ],
+    ids=[
+        "presidio_entities",
+        "presidio_entities_extra",
+        "presidio_score_threshold",
+        "egress_sink_tools",
+        "source_taint_namespaces",
+    ],
+)
+async def test_live_shim_key_moves_no_library_outcome(
+    field: str, on_value: object, off_value: object
+) -> None:
+    """Regression for PET-169: flipping a `live-shim` key changes nothing a
+    library embedder's Pipeline produces. A future change that threads any of
+    these into `petasos/` reds this and owes the verdict a re-classification."""
+    on = await _pipeline(field, on_value).inspect(_TEXT, direction="inbound")
+    off = await _pipeline(field, off_value).inspect(_TEXT, direction="inbound")
+
+    # Positive control: the run reached the anonymization stage under BOTH arms,
+    # so the equality below is a real comparison and not a vacuous one.
+    for arm, result in (("on", on), ("off", off)):
+        assert result.sanitized_content is not None, f"{arm} arm never reached anonymization"
+        assert "<PERSON_1>" in result.sanitized_content, f"{arm} arm anonymized nothing"
+        assert not any("presidio not installed" in e for e in result.errors), (
+            f"{arm} arm took the ImportError path, so it pins the handler not the key"
+        )
+
+    assert _reduce(on) == _reduce(off)

--- a/tests/test_config_surface_honesty.py
+++ b/tests/test_config_surface_honesty.py
@@ -1,0 +1,405 @@
+"""PET-169: the config-surface honesty audit, in executable form.
+
+`_CLASSIFICATION` below is the **tracked authority** for the 2026-08-03 sweep of
+every `PetasosConfig` field. The `docs/research/` audit doc is a dated snapshot
+of the same sweep and is gitignored (spec Decision 8); when the two disagree,
+this file wins.
+
+Verdicts are read-site facts. Each maps onto one of PET-151's three dispositions:
+
+    live-library   Reaches an outcome-affecting consumer on a base install.
+                   No disposition owed; record the evidence.
+    live-partial   Has a decision-point read, but on a pipeline registering only
+                   MinimalScanner (the `pip install petasos` shape) flipping it
+                   changes none of `safe`, `findings` (as {(rule_id, severity)}),
+                   `sanitized_content`, `errors`, or `escalation_tier`, for all
+                   inputs.  -> Caveat (D-C): name the true consumer in help_plain.
+    live-shim      Read only by the deployment shim or the console bootstrap;
+                   inert for a library embedder.  -> Caveat (D-C).
+    not-a-control  A read exists but reaches no outcome-affecting consumer;
+                   retained deliberately for parity.  -> Retire (D-A).
+    dead           No read site anywhere; inert by accident, not by design.
+                   The 2026-08-03 sweep found none.
+
+The `live-partial` boundary applies only to keys whose claimed consumer is the
+scan pipeline. A key with a decision-point or constructor read inside a
+config-accepting session component a base-install embedder can drive directly
+(ToolCallGuard, LineageRegistry, SessionTaintStore, AuditEmitter/AlertManager) is
+`live-library` **through that component**, because its outcome is a GuardResult,
+lineage/taint state, or an on_audit/on_alert emission rather than one of the five
+compared PipelineResult fields. For a key whose only decision-point read is the
+pipeline-side gate that invokes the component, the gate read is the anchor.
+
+Evidence is a `path:line` anchor resolved at collection time, or the
+`none:<declaration site>` sentinel, which is used iff the verdict is `dead`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from petasos.config import _SECRET_FIELDS, PetasosConfig
+from petasos.console._config_meta import _FIELD_META, generate_config_metadata
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_VERDICTS = frozenset({"live-library", "live-partial", "live-shim", "not-a-control", "dead"})
+_CAVEAT_VERDICTS = frozenset({"live-partial", "live-shim"})
+
+# Marker phrases test 4 requires in `help_plain`, one per caveat axis. Carried in
+# the tuple rather than a second dict so a caveat key cannot silently drop out of
+# the disclosure loop (spec Decision 1).
+_M_NORM = "does not gate built-in findings"
+_M_ANON = "needs the presidio extra and a registered PII-detecting scanner"
+_M_MLSCAN = "has no effect until you add an ML scanner"
+_M_CONSOLE = "applies only to the scanner the console builds at startup"
+_M_PLUGIN = "enforced by the Hermes plugin, not by the Petasos library alone"
+_M_INITWAIT = "no effect when Petasos is embedded directly as a library"
+
+# (verdict, evidence, required_help_marker)
+_CLASSIFICATION: dict[str, tuple[str, str, str | None]] = {
+    # --- Normalization -----------------------------------------------------
+    # PET-151, transcribed not re-derived (spec Decision 6). Pins already
+    # shipped: tests/adversarial/normalization/test_unicode_bypass.py:323.
+    "normalize_nfkc": ("live-partial", "petasos/pipeline.py:686", _M_NORM),
+    "strip_zero_width": ("live-partial", "petasos/pipeline.py:687", _M_NORM),
+    "map_homoglyphs": ("live-partial", "petasos/pipeline.py:688", _M_NORM),
+    # PET-151 D-A, transcribed. Pin: test_unicode_bypass.py:347.
+    "detect_rtl_override": ("not-a-control", "petasos/pipeline.py:689", None),
+    # PET-143 D-A, transcribed. Pin: test_unicode_bypass.py:250.
+    "fold_leet": ("not-a-control", "petasos/pipeline.py:690", None),
+    # Threaded into MinimalScanner's constructor when Pipeline builds its own
+    # instance. A caller-supplied MinimalScanner is adopted WITHOUT the flag
+    # (pipeline.py:321-328); the value first reaches it at the next reconfigure
+    # (pipeline.py:399). That is a deployment-axis defect, recorded in the audit
+    # table and routed to a follow-up ticket; the library verdict is unaffected.
+    "decode_encoded_payloads": ("live-library", "petasos/pipeline.py:332", None),
+    # --- Scanning ----------------------------------------------------------
+    "direction": ("live-library", "petasos/pipeline.py:637", None),
+    # The base-install diff is _compute_safe's syntactic-error arm at :215, which
+    # sits BEFORE the `if ml_total == 0` short-circuit at :218. pipeline.py:714 is
+    # a supplementary read site only: early_exit needs a CRITICAL finding, which
+    # already forces safe=False under every mode.
+    "fail_mode": ("live-library", "petasos/pipeline.py:215", None),
+    # Read only inside _scan_with_breaker, constructed only under
+    # `elif self._ml_scanners:` (pipeline.py:722).
+    "scanner_timeout_seconds": ("live-partial", "petasos/pipeline.py:952", _M_MLSCAN),
+    "scanner_circuit_breaker_threshold": ("live-partial", "petasos/pipeline.py:925", _M_MLSCAN),
+    "scanner_circuit_breaker_cooldown_seconds": (
+        "live-partial",
+        "petasos/pipeline.py:966",
+        _M_MLSCAN,
+    ),
+    # PET-167, grandfathered: the shim is its only consumer.
+    "init_wait_timeout_seconds": (
+        "live-shim",
+        "docs/deployment/reference_plugin/__init__.py:766",
+        _M_INITWAIT,
+    ),
+    # --- Anonymization -----------------------------------------------------
+    # Inert on a base install for a reason that is NOT the Presidio ImportError
+    # arm: the import at pipeline.py:852 sits inside `if pii_findings:` (:850),
+    # and pii_findings filters `merged` on finding_type == "pii", which only
+    # PresidioScanner emits. MinimalScanner emits injection/command/encoding/
+    # structural, so the whole block is unreachable and the handler never fires.
+    "anonymize": ("live-partial", "petasos/pipeline.py:836", _M_ANON),
+    "pii_entities": ("live-partial", "petasos/pipeline.py:843", _M_ANON),
+    "redaction_mode": ("live-partial", "petasos/pipeline.py:857", _M_ANON),
+    # Exempt from a test-8 load-bearing arm: hash_key is consumed only under
+    # mode == "hash", an engine-path mode, and config.py:233 rejects
+    # anonymize=True + redaction_mode="hash" + hash_key=None at construction, so
+    # no extras-free configuration exists in which flipping it changes anything.
+    # Its caveat rests on the redaction_mode arm plus this read trace.
+    "hash_key": ("live-partial", "petasos/pipeline.py:858", _M_ANON),
+    # Read ONLY by build_dashboard_pipeline, reachable only from
+    # console/__main__.py and console/hermes/plugin_api.py. Pipeline never
+    # constructs a PresidioScanner; it fans out over whatever the caller supplied
+    # (pipeline.py:722-742). So `pip install petasos[presidio]` plus
+    # Pipeline(scanners=[PresidioScanner()]) still gets nothing from these three:
+    # the extra is installed and they are still inert. An "extras dependency"
+    # caveat would be false prose shipped inside an honesty audit.
+    "presidio_entities": ("live-shim", "petasos/console/_standalone.py:109", _M_CONSOLE),
+    "presidio_entities_extra": ("live-shim", "petasos/console/_standalone.py:109", _M_CONSOLE),
+    "presidio_score_threshold": ("live-shim", "petasos/console/_standalone.py:111", _M_CONSOLE),
+    # --- Feature gates (via Pipeline._FEATURE_GATES, pipeline.py:568-574) ----
+    "frequency_enabled": ("live-library", "petasos/pipeline.py:978", None),
+    "escalation_enabled": ("live-library", "petasos/pipeline.py:998", None),
+    "profile_name": ("live-library", "petasos/pipeline.py:587", None),
+    # The ticket's original premise said this was dead config. Refuted
+    # 2026-08-03: the enforcement site asks is_feature_enabled("tool_guard") by
+    # FEATURE name, which _FEATURE_GATES maps to the attribute, and
+    # _FEATURE_DISABLED is allowed=True, so turning it off allows every tool call
+    # unscanned. tests/test_guard.py::TestFeatureGate already pins the difference.
+    "tool_guard_enabled": ("live-library", "petasos/session/guard.py:440", None),
+    "audit_enabled": ("live-library", "petasos/pipeline.py:1011", None),
+    "alert_enabled": ("live-library", "petasos/pipeline.py:1023", None),
+    # --- Alerting (all read inside AlertManager, a base-install consumer) ----
+    "alert_cooldown_seconds": ("live-library", "petasos/session/alerting.py:149", None),
+    "alert_per_minute_cap": ("live-library", "petasos/session/alerting.py:173", None),
+    "alert_per_hour_cap": ("live-library", "petasos/session/alerting.py:179", None),
+    "alert_critical_per_minute_cap": ("live-library", "petasos/session/alerting.py:141", None),
+    "alert_high_severity_threshold": ("live-library", "petasos/session/alerting.py:312", None),
+    "alert_rapid_fire_count": ("live-library", "petasos/session/alerting.py:356", None),
+    "alert_rapid_fire_window_seconds": ("live-library", "petasos/session/alerting.py:353", None),
+    "alert_cross_session_burst_count": ("live-library", "petasos/session/alerting.py:410", None),
+    "alert_cross_session_burst_window_seconds": (
+        "live-library",
+        "petasos/session/alerting.py:394",
+        None,
+    ),
+    "alert_pii_volume_threshold": ("live-library", "petasos/session/alerting.py:442", None),
+    "alert_pii_volume_window_seconds": ("live-library", "petasos/session/alerting.py:439", None),
+    "alert_ring_buffer_capacity": ("live-library", "petasos/session/alerting.py:349", None),
+    "alert_per_session_contribution_cap": (
+        "live-library",
+        "petasos/session/alerting.py:167",
+        None,
+    ),
+    "alert_max_session_contribution_entries": (
+        "live-library",
+        "petasos/session/alerting.py:158",
+        None,
+    ),
+    # --- Audit (read inside AuditEmitter) -----------------------------------
+    "audit_verbosity": ("live-library", "petasos/session/audit.py:110", None),
+    "audit_emit_findings": ("live-library", "petasos/session/audit.py:111", None),
+    # --- Frequency / escalation --------------------------------------------
+    "frequency_half_life_seconds": ("live-library", "petasos/session/frequency.py:80", None),
+    "frequency_weights": ("live-library", "petasos/session/frequency.py:104", None),
+    "rolling_window_seconds": ("live-library", "petasos/session/frequency.py:81", None),
+    "rolling_threshold": ("live-library", "petasos/session/frequency.py:82", None),
+    "tier1_threshold": ("live-library", "petasos/session/escalation.py:80", None),
+    "tier2_threshold": ("live-library", "petasos/session/escalation.py:80", None),
+    "tier3_threshold": ("live-library", "petasos/session/escalation.py:73", None),
+    # --- Session management -------------------------------------------------
+    "max_sessions": ("live-library", "petasos/session/frequency.py:83", None),
+    "session_ttl_seconds": ("live-library", "petasos/session/frequency.py:84", None),
+    "max_new_sessions_per_minute": ("live-library", "petasos/session/frequency.py:85", None),
+    "max_terminated_tombstones": ("live-library", "petasos/session/frequency.py:131", None),
+    # Excluded from the console for SECRECY, which is an axis orthogonal to the
+    # taxonomy (spec Decision 7): live-library AND excluded. Its consumers are the
+    # guard's session binding and the console spool HMAC, neither of which is one
+    # of the five compared PipelineResult fields, so the boundary-scope rule
+    # applies and the component read is the anchor.
+    "session_secret": ("live-library", "petasos/session/guard.py:669", None),
+    # --- Tool guard / lineage / taint (read inside guard + registries) -------
+    "subagent_lineage_enabled": ("live-library", "petasos/session/guard.py:698", None),
+    "delegate_fanout_enabled": ("live-library", "petasos/session/guard.py:517", None),
+    "lineage_max_depth": ("live-library", "petasos/session/lineage.py:37", None),
+    "lineage_max_edges": ("live-library", "petasos/session/lineage.py:38", None),
+    "lineage_edge_ttl_seconds": ("live-library", "petasos/session/lineage.py:39", None),
+    "delegate_max_fanout_per_window": ("live-library", "petasos/session/guard.py:651", None),
+    "delegate_fanout_window_seconds": ("live-library", "petasos/session/guard.py:234", None),
+    "delegate_tool_names": ("live-library", "petasos/session/guard.py:218", None),
+    # Only behavior reads are the shim's: the canonicalized sink set is built from
+    # config at reference_plugin/__init__.py:685 and rebuilt on rebind at :1245.
+    # Inside petasos/ the name appears only in config.py validation/coercion, its
+    # _FIELD_META entry, a scope comment, and a taint.py docstring mention.
+    "egress_sink_tools": (
+        "live-shim",
+        "docs/deployment/reference_plugin/__init__.py:685",
+        _M_PLUGIN,
+    ),
+    "source_taint_namespaces": (
+        "live-shim",
+        "docs/deployment/reference_plugin/__init__.py:704",
+        _M_PLUGIN,
+    ),
+    # The third knob of the same fence, and the named exemption: unlike its two
+    # siblings it has a real library read, so under the boundary-scope rule it is
+    # live-library through SessionTaintStore and test 2's marker-iff constraint
+    # forbids pinning a caveat marker on it. Its help_plain is still extended to
+    # name the plugin (a deliberately unpinned thirteenth prose edit), and the
+    # audit table records that SessionTaintStore is today instantiated only by the
+    # shim, so the key bites for a library embedder only if they drive the store.
+    "taint_min_span_length": ("live-library", "petasos/session/taint.py:120", None),
+}
+
+_FIELD_NAMES = {f.name for f in dataclasses.fields(PetasosConfig)}
+
+
+def _keys_with_verdict(verdict: str) -> frozenset[str]:
+    return frozenset(k for k, (v, _, _) in _CLASSIFICATION.items() if v == verdict)
+
+
+# ---------------------------------------------------------------------------
+# 1. The tripwire against a future unclassified field.
+# ---------------------------------------------------------------------------
+
+
+def test_every_field_classified() -> None:
+    """Every PetasosConfig field carries a verdict, including the three in
+    _EXCLUDED_FIELDS.
+
+    Ships because the 2026-08-03 sweep met the criterion pre-registered in spec
+    Decision 1 and on the PET-169 Plane item before the sweep ran. BOTH clauses
+    fired: clause 1 (five keys newly live-shim beyond the three disposed of by
+    prior tickets) and clause 2 (twelve keys needing new help_plain caveat prose).
+
+    generate_config_metadata() iterates dataclasses.fields(PetasosConfig) and
+    emits a console entry for everything outside _EXCLUDED_FIELDS, so adding a
+    field publishes an operator control automatically. Metadata coverage is
+    already guarded; what nothing else requires is that a classified, described,
+    well-sectioned field have a read site that affects an outcome.
+    """
+    assert set(_CLASSIFICATION) == _FIELD_NAMES
+
+
+# ---------------------------------------------------------------------------
+# 2. Verdicts and evidence are well formed, and every anchor resolves.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field_name", sorted(_CLASSIFICATION))
+def test_verdicts_and_evidence_wellformed(field_name: str) -> None:
+    verdict, evidence, marker = _CLASSIFICATION[field_name]
+    assert verdict in _VERDICTS, f"{field_name}: unknown verdict {verdict!r}"
+
+    # The `none:` sentinel is used iff the verdict is `dead`, so verdict and
+    # evidence check each other. A dead key has no read site by definition; an
+    # unconditional path:line requirement would force the auditor to fabricate
+    # one, cite the declaration line (which spec Decision 4 disqualifies as a
+    # read), or downgrade the verdict.
+    is_sentinel = evidence.startswith("none:")
+    assert is_sentinel == (verdict == "dead"), (
+        f"{field_name}: the none: sentinel must be used iff verdict is 'dead' "
+        f"(verdict={verdict!r}, evidence={evidence!r})"
+    )
+
+    # Resolve the anchor. Strip the sentinel prefix FIRST: "none:petasos/config.py:93"
+    # splits to the path "none:petasos/config.py", which does not exist, so an
+    # unstripped parser either reds spuriously or gets exempted from resolution
+    # entirely, leaving the one anchor nobody checks on the verdict this ticket
+    # exists to catch. A dead key's declaration site must still exist.
+    raw = evidence[len("none:") :] if is_sentinel else evidence
+    path_str, _, line_str = raw.rpartition(":")
+    assert path_str and line_str.isdigit(), (
+        f"{field_name}: evidence must be path:line, got {raw!r}"
+    )
+    target = _REPO_ROOT / path_str
+    assert target.is_file(), f"{field_name}: evidence path does not exist: {path_str}"
+    # encoding is explicit: the pinned local C:\python310 interpreter defaults to
+    # cp1252 and petasos/normalize.py alone carries 89 non-ASCII characters, so an
+    # unqualified read_text() raises UnicodeDecodeError locally while passing on CI.
+    line_count = len(target.read_text(encoding="utf-8").splitlines())
+    line_no = int(line_str)
+    assert 1 <= line_no <= line_count, (
+        f"{field_name}: evidence line {line_no} is outside {path_str} (1..{line_count})"
+    )
+
+    # A marker is required iff the verdict owes a caveat. An empty-string marker
+    # would make `"" in help_plain` true for every entry, turning test 4 into an
+    # assertion-shaped no-op; a None marker on a caveat key would raise TypeError
+    # rather than fail readably.
+    if verdict in _CAVEAT_VERDICTS:
+        assert marker is not None and marker.strip(), (
+            f"{field_name}: verdict {verdict!r} requires a non-empty help marker"
+        )
+    else:
+        assert marker is None, (
+            f"{field_name}: verdict {verdict!r} must not carry a help marker, got {marker!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-verdict membership is pinned.
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_sets_pinned() -> None:
+    """The `test_config_meta.py:48` idiom applied per verdict.
+
+    Without this, emptying `live-partial` is a one-line edit no test can see,
+    after which test 4 iterates zero keys and no caveat ships; and a future author
+    can silence a red test 4, 5 or 8 by editing a verdict instead of the surface.
+    """
+    assert _keys_with_verdict("live-partial") == frozenset(
+        {
+            # PET-151, prose already shipped.
+            "normalize_nfkc",
+            "strip_zero_width",
+            "map_homoglyphs",
+            # The anonymization group.
+            "anonymize",
+            "pii_entities",
+            "redaction_mode",
+            "hash_key",
+            # The scanner-timeout family: three keys, but only two carry the
+            # `circuit_breaker` prefix, so seeding this group by glob silently
+            # drops scanner_timeout_seconds.
+            "scanner_timeout_seconds",
+            "scanner_circuit_breaker_threshold",
+            "scanner_circuit_breaker_cooldown_seconds",
+        }
+    )
+    assert _keys_with_verdict("live-shim") == frozenset(
+        {
+            "init_wait_timeout_seconds",
+            "presidio_entities",
+            "presidio_entities_extra",
+            "presidio_score_threshold",
+            "egress_sink_tools",
+            "source_taint_namespaces",
+        }
+    )
+    assert _keys_with_verdict("not-a-control") == frozenset({"fold_leet", "detect_rtl_override"})
+    # The 2026-08-03 sweep found no key with no read site anywhere. Recorded as a
+    # pin rather than an omission: a future `dead` verdict is a finding, and it
+    # has to red this line to get added.
+    assert _keys_with_verdict("dead") == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# 4-7. The surface must match the verdicts.
+# ---------------------------------------------------------------------------
+
+
+def test_caveat_keys_disclose_consumer() -> None:
+    """Every live-partial and live-shim key names its true consumer at the point
+    of display. Presence is asserted first so a de-surfaced caveat key reds
+    instead of silently iterating zero times."""
+    by_name = {e["name"]: e for e in generate_config_metadata()}
+    for field_name in sorted(_keys_with_verdict("live-partial") | _keys_with_verdict("live-shim")):
+        _, _, marker = _CLASSIFICATION[field_name]
+        assert field_name in by_name, f"{field_name}: caveat key is not surfaced in the console"
+        assert marker is not None  # guaranteed by test 2; narrows the type here
+        help_plain = by_name[field_name]["help_plain"]
+        assert marker in help_plain, (
+            f"{field_name}: help_plain does not carry the required disclosure marker {marker!r}"
+        )
+
+
+def test_retired_keys_are_de_surfaced() -> None:
+    """Every not-a-control and dead key is gone from BOTH the generated metadata
+    and _FIELD_META. The second half closes the orphan-entry class and keeps the
+    PET-128 doc-count guard honest."""
+    surfaced = {e["name"] for e in generate_config_metadata()}
+    for field_name in sorted(_keys_with_verdict("not-a-control") | _keys_with_verdict("dead")):
+        assert field_name not in surfaced, f"{field_name}: retired key is still rendered"
+        assert field_name not in _FIELD_META, f"{field_name}: retired key still has _FIELD_META"
+
+
+def test_field_meta_has_no_orphans() -> None:
+    """Catches a rename that leaves stale operator prose behind."""
+    assert set(_FIELD_META) <= _FIELD_NAMES
+
+
+def test_secret_defaults_never_published() -> None:
+    """`entry["default"] = _serialize_default(...)` runs unconditionally at
+    _config_meta.py:887 and `entry["redacted"] = True` is additive and scrubs
+    nothing, so a future secret field with a non-None default would publish that
+    default on every metadata fetch. hash_key's default is None today, so the hole
+    is latent, which is precisely the state a tripwire exists to guard. Asserting
+    excluded-or-redacted alone would be true by construction and unfalsifiable."""
+    by_name = {e["name"]: e for e in generate_config_metadata()}
+    for field_name in sorted(_SECRET_FIELDS):
+        entry = by_name.get(field_name)
+        if entry is None:
+            continue  # excluded outright, e.g. session_secret
+        assert entry["default"] is None, (
+            f"{field_name}: a secret field must not publish a default value"
+        )
+        assert entry.get("redacted") is True, f"{field_name}: secret field is not marked redacted"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -826,3 +826,166 @@ class TestMinimalScannerError:
         )
         result = await pipe.inspect("hello world")
         assert result.safe is False
+
+
+# ===================================================================
+# PET-169 test-8 load-bearing arms (6 tests)
+#
+# Every key the config-surface honesty audit newly classified `live-partial`
+# gets an arm proving the caveat's claim is true for the consumer that caveat
+# names. The `live-partial` verdict itself says the key is inert on a base
+# install (MinimalScanner only); these arms are the other half, and without them
+# a caveat ships on the strength of a read trace alone, which is the exact
+# substitution PET-143 D-A and PET-151 forbid.
+#
+# The three PET-151 normalization toggles are exempt (transcribed, pins already
+# shipped as test_normalize_nfkc_is_an_ml_control and its two siblings above).
+# `hash_key` is exempt with its rationale recorded: it is consumed only under
+# mode == "hash", an engine-path mode, and config.py:233 rejects anonymize=True
+# with redaction_mode="hash" and hash_key=None at construction, so no
+# extras-free configuration exists in which flipping it changes anything. Its
+# caveat rests on the redaction_mode arm plus the read trace.
+#
+# No arm here requires a scanner extra: the PII positive control is a stub
+# Scanner emitting positioned finding_type="pii" findings, necessary because
+# MinimalScanner emits only injection/command/encoding/structural, so the
+# pii_findings filter in Stage 9 is always empty on a base install and an
+# unaided diff would compare two identical results with nothing exercised. The
+# anonymization arms set redaction_mode explicitly to "replace" or "mask": the
+# default is "redact", which routes to the engine path, and an arm written at
+# defaults would pin the ImportError handler rather than anonymization.
+# ===================================================================
+
+
+_PII_TEXT = "Alice met alice@example.com today"
+
+
+def _typed_pii_finding(text: str, needle: str, entity_type: str) -> ScanFinding:
+    """A positioned PII finding whose rule_id recovers to ``entity_type``."""
+    start = text.index(needle)
+    return ScanFinding(
+        rule_id=f"petasos.presidio.{entity_type.lower()}",
+        finding_type="pii",
+        severity=Severity.MEDIUM,
+        confidence=0.9,
+        message=f"PII detected: {entity_type}",
+        scanner_name="pii-stub",
+        position=Position(start=start, end=start + len(needle)),
+        matched_text=needle,
+    )
+
+
+def _pii_stub_pipeline(**overrides: object) -> Pipeline:
+    """A pipeline whose lone ML scanner reports two typed PII spans, standing in
+    for the PII-detecting scanner the anonymization caveats name."""
+    findings = (
+        _typed_pii_finding(_PII_TEXT, "Alice", "PERSON"),
+        _typed_pii_finding(_PII_TEXT, "alice@example.com", "EMAIL_ADDRESS"),
+    )
+    cfg = PetasosConfig(**overrides)  # type: ignore[arg-type]
+    return Pipeline(scanners=[MockScanner("pii-stub", findings=findings)], config=cfg)
+
+
+class TestConfigSurfaceLoadBearingArms:
+    async def test_anonymize_is_a_control_with_a_pii_scanner(self) -> None:
+        # Regression for PET-169: `anonymize` is live once a PII-detecting
+        # scanner is registered, which is what its help_plain caveat claims.
+        on = await _pii_stub_pipeline(anonymize=True, redaction_mode="replace").inspect(_PII_TEXT)
+        off = await _pii_stub_pipeline(anonymize=False, redaction_mode="replace").inspect(
+            _PII_TEXT
+        )
+        assert off.sanitized_content is None
+        assert on.sanitized_content is not None
+        assert "Alice" not in on.sanitized_content
+        assert "<PERSON_1>" in on.sanitized_content
+        # No ImportError arm was taken: the manual replace/mask path is pure
+        # Python, so a missing presidio backend cannot explain this diff.
+        assert not any("presidio not installed" in e for e in on.errors)
+
+    async def test_pii_entities_is_a_control_with_a_pii_scanner(self) -> None:
+        # Regression for PET-169: narrowing pii_entities changes which spans the
+        # anonymize step hides, once something is being hidden at all.
+        wide = await _pii_stub_pipeline(anonymize=True, redaction_mode="replace").inspect(
+            _PII_TEXT
+        )
+        narrowed = await _pii_stub_pipeline(
+            anonymize=True, redaction_mode="replace", pii_entities=("PERSON",)
+        ).inspect(_PII_TEXT)
+        assert wide.sanitized_content is not None and narrowed.sanitized_content is not None
+        assert wide.sanitized_content != narrowed.sanitized_content
+        assert "alice@example.com" not in wide.sanitized_content
+        assert "alice@example.com" in narrowed.sanitized_content
+        assert "Alice" not in narrowed.sanitized_content
+
+    async def test_redaction_mode_is_a_control_with_a_pii_scanner(self) -> None:
+        # Regression for PET-169: "replace" and "mask" both route through the
+        # extras-free manual path and produce different output.
+        replaced = await _pii_stub_pipeline(anonymize=True, redaction_mode="replace").inspect(
+            _PII_TEXT
+        )
+        masked = await _pii_stub_pipeline(anonymize=True, redaction_mode="mask").inspect(_PII_TEXT)
+        assert replaced.sanitized_content is not None and masked.sanitized_content is not None
+        assert replaced.sanitized_content != masked.sanitized_content
+        assert "<PERSON_1>" in replaced.sanitized_content
+        assert "<PERSON_1>" not in masked.sanitized_content
+        assert "*" in masked.sanitized_content
+
+    async def test_scanner_timeout_seconds_is_a_control_with_an_ml_scanner(self) -> None:
+        # Regression for PET-169: the per-scanner deadline is read only inside
+        # _scan_with_breaker, which runs only when an ML scanner is registered.
+        # With one registered the toggle moves `safe`: a timeout counts as a
+        # scanner failure and degraded mode blocks.
+        slow = MockScanner("slow-ml", delay=0.2)
+        tight = Pipeline([slow], config=PetasosConfig(scanner_timeout_seconds=0.01))
+        loose = Pipeline([slow], config=PetasosConfig(scanner_timeout_seconds=5.0))
+        assert (await tight.inspect("hello world")).safe is False
+        assert (await loose.inspect("hello world")).safe is True
+
+    async def test_circuit_breaker_threshold_is_a_control_with_an_ml_scanner(self) -> None:
+        # Regression for PET-169: at threshold 1 the second scan is
+        # short-circuited by the open breaker; at threshold 3 the scanner is
+        # re-awaited and times out again. Distinct error classes, same input.
+        from petasos.pipeline import _BREAKER_OPEN_ERROR_PREFIX, _TIMEOUT_ERROR_PREFIX
+
+        async def _second_scan_error(threshold: int) -> str:
+            pipe = Pipeline(
+                [MockScanner("slow-ml", delay=0.2)],
+                config=PetasosConfig(
+                    scanner_timeout_seconds=0.01,
+                    scanner_circuit_breaker_threshold=threshold,
+                    scanner_circuit_breaker_cooldown_seconds=30.0,
+                ),
+            )
+            await pipe.inspect("hello world")
+            second = await pipe.inspect("hello world")
+            errors = [r.error for r in second.scanner_results if r.scanner_name == "slow-ml"]
+            assert len(errors) == 1 and errors[0] is not None
+            return errors[0]
+
+        assert (await _second_scan_error(1)).startswith(_BREAKER_OPEN_ERROR_PREFIX)
+        assert (await _second_scan_error(3)).startswith(_TIMEOUT_ERROR_PREFIX)
+
+    async def test_circuit_breaker_cooldown_is_a_control_with_an_ml_scanner(self) -> None:
+        # Regression for PET-169: with the breaker already open, a cooldown that
+        # has elapsed lets the scanner be re-awaited (timeout error); one that
+        # has not keeps it short-circuited (breaker-open error).
+        from petasos.pipeline import _BREAKER_OPEN_ERROR_PREFIX, _TIMEOUT_ERROR_PREFIX
+
+        async def _error_after_cooldown(cooldown: float) -> str:
+            pipe = Pipeline(
+                [MockScanner("slow-ml", delay=0.2)],
+                config=PetasosConfig(
+                    scanner_timeout_seconds=0.01,
+                    scanner_circuit_breaker_threshold=1,
+                    scanner_circuit_breaker_cooldown_seconds=cooldown,
+                ),
+            )
+            await pipe.inspect("hello world")  # opens the breaker
+            await asyncio.sleep(0.05)
+            after = await pipe.inspect("hello world")
+            errors = [r.error for r in after.scanner_results if r.scanner_name == "slow-ml"]
+            assert len(errors) == 1 and errors[0] is not None
+            return errors[0]
+
+        assert (await _error_after_cooldown(0.01)).startswith(_TIMEOUT_ERROR_PREFIX)
+        assert (await _error_after_cooldown(30.0)).startswith(_BREAKER_OPEN_ERROR_PREFIX)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -958,6 +958,7 @@ class TestConfigSurfaceLoadBearingArms:
             )
             await pipe.inspect("hello world")
             second = await pipe.inspect("hello world")
+            assert second.safe is False
             errors = [r.error for r in second.scanner_results if r.scanner_name == "slow-ml"]
             assert len(errors) == 1 and errors[0] is not None
             return errors[0]


### PR DESCRIPTION
## Summary

- **Swept all 64 `PetasosConfig` fields** for the displayed-but-inert shape and recorded an evidence-bearing verdict for each in `tests/test_config_surface_honesty.py`, which is the tracked authority. Result: **46 `live-library`, 10 `live-partial`, 6 `live-shim`, 2 `not-a-control`, 0 `dead`.**
- **Nothing was newly retired**, so no field is de-surfaced, `_EXCLUDED_FIELDS` is unchanged, no preset bundle moved, and every `docs/usage/configuration.md` count stands at 61. The entire disposition load landed on **Caveat (D-C)**: thirteen `help_plain` edits, twelve of them machine-pinned.
- **Five keys were newly found inert for a library embedder** while still rendered as unqualified operator controls: `presidio_entities`, `presidio_entities_extra`, `presidio_score_threshold`, `egress_sink_tools`, `source_taint_namespaces`.
- No `PetasosConfig` field was added, removed, or retyped, and no enforcement path changed. Every existing operator config keeps loading and behaving exactly as before.

## The finding worth reading

`presidio_entities`, `presidio_entities_extra`, and `presidio_score_threshold` are read **only** inside `build_dashboard_pipeline` (`petasos/console/_standalone.py:109`, `:111`). `Pipeline` never constructs a `PresidioScanner`; it fans out over whatever the caller supplied. So an embedder who runs `pip install petasos[presidio]` and passes `Pipeline(scanners=[PresidioScanner()])` gets **nothing** from these three: the extra is installed and they are still inert.

That is why their caveat names the console bootstrap and not the extra. An "install the presidio extra" caveat would have been false prose shipped inside an honesty audit, and then pinned by a test as the machine-checked contract.

## Layered defense: why a read trace was not allowed to settle anything

The ticket was filed on a false premise (`tool_guard_enabled` is dead config), produced by a grep that missed a string-keyed indirection. So the sweep resolves indirection in both directions, and then refuses to let the trace decide:

1. **Indirection that hides a real read** — `_FEATURE_GATES` string keys, `getattr`-by-computed-name, and values threaded into a constructor rather than read at a decision point.
2. **Generic reads that are not enforcement** — serialization, type coercion, and `__post_init__` validation do not count. `init_wait_timeout_seconds` is read four times by validation alone; a sweep counting those would classify the canonical `live-shim` key as `live-library`.
3. **The trace narrows the candidate set; an outcome diff settles the verdict.** Every newly assigned `live-partial` and `live-shim` verdict is discharged by an on/off test, per the PET-143 D-A standard ("verify each toggle moves a detection *outcome* ... if it cannot, retire the surface").

## Two-check interaction: the marker lives in the classification tuple

Each entry is `(verdict, evidence, required_help_marker)`. The marker is non-`None` **iff** the verdict is `live-partial` or `live-shim`, asserted in both directions. That is what makes the two halves check each other:

- Editing a verdict to dodge a disposition reds `test_verdict_sets_pinned`.
- Dropping a caveat key out of the disclosure loop is impossible, because the marker travels with the verdict rather than in a second dict.
- An empty-string marker would make `"" in help_plain` true for every entry, turning the disclosure test into an assertion-shaped no-op across the whole caveat set. Rejected explicitly.
- Evidence uses a `none:` sentinel **iff** the verdict is `dead`, so verdict and evidence are mutually checking, and the sentinel prefix is stripped before resolution so the one anchor on the verdict this ticket exists to catch is not the one anchor nobody checks.

## Files changed

| File | Change |
|------|--------|
| `tests/test_config_surface_honesty.py` | **New.** The 64-field `_CLASSIFICATION` literal (the tracked authority) plus seven structural tests. |
| `tests/adversarial/pipeline/test_config_surface_inertness.py` | **New.** Five inertness arms proving each newly `live-shim` key moves no library outcome, each with a positive control. |
| `tests/test_pipeline.py` | Adds six load-bearing arms proving each newly `live-partial` key moves an outcome once its named consumer is present. |
| `petasos/console/_config_meta.py` | Thirteen `help_plain` caveats naming the true consumer. No `_FIELD_META` deletions, no `_EXCLUDED_FIELDS` additions. |
| `petasos/console/_presets.py` | Steel and Titanium no longer assert PII anonymization as an unconditional posture. Overrides untouched. |
| `petasos/config.py` | Rationale comment only. Corrects the claim that `decode_encoded_payloads` bites "in every pipeline build path". |
| `docs/usage/configuration.md` | Qualifies the unconditional egress and taint fence guarantees. Counts unchanged. |
| `CHANGELOG.md` | One `Unreleased` entry. |

## Notable exemptions, each recorded rather than silent

- **`hash_key`** gets no load-bearing arm. It is consumed only under `mode == "hash"`, an engine-path mode, and `config.py:233` rejects `anonymize=True` + `redaction_mode="hash"` + `hash_key=None` at construction, so no extras-free configuration exists in which flipping it changes anything. Its caveat rests on the `redaction_mode` arm plus the read trace. No `conftest.py` / `NONSKIPPING_LANES` change was needed.
- **`taint_min_span_length`** is `live-library` through `SessionTaintStore`, so the marker-iff constraint **forbids** pinning a caveat marker on it. Its prose was still extended to name the plugin: a deliberately unpinned thirteenth edit.
- **`decode_encoded_payloads`** stays `live-library`, but the shim passes a bare `MinimalScanner` that the pipeline adopts without the flag, so that deployment runs the decode stage at its default until the first live rebind. Filed as **PET-173**; the misleading `config.py` comment is corrected here.
- **No Thread ticket is owed.** PET-119 D1 requires one per `dead` key; the sweep found none, so the obligation is discharged vacuously and recorded as such.

## The anonymization arms had to avoid two traps

`MinimalScanner` emits only `injection`/`command`/`encoding`/`structural`, so the Stage 9 `pii_findings` filter is always empty on a base install and an unaided diff would compare two identical results with nothing exercised. Every arm therefore supplies a stub `Scanner` emitting positioned `finding_type="pii"` findings as its positive control. And each sets `redaction_mode` explicitly to `replace` or `mask`: the default is `redact`, which routes to the engine path, and an arm written at defaults would produce a diff that pins the `ImportError` handler rather than anonymization. Both paths are pure Python, so **no arm requires a scanner extra**.

## Test plan

- [x] `C:\python310\python.exe -m pytest tests/test_config_surface_honesty.py tests/test_config_meta.py tests/test_config.py tests/test_presets.py tests/test_docs_usage_consistency.py tests/test_pipeline.py tests/adversarial/normalization/test_unicode_bypass.py tests/adversarial/pipeline/test_config_surface_inertness.py tests/test_guard.py -q` — 345/345 pass
- [x] Full suite: `pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — **2361 passed, 42 skipped, 1 xfailed**. The deselect covers a pre-existing `master` failure (Unicode 13 vs 14 on the local 3.10 interpreter), not a regression from this work.
- [x] `ruff check .` clean, `ruff format --check .` clean, `mypy --strict .` clean (165 files)
- [x] **Falsifiability probes run against every new pin class**, since a green audit test is worthless if it cannot fail: a removed disclosure marker reds the caveat test; an anchor past EOF, a missing path, a `dead` verdict without the sentinel, a missing marker, a whitespace-only marker, and a marker on a non-caveat verdict are each caught; a new unclassified field reds the tripwire; and a genuinely live key reds the same equality the inertness arms use, proving that comparison is not vacuous.
- [x] `tests/test_docs_usage_consistency.py` green, and the two unenforced prose counts (`configuration.md:34`, `:320`) checked by hand against the final `_FIELD_META` length of 61
- [x] Strength-dial descriptions audited by hand (nothing asserts on description prose): Steel and Titanium qualified, Tin and Bronze/Iron checked and deliberately left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified enforcement boundaries for egress blocking and source-taint controls.
  * Documented scanner applicability, configuration timing, required settings, and consumer-specific limitations.
  * Updated Steel and Titanium preset descriptions with clearer PII-scanning conditions.
  * Added disclosures for anonymization, ML behavior, Presidio configuration, and secret requirements.

* **Tests**
  * Added coverage for anonymization, filtering, masking, timeouts, circuit breakers, and cooldowns.
  * Added audits verifying complete, accurate, and safe configuration disclosures.
  * Added regression coverage for configuration settings that do not affect active processing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->