### PR TITLE
fix(pet-174): one shared scanner bootstrap so config reaches the enforcement path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [Unreleased]
 
+### Added
+
+- **`petasos.scanners.build_scanners(config)`**, plus the `ScannerBuildStatus`
+  record and `ScannerOutcome` literal it returns (PET-174). One published helper
+  that turns a `PetasosConfig` into the scanner list a `Pipeline` needs: the
+  `MinimalScanner` carrying `decode_encoded_payloads`, then each optional backend
+  that constructed, with Presidio built from `presidio_entities`,
+  `presidio_entities_extra`, and `presidio_score_threshold`. It returns data and
+  never logs, so a caller keeps its own wording and levels, and it never raises
+  for an optional-backend failure. Embedders who construct their own `Pipeline`
+  can call it instead of hand-wiring each scanner's config.
+
+### Fixed
+
+- **Presidio detection config and the payload-decode flag now reach the
+  enforcement path** (PET-174). Petasos built its scanner list twice by hand: the
+  console bootstrap wired `presidio_entities`, `presidio_entities_extra`,
+  `presidio_score_threshold`, and `decode_encoded_payloads` into the scanner
+  constructors, and the reference plugin's bootstrap, which serves the Hermes
+  hook that actually blocks tool calls, wired none of them. Setting any of the
+  four was therefore honored by the pipeline that renders the console and dropped
+  by the pipeline that enforces, including through all five console posture
+  presets. Both bootstraps now route through `build_scanners`, and a structural
+  test fails the build if a third bootstrap constructs scanners by hand. Log
+  wording, levels, and ordering on both paths are unchanged. These fields still
+  apply at construction time only: a live config edit or a Hermes-profile
+  re-bind takes effect at the next restart.
+- **Plugin/library sync requirement.** The reference plugin now imports
+  `build_scanners`, so it requires a `petasos` release that exports it. Copy the
+  plugin files and upgrade the library together; a newer plugin over an older
+  library fails init and leaves tool calls unenforced. `verify.py`'s
+  scanner-imports check FAILs on that skew before boot.
+
 ## [0.2.0] - 2026-06-30
 
 Headline release since 0.1.2: Hermes-agent profile/role awareness end to end,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ petasos/
 ├── pipeline.py          # Pipeline class — central orchestrator
 ├── config.py            # PetasosConfig dataclass
 ├── scanners/
+│   ├── bootstrap.py     # build_scanners (shared config-to-scanner build, base install)
 │   ├── minimal.py       # MinimalScanner (zero-dep, 23 rules across 6 families)
 │   ├── llm_guard.py     # LlmGuardScanner (extras: llm-guard)
 │   ├── llama_firewall.py # LlamaFirewallScanner (extras: llamafirewall)

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -435,6 +435,12 @@ minor update:
    Copy-Item -Recurse "$env:LOCALAPPDATA\hermes\plugins\petasos" "$env:LOCALAPPDATA\hermes\profiles\gibson\plugins\petasos"
    ```
 
+   The plugin files and the `petasos` library in Hermes's venv must move
+   together: the plugin requires a `petasos` release that exports
+   `petasos.scanners.build_scanners`, and a newer plugin over an older library
+   fails init and leaves every tool call unenforced. `verify.py`'s scanner-imports
+   check FAILs on that skew, so run it before restarting.
+
 3. Restart Hermes Desktop.
 
 If the plugin files are absent from the resolved home, enforcement is **silently

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -11,6 +11,10 @@ Deploy: copy this directory to the active Hermes profile's plugin dir:
 Config: add a top-level ``petasos:`` section to the profile's config.yaml
 Env:    PETASOS_LICENSE_KEY, PETASOS_SESSION_SECRET, PETASOS_HASH_KEY,
         PETASOS_AUDIT_FINDING
+Needs:  a ``petasos`` release that exports ``petasos.scanners.build_scanners``;
+        sync this file and the library together. Copying a newer plugin over an
+        older library fails init and leaves every tool call unenforced. Run
+        ``verify.py`` first: its scanner-imports check FAILs on that skew.
 
 Capture window (PET-136): to record per-finding tuning data, open a short
 capture window by setting ``PETASOS_AUDIT_FINDING=1`` (or flipping the
@@ -452,6 +456,18 @@ def _build_config_from_section(section: dict[str, Any]) -> PetasosConfig:
 # Deferred initialization — runs in background thread from register()
 # ---------------------------------------------------------------------------
 
+# PET-174: per-backend not-installed wording, preserved verbatim from the three
+# inline blocks this plugin used before `build_scanners`. Looked up with `.get`
+# and a generic fallback, never `[...]`: a fourth backend added inside
+# `build_scanners` must not raise KeyError inside _deferred_init's outer try,
+# which would latch _init_error and boot the plugin unenforcing. The helper owns
+# the backend set; this table only carries wording.
+_NOT_INSTALLED_MSG = {
+    "llm_guard": "LLM Guard not installed — syntactic-only for that backend",
+    "llama_firewall": "LlamaFirewall not installed — skipped",
+    "presidio": "Presidio not installed — PII detection unavailable",
+}
+
 
 def _deferred_init() -> None:
     global _pipeline, _guard, _initialized, _init_error
@@ -466,7 +482,7 @@ def _deferred_init() -> None:
 
             try:
                 from petasos import PetasosConfig, Pipeline, ToolCallGuard
-                from petasos.scanners import MinimalScanner
+                from petasos.scanners import build_scanners
 
                 raw_config = _config or {}
 
@@ -518,73 +534,35 @@ def _deferred_init() -> None:
                     logger.error("PetasosConfig validation failed: %s — using defaults", exc)
                     config = PetasosConfig()
 
-                scanners = [MinimalScanner()]
+                # PET-174: one shared config-to-scanner build with the console
+                # bootstrap, so the four scanner-construction config fields
+                # (presidio_entities, presidio_entities_extra,
+                # presidio_score_threshold, decode_encoded_payloads) reach the
+                # enforcement pipeline, not just the one that renders the console.
+                # This caller owns only the rendering; every message template and
+                # level below is unchanged from the three inline blocks.
+                scanners, statuses = build_scanners(config)
                 unavailable: list[str] = []
-                try:
-                    from petasos.scanners import LlmGuardScanner
-
-                    instance = LlmGuardScanner()
-                    scanners.append(instance)
-                    avail, reason, _cause = instance.availability()
-                    if avail:
-                        logger.info("LLM Guard backend verified — scanner active")
-                    else:
-                        unavailable.append("llm_guard")
+                for st in statuses:
+                    if st.outcome == "verified":
+                        logger.info("%s backend verified — scanner active", st.display_name)
+                        continue
+                    unavailable.append(st.scanner_id)
+                    if st.outcome == "degraded":
                         logger.warning(
-                            "LLM Guard backend missing — scanner registered degraded "
+                            "%s backend missing — scanner registered degraded "
                             "(every scan will error): %s",
-                            reason,
+                            st.display_name,
+                            st.reason,
                         )
-                except ImportError:
-                    unavailable.append("llm_guard")
-                    logger.info("LLM Guard not installed — syntactic-only for that backend")
-                except Exception as exc:
-                    unavailable.append("llm_guard")
-                    logger.warning("LLM Guard failed to load: %s", exc)
-
-                try:
-                    from petasos.scanners import LlamaFirewallScanner
-
-                    instance = LlamaFirewallScanner()
-                    scanners.append(instance)
-                    avail, reason, _cause = instance.availability()
-                    if avail:
-                        logger.info("LlamaFirewall backend verified — scanner active")
+                    elif st.outcome == "missing":
+                        logger.info(
+                            _NOT_INSTALLED_MSG.get(
+                                st.scanner_id, f"{st.display_name} not installed, skipped"
+                            )
+                        )
                     else:
-                        unavailable.append("llama_firewall")
-                        logger.warning(
-                            "LlamaFirewall backend missing — scanner registered degraded "
-                            "(every scan will error): %s",
-                            reason,
-                        )
-                except ImportError:
-                    unavailable.append("llama_firewall")
-                    logger.info("LlamaFirewall not installed — skipped")
-                except Exception as exc:
-                    unavailable.append("llama_firewall")
-                    logger.warning("LlamaFirewall failed to load: %s", exc)
-
-                try:
-                    from petasos.scanners import PresidioScanner
-
-                    instance = PresidioScanner()
-                    scanners.append(instance)
-                    avail, reason, _cause = instance.availability()
-                    if avail:
-                        logger.info("Presidio backend verified — scanner active")
-                    else:
-                        unavailable.append("presidio")
-                        logger.warning(
-                            "Presidio backend missing — scanner registered degraded "
-                            "(every scan will error): %s",
-                            reason,
-                        )
-                except ImportError:
-                    unavailable.append("presidio")
-                    logger.info("Presidio not installed — PII detection unavailable")
-                except Exception as exc:
-                    unavailable.append("presidio")
-                    logger.warning("Presidio failed to load: %s", exc)
+                        logger.warning("%s failed to load: %s", st.display_name, st.reason)
 
                 _pipeline = Pipeline(
                     config=config,

--- a/docs/deployment/reference_plugin/verify.py
+++ b/docs/deployment/reference_plugin/verify.py
@@ -39,6 +39,22 @@ def check(name: str, fn: Callable[[], CheckResult]) -> None:
 
 
 def check_scanner_imports() -> CheckResult:
+    # PET-174: the plugin/library capability floor, probed FIRST. This function has
+    # two earlier exits (the base-install WARN below and the PASS after it), and
+    # main() counts only FAIL toward fail_count — appended after the tally, this
+    # probe would be skipped on exactly the deployment where it matters most: a
+    # base install with no ML extras, which returns WARN, exits 0, and prints
+    # "All checks passed" over a skew that boots the plugin unenforcing.
+    try:
+        from petasos.scanners import build_scanners  # noqa: F401
+    except ImportError:
+        return (
+            FAIL,
+            "Installed petasos does not export petasos.scanners.build_scanners."
+            " This plugin requires a petasos release that does; sync the plugin"
+            " files and the library together.",
+        )
+
     from petasos.scanners import MinimalScanner  # noqa: F401
 
     available = ["MinimalScanner"]

--- a/docs/usage/scanners.md
+++ b/docs/usage/scanners.md
@@ -209,6 +209,11 @@ separate anonymization stage acts on what is found:
   mask).
 - `hash_key`: the secret key used when `redaction_mode` is `hash`.
 
+The three `presidio_*` fields are read where the scanner is constructed, so an
+embedder who builds a `PresidioScanner` itself has to pass them through, or call
+`petasos.scanners.build_scanners(config)` and hand the returned list to
+`Pipeline` (that is the helper both bundled bootstraps use).
+
 See [the configuration guide](configuration.md) for the full walkthrough of these
 fields.
 

--- a/petasos/console/_standalone.py
+++ b/petasos/console/_standalone.py
@@ -21,7 +21,6 @@ self-initialized summary). Do not reword them without updating those tests.
 from __future__ import annotations
 
 import base64
-import importlib
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -53,7 +52,7 @@ def build_dashboard_pipeline(raw_config: dict[str, Any]) -> Pipeline:
     silently unattested spool reads.
     """
     from petasos import PetasosConfig, Pipeline
-    from petasos.scanners import MinimalScanner
+    from petasos.scanners import build_scanners
 
     # Defensive copy: the builder mutates (pops + injects), so a caller's dict is
     # left untouched.
@@ -84,60 +83,26 @@ def build_dashboard_pipeline(raw_config: dict[str, Any]) -> Pipeline:
         logger.warning("config.yaml rejected (%s); falling back to defaults", exc)
         config = PetasosConfig()
 
-    scanners = [MinimalScanner(decode_encoded_payloads=config.decode_encoded_payloads)]
+    # PET-174: one shared config-to-scanner build, so the four scanner-construction
+    # config fields reach the enforcement path too. This caller owns only the
+    # rendering; every message template below is unchanged from the inline loop.
+    scanners, statuses = build_scanners(config)
     unavailable: list[str] = []
-    for name, cls_path in [
-        ("LLM Guard", "petasos.scanners.LlmGuardScanner"),
-        ("LlamaFirewall", "petasos.scanners.LlamaFirewallScanner"),
-        ("Presidio", "petasos.scanners.PresidioScanner"),
-    ]:
-        try:
-            mod, cls = cls_path.rsplit(".", 1)
-
-            m = importlib.import_module(mod)
-            if name == "Presidio":
-                # PET-109: build Presidio from config (entities + score_threshold)
-                # instead of the bare no-arg ctor. resolve_presidio_entities lives in
-                # presidio.py, whose module imports are stdlib + petasos._types only —
-                # importing it does NOT import the presidio backend, so the
-                # "importable without the extra" invariant holds and the surrounding
-                # try/except ImportError still catches a genuinely-absent backend.
-                from petasos.scanners.presidio import resolve_presidio_entities
-
-                instance = getattr(m, cls)(
-                    entities=resolve_presidio_entities(
-                        config.presidio_entities, config.presidio_entities_extra
-                    ),
-                    score_threshold=config.presidio_score_threshold,
-                )
-            else:
-                instance = getattr(m, cls)()
-            scanners.append(instance)
-            probe = getattr(instance, "availability", None)
-            if probe is not None:
-                # PET-103 D4: arity-tolerant extraction — availability() is
-                # duck-typed here (getattr), so tolerate both the legacy 2-tuple
-                # and the widened 3-tuple (ok, reason, cause).
-                probe_result = probe()
-                avail = bool(probe_result[0])
-                reason = probe_result[1] if len(probe_result) > 1 else None
-                if avail:
-                    logger.info("Dashboard scanner %s: backend verified", name)
-                else:
-                    unavailable.append(name)
-                    logger.warning(
-                        "Dashboard scanner %s: backend missing — registered degraded: %s",
-                        name,
-                        reason,
-                    )
-            else:
-                logger.info("Dashboard scanner %s: backend verified", name)
-        except ImportError:
-            unavailable.append(name)
-            logger.warning("Dashboard scanner %s: import failed", name)
-        except Exception as exc:
-            unavailable.append(name)
-            logger.warning("Dashboard scanner %s failed: %s", name, exc)
+    for st in statuses:
+        if st.outcome == "verified":
+            logger.info("Dashboard scanner %s: backend verified", st.display_name)
+            continue
+        unavailable.append(st.display_name)
+        if st.outcome == "degraded":
+            logger.warning(
+                "Dashboard scanner %s: backend missing — registered degraded: %s",
+                st.display_name,
+                st.reason,
+            )
+        elif st.outcome == "missing":
+            logger.warning("Dashboard scanner %s: import failed", st.display_name)
+        else:
+            logger.warning("Dashboard scanner %s failed: %s", st.display_name, st.reason)
 
     pipeline = Pipeline(config=config, scanners=scanners, host_id="dashboard")
 

--- a/petasos/scanners/__init__.py
+++ b/petasos/scanners/__init__.py
@@ -47,3 +47,14 @@ except ImportError as _exc:
         raise
     _logger.debug("PresidioScanner not available: %s", _exc)
     del _exc
+
+# PET-174: imported AFTER the extras blocks above so the bootstrap module's
+# MinimalScanner import is already satisfied and no partial-initialization cycle
+# is possible. Unconditional - the helper is base install.
+from petasos.scanners.bootstrap import (  # noqa: E402
+    ScannerBuildStatus,
+    ScannerOutcome,
+    build_scanners,
+)
+
+__all__ += ["ScannerBuildStatus", "ScannerOutcome", "build_scanners"]

--- a/petasos/scanners/bootstrap.py
+++ b/petasos/scanners/bootstrap.py
@@ -1,0 +1,191 @@
+"""Shared config-to-scanner-list build (PET-174).
+
+One translation from ``PetasosConfig`` to the scanner list every bootstrap hands
+to ``Pipeline``. Two call sites use it today:
+
+- ``petasos.console._standalone.build_dashboard_pipeline`` (the console pipeline), and
+- the reference plugin's ``_deferred_init`` (the Hermes enforcement pipeline).
+
+Before this module they were two hand-maintained loops, and the four
+scanner-construction config fields (``presidio_entities``,
+``presidio_entities_extra``, ``presidio_score_threshold``,
+``decode_encoded_payloads``) reached only the first of them: the pipeline that
+rendered the console honored them and the pipeline that blocked tool calls did
+not. A third bootstrap that hand-copies the constructors would drift the same
+way, so ``tests/test_scanner_bootstrap_structure.py`` pins the routing
+structurally.
+
+The helper returns data and never logs: the two callers differ in logger name,
+message wording, level for the not-installed case, and identifier vocabulary, so
+each formats its own lines from the returned ``ScannerBuildStatus`` records.
+
+Base install: module-level imports are stdlib plus ``petasos.scanners.minimal``
+(already imported unconditionally by ``petasos.pipeline``). Every optional
+backend import is function-local, inside the per-backend ``try/except
+ImportError``, so importing this module pulls in no ML dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from petasos.scanners.minimal import MinimalScanner
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from petasos._types import Scanner
+    from petasos.config import PetasosConfig
+
+ScannerOutcome = Literal["verified", "degraded", "missing", "failed"]
+"""How one optional backend fared during :func:`build_scanners`.
+
+``verified`` - constructed and its availability probe said the backend is usable.
+``degraded`` - constructed and registered, but the probe reported the backend
+unusable (every scan will error).
+``missing`` - the class could not be imported, or its constructor raised
+``ImportError``; nothing was registered.
+``failed`` - anything else went wrong. Ambiguous by construction: a constructor
+raising a non-``ImportError`` registers nothing, while a throwing availability
+probe leaves the instance registered. Read the returned scanner list, not this
+value, to learn what is registered.
+"""
+
+
+@dataclass(frozen=True)
+class ScannerBuildStatus:
+    """One optional backend's build outcome, for the caller to render."""
+
+    scanner_id: str
+    """Snake id, equal to the backend's ``Scanner.name``
+    (``llm_guard`` / ``llama_firewall`` / ``presidio``). Same vocabulary
+    ``Pipeline.scanner_health()`` and the console Scanner Health panel key on."""
+
+    display_name: str
+    """Human-facing name (``LLM Guard`` / ``LlamaFirewall`` / ``Presidio``)."""
+
+    outcome: ScannerOutcome
+    reason: str | None = None
+    """Populated for every non-``verified`` outcome: the probe reason for
+    ``degraded``, ``str(exc)`` for ``missing`` and ``failed``."""
+
+
+def _build_llm_guard(config: PetasosConfig) -> Scanner:
+    from petasos.scanners import LlmGuardScanner
+
+    return LlmGuardScanner()
+
+
+def _build_llama_firewall(config: PetasosConfig) -> Scanner:
+    from petasos.scanners import LlamaFirewallScanner
+
+    return LlamaFirewallScanner()
+
+
+def _build_presidio(config: PetasosConfig) -> Scanner:
+    from petasos.scanners import PresidioScanner
+
+    # PET-109: build Presidio from config (entities + score_threshold) instead of
+    # the bare no-arg ctor. resolve_presidio_entities lives in presidio.py, whose
+    # module imports are stdlib + petasos._types only - importing it does NOT
+    # import the presidio backend, so the "importable without the extra"
+    # invariant holds and the caller's try/except ImportError still catches a
+    # genuinely-absent backend.
+    from petasos.scanners.presidio import resolve_presidio_entities
+
+    return PresidioScanner(
+        entities=resolve_presidio_entities(
+            config.presidio_entities, config.presidio_entities_extra
+        ),
+        score_threshold=config.presidio_score_threshold,
+    )
+
+
+# (scanner_id, display_name, builder). Order is the registration order both
+# pre-PET-174 loops produced, so `Pipeline`'s minimal-scanner detection and both
+# callers' `scanners=%s` log lines are unchanged.
+_BACKENDS: tuple[tuple[str, str, Callable[[PetasosConfig], Scanner]], ...] = (
+    ("llm_guard", "LLM Guard", _build_llm_guard),
+    ("llama_firewall", "LlamaFirewall", _build_llama_firewall),
+    ("presidio", "Presidio", _build_presidio),
+)
+
+
+def build_scanners(
+    config: PetasosConfig,
+) -> tuple[list[Scanner], list[ScannerBuildStatus]]:
+    """Build the scanner list a ``Pipeline`` bootstrap needs, plus per-backend status.
+
+    Returns ``(scanners, statuses)``.
+
+    ``scanners[0]`` is always the ``MinimalScanner``, carrying
+    ``config.decode_encoded_payloads``; each optional backend that constructed
+    successfully follows, in the fixed order LLM Guard, LlamaFirewall, Presidio.
+
+    ``statuses`` carries one record per **optional backend only**, in that same
+    fixed order. The ``MinimalScanner`` gets no record: neither in-tree caller
+    logs anything for it, and emitting one would force both to filter it back out.
+
+    Registration is three-way, and ``scanners`` is the authority. ``missing``
+    means nothing was registered. ``degraded`` always means an instance **is**
+    registered. ``failed`` is ambiguous: a constructor that raised registered
+    nothing, while a throwing availability probe left the instance registered.
+    Do not infer registration from ``failed``; read the returned list.
+
+    Never raises for an optional-backend failure - every such failure is folded
+    into a status record. A ``MinimalScanner`` construction failure is
+    deliberately not caught: that is a base-install invariant breach and must
+    surface.
+
+    Holds no module-level mutable state, so a plugin's background init thread and
+    a dashboard process can both call it without coordination.
+    """
+    scanners: list[Scanner] = [
+        MinimalScanner(decode_encoded_payloads=config.decode_encoded_payloads)
+    ]
+    statuses: list[ScannerBuildStatus] = []
+
+    for scanner_id, display_name, build in _BACKENDS:
+        # Build stage. An ImportError here means the wrapper module (or the
+        # backend a future wrapper imports at module level) did not import, so
+        # nothing is registered -> `missing`.
+        try:
+            instance = build(config)
+        except ImportError as exc:
+            statuses.append(ScannerBuildStatus(scanner_id, display_name, "missing", str(exc)))
+            continue
+        except Exception as exc:
+            statuses.append(ScannerBuildStatus(scanner_id, display_name, "failed", str(exc)))
+            continue
+
+        # Append BEFORE probing (both pre-PET-174 loops did): a scanner whose
+        # availability() raises stays registered and is reported unavailable,
+        # rather than vanishing from the pipeline.
+        scanners.append(instance)
+
+        # Probe stage, in its own try so an ImportError escaping a duck-typed
+        # probe classifies as `failed`, not `missing`. Under one wide try, a
+        # registered scanner that errors on every scan (and, under the default
+        # fail_mode="degraded", blocks content) would be reported as "not
+        # installed" at INFO - the one arrangement where the operator-visible
+        # signal is the opposite of what is happening.
+        try:
+            probe = getattr(instance, "availability", None)
+            if probe is None:
+                statuses.append(ScannerBuildStatus(scanner_id, display_name, "verified"))
+                continue
+            # PET-103 D4: arity-tolerant extraction - availability() is duck-typed
+            # here, so tolerate both the legacy 2-tuple and the widened 3-tuple
+            # (ok, reason, cause).
+            probe_result = probe()
+            ok = bool(probe_result[0])
+            reason = probe_result[1] if len(probe_result) > 1 else None
+            if ok:
+                statuses.append(ScannerBuildStatus(scanner_id, display_name, "verified"))
+            else:
+                statuses.append(ScannerBuildStatus(scanner_id, display_name, "degraded", reason))
+        except Exception as exc:
+            statuses.append(ScannerBuildStatus(scanner_id, display_name, "failed", str(exc)))
+
+    return scanners, statuses

--- a/tests/test_scanner_bootstrap.py
+++ b/tests/test_scanner_bootstrap.py
@@ -1,0 +1,508 @@
+"""PET-174 — behavior tests for the shared scanner bootstrap.
+
+Every row runs on the ML-free ``ci.yml`` lane: the optional backends are patched
+onto ``petasos.scanners`` with ``monkeypatch.setattr(..., raising=False)`` /
+``monkeypatch.delattr(..., raising=False)``, so presence or absence of the extras
+is irrelevant. The one deliberate exception is
+``test_scanner_id_matches_scanner_name``, which must compare against the *real*
+classes — comparing a fake's self-declared ``.name`` to the hardcoded
+``scanner_id`` would only assert that the test author typed the same string
+twice, and could not fail on the rename it exists to catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+import pytest
+
+import petasos.scanners  # noqa: F401  (ensures sys.modules carries the package)
+from petasos import PetasosConfig
+from petasos._types import ScanResult
+from petasos.scanners import MinimalScanner, ScannerBuildStatus, build_scanners
+from petasos.scanners.presidio import DEFAULT_PRESIDIO_ENTITIES
+
+if TYPE_CHECKING:
+    import types
+
+    from petasos._types import Direction
+
+# ---------------------------------------------------------------------------
+# reference_plugin import via file path (same idiom as test_plugin_init_logging)
+# ---------------------------------------------------------------------------
+
+_REF_PLUGIN_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "docs"
+    / "deployment"
+    / "reference_plugin"
+    / "__init__.py"
+)
+
+
+def _import_reference_plugin() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin", str(_REF_PLUGIN_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _scanners_module() -> types.ModuleType:
+    """The module object a ``from petasos.scanners import X`` actually resolves to.
+
+    ``tests/test_scanner_init.py`` reimports ``petasos.scanners`` and then restores
+    ``sys.modules`` from a snapshot, which can leave the ``scanners`` *attribute*
+    on the ``petasos`` package pointing at a different module object than
+    ``sys.modules`` does. Both callers (and ``build_scanners`` itself) import
+    function-locally, and that path reads ``sys.modules`` — so patches must land
+    there, not on ``petasos.scanners`` resolved through the package attribute.
+    """
+    return sys.modules["petasos.scanners"]
+
+
+def _reset_plugin(ref: types.ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The plugin-reset idiom from tests/test_profile_rebind.py."""
+    monkeypatch.setattr(ref, "_config", {})
+    monkeypatch.setattr(ref, "_initialized", False)
+    monkeypatch.setattr(ref, "_init_error", None)
+    monkeypatch.setattr(ref, "_pipeline", None)
+    monkeypatch.setattr(ref, "_guard", None)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PETASOS_LICENSE_KEY", "PETASOS_SESSION_SECRET", "PETASOS_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Recording fakes — the FULL Scanner protocol, as _validate_scanner enforces it
+# ---------------------------------------------------------------------------
+
+
+class _BaseFakeScanner:
+    """A fake with no ``availability`` attribute at all.
+
+    ``scan`` carries the complete protocol signature (``petasos/_types.py``
+    ``_validate_scanner``): a narrower ``async def scan(self, text)`` raises
+    ``TypeError`` at ``Pipeline.__init__``, which both parity rows would hit.
+    """
+
+    scanner_name: ClassVar[str] = "fake"
+    ctor_exc: ClassVar[BaseException | None] = None
+    calls: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        exc = type(self).ctor_exc
+        if exc is not None:
+            raise exc
+        type(self).calls.append(dict(kwargs))
+
+    @property
+    def name(self) -> str:
+        return type(self).scanner_name
+
+    async def scan(
+        self,
+        text: str,
+        *,
+        direction: Direction = "inbound",
+        session_id: str | None = None,
+    ) -> ScanResult:
+        return ScanResult(scanner_name=self.name, findings=())
+
+
+class _ProbingFakeScanner(_BaseFakeScanner):
+    """A fake that also implements ``availability()``."""
+
+    probe: ClassVar[tuple[Any, ...]] = (True, None, None)
+    probe_exc: ClassVar[BaseException | None] = None
+
+    def availability(self) -> tuple[Any, ...]:
+        exc = type(self).probe_exc
+        if exc is not None:
+            raise exc
+        return type(self).probe
+
+
+def _fake_class(
+    *,
+    scanner_name: str = "fake",
+    probe: tuple[Any, ...] = (True, None, None),
+    probe_exc: BaseException | None = None,
+    ctor_exc: BaseException | None = None,
+) -> type[_ProbingFakeScanner]:
+    class _Fake(_ProbingFakeScanner):
+        calls: ClassVar[list[dict[str, Any]]] = []
+
+    _Fake.scanner_name = scanner_name
+    _Fake.probe = probe
+    _Fake.probe_exc = probe_exc
+    _Fake.ctor_exc = ctor_exc
+    return _Fake
+
+
+def _no_probe_class(*, scanner_name: str = "fake") -> type[_BaseFakeScanner]:
+    class _Fake(_BaseFakeScanner):
+        calls: ClassVar[list[dict[str, Any]]] = []
+
+    _Fake.scanner_name = scanner_name
+    return _Fake
+
+
+def _patch_presidio(
+    monkeypatch: pytest.MonkeyPatch, cls: type[_BaseFakeScanner]
+) -> type[_BaseFakeScanner]:
+    monkeypatch.setattr(_scanners_module(), "PresidioScanner", cls, raising=False)
+    return cls
+
+
+def _status_by_id(statuses: list[ScannerBuildStatus], scanner_id: str) -> ScannerBuildStatus:
+    matches = [s for s in statuses if s.scanner_id == scanner_id]
+    assert len(matches) == 1, f"expected exactly one {scanner_id} status, got {statuses}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Constructor arguments (Done-when #2)
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_gets_decode_flag() -> None:
+    scanners, _ = build_scanners(PetasosConfig(decode_encoded_payloads=False))
+    assert cast("MinimalScanner", scanners[0])._decode_encoded_payloads is False
+
+    scanners, _ = build_scanners(PetasosConfig())
+    assert cast("MinimalScanner", scanners[0])._decode_encoded_payloads is True
+
+
+def test_presidio_gets_entities_and_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio"))
+    build_scanners(
+        PetasosConfig(
+            presidio_entities=("US_SSN",),
+            presidio_entities_extra=("URL",),
+            presidio_score_threshold=0.9,
+        )
+    )
+    assert fake.calls == [{"entities": ["US_SSN", "URL"], "score_threshold": 0.9}]
+
+
+def test_presidio_default_entities(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio"))
+    build_scanners(PetasosConfig(presidio_entities=None))
+    assert fake.calls[0]["entities"] == list(DEFAULT_PRESIDIO_ENTITIES)
+
+
+# ---------------------------------------------------------------------------
+# Ordering + vocabulary contracts (D1)
+# ---------------------------------------------------------------------------
+
+
+def test_scanner_order_and_status_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _scanners_module(), "LlmGuardScanner", _fake_class(scanner_name="llm_guard"), raising=False
+    )
+    monkeypatch.setattr(
+        _scanners_module(),
+        "LlamaFirewallScanner",
+        _fake_class(scanner_name="llama_firewall"),
+        raising=False,
+    )
+    _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio"))
+
+    scanners, statuses = build_scanners(PetasosConfig())
+
+    assert [s.name for s in scanners] == ["minimal", "llm_guard", "llama_firewall", "presidio"]
+    assert [s.scanner_id for s in statuses] == ["llm_guard", "llama_firewall", "presidio"]
+    # No status record for the MinimalScanner: neither caller logs one.
+    assert not any(s.scanner_id == "minimal" for s in statuses)
+
+
+def test_scanner_id_matches_scanner_name() -> None:
+    """The hardcoded ``scanner_id`` must equal the backend's ``Scanner.name``.
+
+    Deliberately unpatched: the fakes cannot pin this (they would only compare a
+    string the test author typed twice). Per D0 the three real wrapper classes
+    always import and their constructors only assign attributes, so they are
+    constructible on the ML-free lane with no backend present.
+    """
+    from petasos.scanners import LlamaFirewallScanner, LlmGuardScanner, PresidioScanner
+
+    _, statuses = build_scanners(PetasosConfig())
+    by_id = {s.scanner_id for s in statuses}
+    assert by_id == {LlmGuardScanner().name, LlamaFirewallScanner().name, PresidioScanner().name}
+
+
+# ---------------------------------------------------------------------------
+# Outcome classification (D1 steps 1-5)
+# ---------------------------------------------------------------------------
+
+
+def test_absent_class_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(_scanners_module(), "PresidioScanner", raising=False)
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "missing"
+    assert status.reason
+    assert not any(s.name == "presidio" for s in scanners)
+
+
+def test_ctor_raising_importerror_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A present class whose ctor raises ImportError also classifies ``missing``."""
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", ctor_exc=ImportError("no backend"))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "missing"
+    assert status.reason == "no backend"
+    assert not any(s.name == "presidio" for s in scanners)
+
+
+def test_degraded_probe_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", probe=(False, "no model", None))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "degraded"
+    assert status.reason == "no model"
+    # degraded ALWAYS means an instance is registered.
+    assert any(s.name == "presidio" for s in scanners)
+
+
+def test_probe_raise_keeps_scanner_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Append-before-probe: a throwing availability() does not unregister."""
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", probe_exc=RuntimeError("probe blew up"))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "failed"
+    assert status.reason == "probe blew up"
+    assert any(s.name == "presidio" for s in scanners)
+
+
+def test_probe_raising_importerror_is_failed_not_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pins the two-`try` split and the "missing implies no instance" contract."""
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", probe_exc=ImportError("late import"))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "failed"
+    assert any(s.name == "presidio" for s in scanners)
+
+
+def test_two_tuple_probe_tolerated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PET-103 D4 arity tolerance: a legacy 2-tuple is not a `failed`."""
+    _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio", probe=(False, "legacy")))
+    _, statuses = build_scanners(PetasosConfig())
+    assert _status_by_id(statuses, "presidio").outcome == "degraded"
+    assert _status_by_id(statuses, "presidio").reason == "legacy"
+
+    _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio", probe=(True, None)))
+    _, statuses = build_scanners(PetasosConfig())
+    assert _status_by_id(statuses, "presidio").outcome == "verified"
+
+
+def test_no_probe_attribute_is_verified(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_presidio(monkeypatch, _no_probe_class(scanner_name="presidio"))
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "verified"
+    assert status.reason is None
+    assert any(s.name == "presidio" for s in scanners)
+
+
+def test_ctor_failure_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", ctor_exc=RuntimeError("bad ctor"))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    status = _status_by_id(statuses, "presidio")
+    assert status.outcome == "failed"
+    assert status.reason == "bad ctor"
+    assert not any(s.name == "presidio" for s in scanners)
+
+
+def test_build_scanners_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every optional-backend failure arm returns normally."""
+    monkeypatch.delattr(_scanners_module(), "LlmGuardScanner", raising=False)
+    monkeypatch.setattr(
+        _scanners_module(),
+        "LlamaFirewallScanner",
+        _fake_class(scanner_name="llama_firewall", ctor_exc=RuntimeError("boom")),
+        raising=False,
+    )
+    _patch_presidio(
+        monkeypatch, _fake_class(scanner_name="presidio", probe_exc=RuntimeError("probe boom"))
+    )
+    scanners, statuses = build_scanners(PetasosConfig())
+    assert [s.outcome for s in statuses] == ["missing", "failed", "failed"]
+    assert scanners[0].name == "minimal"
+
+
+# ---------------------------------------------------------------------------
+# Caller formatting (Done-when #4)
+# ---------------------------------------------------------------------------
+
+_FOUR_OUTCOMES: list[ScannerBuildStatus] = [
+    ScannerBuildStatus("llm_guard", "LLM Guard", "verified"),
+    ScannerBuildStatus("llama_firewall", "LlamaFirewall", "degraded", "no model"),
+    ScannerBuildStatus("presidio", "Presidio", "missing", "import blew up"),
+    ScannerBuildStatus("extra_backend", "Extra Backend", "failed", "kaboom"),
+]
+
+
+def _patch_build_scanners(
+    monkeypatch: pytest.MonkeyPatch, statuses: list[ScannerBuildStatus]
+) -> None:
+    """Patch on ``petasos.scanners``, NOT on the caller module.
+
+    Both callers import ``build_scanners`` function-locally, and a function-local
+    ``from X import Y`` reads the attribute off ``X`` at call time and binds a
+    local — patching the caller module has no effect (and would raise
+    ``AttributeError``, since the name never lands there).
+    """
+
+    def _fake_build(config: Any) -> tuple[list[Any], list[ScannerBuildStatus]]:
+        return [MinimalScanner()], list(statuses)
+
+    monkeypatch.setattr(_scanners_module(), "build_scanners", _fake_build)
+
+
+class TestCallerFormatting:
+    def test_console_renders_all_four_outcomes(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from petasos.console._standalone import build_dashboard_pipeline
+
+        _patch_build_scanners(monkeypatch, _FOUR_OUTCOMES)
+        with caplog.at_level(logging.DEBUG):
+            build_dashboard_pipeline({})
+
+        rendered = {r.getMessage(): r.levelno for r in caplog.records}
+        assert rendered["Dashboard scanner LLM Guard: backend verified"] == logging.INFO
+        assert (
+            rendered[
+                "Dashboard scanner LlamaFirewall: backend missing — registered degraded: no model"
+            ]
+            == logging.WARNING
+        )
+        assert rendered["Dashboard scanner Presidio: import failed"] == logging.WARNING
+        assert rendered["Dashboard scanner Extra Backend failed: kaboom"] == logging.WARNING
+        # The unavailable list keeps display-name vocabulary.
+        assert any(
+            "unavailable=['LlamaFirewall', 'Presidio', 'Extra Backend']" in m for m in rendered
+        )
+
+    def test_plugin_renders_all_four_outcomes(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ref = _import_reference_plugin()
+        _reset_plugin(ref, monkeypatch)
+        _patch_build_scanners(monkeypatch, _FOUR_OUTCOMES)
+
+        with caplog.at_level(logging.DEBUG):
+            ref._deferred_init()
+
+        rendered = {r.getMessage(): r.levelno for r in caplog.records}
+        assert rendered["LLM Guard backend verified — scanner active"] == logging.INFO
+        assert (
+            rendered[
+                "LlamaFirewall backend missing — scanner registered degraded "
+                "(every scan will error): no model"
+            ]
+            == logging.WARNING
+        )
+        assert rendered["Presidio not installed — PII detection unavailable"] == logging.INFO
+        assert rendered["Extra Backend failed to load: kaboom"] == logging.WARNING
+        # The startup summary keeps snake ids.
+        assert any(
+            "unavailable=['llama_firewall', 'presidio', 'extra_backend']" in m for m in rendered
+        )
+
+
+class TestPluginNotInstalledTable:
+    def test_unknown_scanner_id_uses_fallback_message(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A backend absent from ``_NOT_INSTALLED_MSG`` renders the generic line
+        and must not KeyError inside ``_deferred_init``'s outer try (which would
+        latch ``_init_error`` and boot the plugin unenforcing)."""
+        ref = _import_reference_plugin()
+        _reset_plugin(ref, monkeypatch)
+        _patch_build_scanners(
+            monkeypatch, [ScannerBuildStatus("brand_new", "Brand New", "missing", "nope")]
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            ref._deferred_init()
+
+        assert any(r.getMessage() == "Brand New not installed, skipped" for r in caplog.records)
+        assert ref._init_error is None
+        assert ref._initialized is True
+
+
+# ---------------------------------------------------------------------------
+# Enforcement parity (Done-when #1)
+# ---------------------------------------------------------------------------
+
+
+class TestEnforcementParity:
+    def test_both_bootstraps_construct_identically(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression for PET-174: one non-default config, two bootstraps, one
+        set of Presidio constructor arguments."""
+        from petasos.console._standalone import build_dashboard_pipeline
+
+        fake = _patch_presidio(monkeypatch, _fake_class(scanner_name="presidio"))
+        raw: dict[str, Any] = {
+            "host_id": "test-host",
+            "enabled": True,
+            "presidio_entities": ["US_SSN"],
+            "presidio_entities_extra": ["URL"],
+            "presidio_score_threshold": 0.9,
+            "decode_encoded_payloads": False,
+        }
+
+        # Each path gets its OWN copy: the console copies defensively, but
+        # _deferred_init pops host_id/enabled off _config in place.
+        console_pipeline = build_dashboard_pipeline(dict(raw))
+
+        ref = _import_reference_plugin()
+        _reset_plugin(ref, monkeypatch)
+        monkeypatch.setattr(ref, "_config", dict(raw))
+        ref._deferred_init()
+        assert ref._init_error is None
+        plugin_pipeline = ref._pipeline
+
+        assert len(fake.calls) == 2
+        assert fake.calls[0] == fake.calls[1]
+        assert fake.calls[0] == {"entities": ["US_SSN", "URL"], "score_threshold": 0.9}
+
+        for pipeline in (console_pipeline, plugin_pipeline):
+            minimal = pipeline._minimal_scanner
+            assert minimal is not None
+            assert minimal._decode_encoded_payloads is False
+
+    def test_plugin_honors_decode_flag_at_startup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The regression that would have caught PET-174: the plugin-path minimal
+        scanner reflects ``decode_encoded_payloads: false`` BEFORE any reconfigure."""
+        ref = _import_reference_plugin()
+        _reset_plugin(ref, monkeypatch)
+        monkeypatch.setattr(ref, "_config", {"decode_encoded_payloads": False})
+        ref._deferred_init()
+
+        assert ref._init_error is None
+        minimal = ref._pipeline._minimal_scanner
+        assert minimal is not None
+        assert minimal._decode_encoded_payloads is False

--- a/tests/test_scanner_bootstrap_structure.py
+++ b/tests/test_scanner_bootstrap_structure.py
@@ -1,0 +1,441 @@
+"""PET-174 structural pin — one scanner bootstrap, enforced.
+
+The bug class this guards is "a new scanner-bootstrap site hand-copies the
+scanner constructors and drifts": PET-98 and PET-109 both wired one of the two
+bootstraps and not the other, and PET-174 is the third field-set to travel that
+path. So the routing is pinned mechanically, not by review habit.
+
+Modeled on ``tests/test_ci_extras_lanes.py`` and the posture wiki
+``decisions/2026-06-17-pet-77-deploy-parity-guard.md`` endorses: count real AST
+call nodes, never raw substrings; keep the checkers pure so they are provable on
+synthetic sources, then run them against the real repo as a live witness.
+
+Two invariants:
+
+1. Both bootstraps call ``build_scanners`` and construct no scanner themselves.
+2. No un-allowlisted site under ``petasos/`` or ``docs/deployment/`` constructs
+   any of the four scanner classes, ``MinimalScanner`` included. ``scripts/`` and
+   ``tests/`` are out of the sweep by design (replay harnesses and fixtures
+   construct scanners freely; neither ships as a bootstrap).
+
+Construction is detected in four node shapes, because the two bootstraps
+constructed differently and the console's dispatch shape is the one a copy-paste
+would carry forward. A residual fifth shape (a table-driven pair of bare
+literals) is named in the spec's § Deferred; bare-name matching was rejected
+because it false-positives on six legitimate in-tree label sites.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+_SCANNER_CLASSES = frozenset(
+    {"MinimalScanner", "LlmGuardScanner", "LlamaFirewallScanner", "PresidioScanner"}
+)
+
+# Dispatch helpers whose *bare* class-name string argument is a construction in
+# disguise (shape d).
+_DISPATCH_FUNCS = frozenset({"getattr", "import_module"})
+
+_MODULE_SCOPE = "<module>"
+
+_SWEEP_ROOTS = ("petasos", "docs/deployment")
+
+# The five modules that DEFINE the scanner classes (and the helper that owns the
+# one legitimate construction of each). A file list, not a directory one, so a
+# future petasos/scanners/factory.py is swept rather than born invisible.
+# Repo-relative POSIX strings, per the Paths rule below.
+_DEFINITION_MODULES = frozenset(
+    {
+        "petasos/scanners/minimal.py",
+        "petasos/scanners/llm_guard.py",
+        "petasos/scanners/llama_firewall.py",
+        "petasos/scanners/presidio.py",
+        "petasos/scanners/bootstrap.py",
+    }
+)
+
+# (repo-relative POSIX path, qualified enclosing function) pairs that may construct
+# a scanner. Each row carries its reason:
+#   petasos/pipeline.py :: Pipeline.__init__          - the no-minimal-supplied
+#       fallback; spec Decision 4 keeps it.
+#   reference_plugin/__init__.py :: _get_fallback_scanner - the cold-window
+#       fast-path fallback; spec Decision 7 keeps it bare.
+#   reference_plugin/verify.py :: check_features / check_injection_scan - a
+#       verification script, not a bootstrap.
+# The function is QUALIFIED (ClassName.method): a bare "__init__" key would exempt
+# every __init__ in pipeline.py, present and future. A module-scope construction
+# is never allowlisted.
+_ALLOWLIST = frozenset(
+    {
+        ("petasos/pipeline.py", "Pipeline.__init__"),
+        ("docs/deployment/reference_plugin/__init__.py", "_get_fallback_scanner"),
+        ("docs/deployment/reference_plugin/verify.py", "check_features"),
+        ("docs/deployment/reference_plugin/verify.py", "check_injection_scan"),
+    }
+)
+
+# (repo-relative POSIX path, bootstrap function) - invariant 1's targets.
+_BOOTSTRAPS = (
+    ("petasos/console/_standalone.py", "build_dashboard_pipeline"),
+    ("docs/deployment/reference_plugin/__init__.py", "_deferred_init"),
+)
+
+
+@dataclass(frozen=True)
+class Construction:
+    path: str
+    function: str
+    class_name: str
+    lineno: int
+
+
+# --------------------------------------------------------------------------- #
+# Pure checks
+# --------------------------------------------------------------------------- #
+
+
+def _scoped_nodes(node: ast.AST, scope: str, class_prefix: str) -> Iterator[tuple[ast.AST, str]]:
+    """Yield ``(node, qualified enclosing function)`` for every descendant.
+
+    ``ClassName.method`` for a method (dotted ClassDef ancestry), the bare name
+    for a module-level function, ``"<module>"`` at module scope.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            yield child, scope
+            nested = f"{class_prefix}.{child.name}" if class_prefix else child.name
+            yield from _scoped_nodes(child, scope, nested)
+        elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            qualified = f"{class_prefix}.{child.name}" if class_prefix else child.name
+            inner = qualified if scope == _MODULE_SCOPE else f"{scope}.{child.name}"
+            yield child, scope
+            yield from _scoped_nodes(child, inner, "")
+        else:
+            yield child, scope
+            yield from _scoped_nodes(child, scope, class_prefix)
+
+
+def _dotted_class(value: str) -> str | None:
+    """Shape (c): a dotted constant naming a scanner class.
+
+    Dotted-only is load-bearing. A bare-name match false-positives on six
+    legitimate in-tree sites that name a class without constructing anything
+    (``__all__`` bookkeeping in petasos/scanners/__init__.py, PASS/WARN report
+    labels in verify.py), which would force a permanently non-empty allowlist.
+    """
+    if "." not in value:
+        return None
+    for cls in _SCANNER_CLASSES:
+        if value.endswith(f".{cls}"):
+            return cls
+    return None
+
+
+def _constructions_in(node: ast.AST, path: str, scope: str = _MODULE_SCOPE) -> list[Construction]:
+    """Every scanner construction under ``node``, in all four detected shapes."""
+    found: list[Construction] = []
+    for child, child_scope in _scoped_nodes(node, scope, ""):
+        if isinstance(child, ast.Call):
+            func = child.func
+            # (a) direct name call - LlmGuardScanner()
+            if isinstance(func, ast.Name) and func.id in _SCANNER_CLASSES:
+                found.append(Construction(path, child_scope, func.id, child.lineno))
+            # (b) attribute call - petasos.scanners.PresidioScanner()
+            elif isinstance(func, ast.Attribute) and func.attr in _SCANNER_CLASSES:
+                found.append(Construction(path, child_scope, func.attr, child.lineno))
+            # (d) split-literal dispatch - getattr(m, "PresidioScanner")()
+            dispatch = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr
+                if isinstance(func, ast.Attribute)
+                else None
+            )
+            if dispatch in _DISPATCH_FUNCS:
+                for arg in child.args:
+                    if (
+                        isinstance(arg, ast.Constant)
+                        and isinstance(arg.value, str)
+                        and arg.value in _SCANNER_CLASSES
+                    ):
+                        found.append(Construction(path, child_scope, arg.value, arg.lineno))
+        # (c) dotted dispatch constant - "petasos.scanners.PresidioScanner"
+        elif isinstance(child, ast.Constant) and isinstance(child.value, str):
+            cls = _dotted_class(child.value)
+            if cls is not None:
+                found.append(Construction(path, child_scope, cls, child.lineno))
+    # Shapes can overlap (a dotted constant handed to import_module); report once.
+    return sorted(set(found), key=lambda c: (c.lineno, c.class_name))
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _calls_build_scanners(func: ast.AST) -> bool:
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        called = node.func
+        if isinstance(called, ast.Name) and called.id == "build_scanners":
+            return True
+        if isinstance(called, ast.Attribute) and called.attr == "build_scanners":
+            return True
+    return False
+
+
+def check_bootstrap_routes(source: str | None, path: str, func_name: str) -> list[str]:
+    """Invariant 1 for one bootstrap. ``None`` source means the file is absent.
+
+    Liveness: an absent file or a missing function is a violation, not a silent
+    pass — otherwise a rename would quietly retire the check.
+    """
+    if source is None:
+        return [f"{path}: file is missing — the bootstrap pin cannot run."]
+    tree = ast.parse(source)
+    func = _find_function(tree, func_name)
+    if func is None:
+        return [f"{path}: function {func_name!r} not found — the bootstrap pin cannot run."]
+    violations = []
+    if not _calls_build_scanners(func):
+        violations.append(
+            f"{path}::{func_name} does not call build_scanners — every scanner "
+            f"bootstrap must route through petasos.scanners.build_scanners."
+        )
+    for c in _constructions_in(func, path, func_name):
+        violations.append(
+            f"{path}::{c.function}:{c.lineno} constructs {c.class_name} directly — "
+            f"call build_scanners(config) instead."
+        )
+    return violations
+
+
+def check_no_unallowlisted_constructions(
+    sources: dict[str, str], allowlist: frozenset[tuple[str, str]]
+) -> list[Construction]:
+    """Invariant 2 over ``{repo-relative POSIX path: source}``."""
+    violations: list[Construction] = []
+    for path in sorted(sources):
+        if path in _DEFINITION_MODULES:
+            continue
+        for c in _constructions_in(ast.parse(sources[path]), path):
+            if (c.path, c.function) in allowlist:
+                continue
+            violations.append(c)
+    return violations
+
+
+# --------------------------------------------------------------------------- #
+# Repo loaders (IO)
+# --------------------------------------------------------------------------- #
+
+
+def _read(path: str) -> str | None:
+    """Read a repo-relative file as UTF-8.
+
+    The explicit encoding is load-bearing on this ticket's declared local gate:
+    the 3.10 dev interpreter's default locale encoding is cp1252, which cannot
+    decode petasos/normalize.py or petasos/session/license.py (both carry UTF-8
+    zero-width characters).
+    """
+    p = _REPO_ROOT / path
+    if not p.is_file():
+        return None
+    return p.read_text(encoding="utf-8")
+
+
+def _sweep_sources() -> dict[str, str]:
+    """Every ``*.py`` under the swept roots, keyed by repo-relative POSIX path.
+
+    POSIX-normalized keys are load-bearing, not cosmetic: on Windows the default
+    ``str(p.relative_to(root))`` yields ``petasos\\pipeline.py``, which matches
+    neither the definition-module exclusion list nor the allowlist.
+    """
+    sources: dict[str, str] = {}
+    for root in _SWEEP_ROOTS:
+        for p in sorted((_REPO_ROOT / root).rglob("*.py")):
+            sources[p.relative_to(_REPO_ROOT).as_posix()] = p.read_text(encoding="utf-8")
+    return sources
+
+
+# --------------------------------------------------------------------------- #
+# Tests — live witness
+# --------------------------------------------------------------------------- #
+
+
+def test_both_bootstraps_route_through_helper() -> None:
+    """Invariant 1, live (Done-when #3)."""
+    for path, func_name in _BOOTSTRAPS:
+        assert (_REPO_ROOT / path).is_file(), f"{path} is missing"
+        assert check_bootstrap_routes(_read(path), path, func_name) == []
+
+
+def test_no_unallowlisted_scanner_construction() -> None:
+    """Invariant 2, live (Done-when #3)."""
+    sources = _sweep_sources()
+    assert sources, "the sweep visited no files — the checker would pass vacuously"
+    for path, _ in _BOOTSTRAPS:
+        assert path in sources, f"{path} was not visited by the sweep"
+    assert check_no_unallowlisted_constructions(sources, _ALLOWLIST) == []
+
+
+def test_allowlist_is_exactly_the_documented_rows() -> None:
+    """An implementer who silences a violation by adding a row has to change this
+    assertion too, so the spec table and the code cannot drift."""
+    documented = frozenset(
+        {
+            ("petasos/pipeline.py", "Pipeline.__init__"),
+            ("docs/deployment/reference_plugin/__init__.py", "_get_fallback_scanner"),
+            ("docs/deployment/reference_plugin/verify.py", "check_features"),
+            ("docs/deployment/reference_plugin/verify.py", "check_injection_scan"),
+        }
+    )
+    assert documented == _ALLOWLIST
+
+
+def test_allowlisted_sites_still_exist() -> None:
+    """Liveness for the allowlist itself: every row names a real construction, so
+    a stale exemption cannot silently widen the checker."""
+    sources = _sweep_sources()
+    live = {
+        (c.path, c.function)
+        for path in sources
+        for c in _constructions_in(ast.parse(sources[path]), path)
+    }
+    assert live >= _ALLOWLIST
+
+
+# --------------------------------------------------------------------------- #
+# Tests — synthetic (the checkers have teeth without touching the repo)
+# --------------------------------------------------------------------------- #
+
+_PRE_FIX_PLUGIN = """
+def _deferred_init():
+    scanners = [MinimalScanner()]
+    try:
+        from petasos.scanners import PresidioScanner
+
+        instance = PresidioScanner()
+        scanners.append(instance)
+    except ImportError:
+        pass
+"""
+
+_PRE_FIX_CONSOLE = """
+def build_dashboard_pipeline(raw_config):
+    for name, cls_path in [
+        ("LLM Guard", "petasos.scanners.LlmGuardScanner"),
+        ("LlamaFirewall", "petasos.scanners.LlamaFirewallScanner"),
+        ("Presidio", "petasos.scanners.PresidioScanner"),
+    ]:
+        mod, cls = cls_path.rsplit(".", 1)
+        m = importlib.import_module(mod)
+        instance = getattr(m, cls)()
+"""
+
+
+def test_retro_pre_fix_plugin_would_be_flagged() -> None:
+    """Retro (shape a): the pre-PET-174 plugin body constructs MinimalScanner and
+    PresidioScanner by hand and calls no helper."""
+    violations = check_bootstrap_routes(
+        _PRE_FIX_PLUGIN, "docs/deployment/reference_plugin/__init__.py", "_deferred_init"
+    )
+    assert any("build_scanners" in v for v in violations)
+    assert any("PresidioScanner" in v for v in violations)
+    assert any("MinimalScanner" in v for v in violations)
+
+
+def test_retro_pre_fix_console_would_be_flagged() -> None:
+    """Retro (shape c): the dotted dispatch table the ticket deletes. This is what
+    proves the widened checker reaches the console's idiom, not just the plugin's."""
+    violations = check_bootstrap_routes(
+        _PRE_FIX_CONSOLE, "petasos/console/_standalone.py", "build_dashboard_pipeline"
+    )
+    assert any("LlmGuardScanner" in v for v in violations)
+    assert any("LlamaFirewallScanner" in v for v in violations)
+    assert any("PresidioScanner" in v for v in violations)
+
+
+def test_attribute_call_is_flagged() -> None:
+    """Shape (b)."""
+    source = "def boot():\n    return petasos.scanners.PresidioScanner()\n"
+    found = _constructions_in(ast.parse(source), "x.py")
+    assert [c.class_name for c in found] == ["PresidioScanner"]
+    assert found[0].function == "boot"
+
+
+def test_split_literal_getattr_is_flagged() -> None:
+    """Shape (d): the split-literal variant of the console's dispatch idiom, one
+    token away from the code this ticket deletes."""
+    source = (
+        "def boot():\n"
+        '    m = importlib.import_module("petasos.scanners")\n'
+        '    return getattr(m, "PresidioScanner")()\n'
+    )
+    found = _constructions_in(ast.parse(source), "x.py")
+    assert [c.class_name for c in found] == ["PresidioScanner"]
+
+
+def test_all_bookkeeping_is_not_flagged() -> None:
+    """Negative row: naming a class in ``__all__`` constructs nothing. Pins the
+    dotted-only narrowing of shape (c)."""
+    source = '__all__ += ["PresidioScanner"]\n'
+    assert _constructions_in(ast.parse(source), "x.py") == []
+
+
+def test_report_label_is_not_flagged() -> None:
+    """Negative row: a PASS/WARN report label constructs nothing."""
+    source = 'def check():\n    available.append("PresidioScanner")\n'
+    assert _constructions_in(ast.parse(source), "x.py") == []
+
+
+def test_method_scope_is_qualified() -> None:
+    """A method-scoped construction reports ``ClassName.method``, so a bare
+    ``__init__`` allowlist key cannot exempt every ``__init__`` in a module."""
+    source = "class Pipeline:\n    def __init__(self):\n        self.s = MinimalScanner()\n"
+    found = _constructions_in(ast.parse(source), "petasos/pipeline.py")
+    assert [c.function for c in found] == ["Pipeline.__init__"]
+
+
+def test_module_scope_construction_is_reported() -> None:
+    """A module-scope construction is never allowlisted, so it must be reported
+    under the ``<module>`` scope rather than silently attributed to a function."""
+    sources = {"x.py": "_scanner = MinimalScanner()\n"}
+    violations = check_no_unallowlisted_constructions(sources, _ALLOWLIST)
+    assert [(c.function, c.class_name) for c in violations] == [("<module>", "MinimalScanner")]
+
+
+def test_definition_modules_are_excluded() -> None:
+    """The five defining modules may construct freely; everything else may not."""
+    sources = {
+        "petasos/scanners/bootstrap.py": "def build():\n    return MinimalScanner()\n",
+        "petasos/scanners/factory.py": "def build():\n    return MinimalScanner()\n",
+    }
+    violations = check_no_unallowlisted_constructions(sources, _ALLOWLIST)
+    assert [c.path for c in violations] == ["petasos/scanners/factory.py"]
+
+
+def test_missing_bootstrap_file_is_a_violation() -> None:
+    """Liveness: an absent file is not a clean file."""
+    violations = check_bootstrap_routes(None, "petasos/console/_standalone.py", "build")
+    assert any("missing" in v for v in violations)
+
+
+def test_renamed_bootstrap_function_is_a_violation() -> None:
+    """Liveness: a renamed target does not silently pass."""
+    violations = check_bootstrap_routes(
+        "def other():\n    pass\n", "petasos/console/_standalone.py", "build_dashboard_pipeline"
+    )
+    assert any("not found" in v for v in violations)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -325,6 +325,37 @@ def test_verify_detects_split_brain_non_incident_key(
     assert "anonymize" in detail
 
 
+def test_missing_build_scanners_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PET-174 D7: a plugin newer than the library FAILs pre-flight.
+
+    Asserted twice. The base-install shape (no ML extras) is the one that matters:
+    ``check_scanner_imports`` returns WARN there and ``main()`` counts only FAIL,
+    so a probe appended after the availability tally would be skipped on exactly
+    the deployment where the skew boots the plugin unenforcing.
+    """
+    # sys.modules, not the package attribute: tests/test_scanner_init.py reimports
+    # petasos.scanners and restores sys.modules from a snapshot, so the two can
+    # point at different module objects. verify.py's function-local
+    # `from petasos.scanners import ...` reads sys.modules.
+    import sys
+
+    import petasos.scanners  # noqa: F401
+
+    scanners_pkg = sys.modules["petasos.scanners"]
+    verify = _load_verify_module()
+
+    monkeypatch.delattr(scanners_pkg, "build_scanners", raising=False)
+    status, detail = verify.check_scanner_imports()
+    assert status == verify.FAIL
+    assert "build_scanners" in detail
+
+    for class_name in ("LlmGuardScanner", "LlamaFirewallScanner", "PresidioScanner"):
+        monkeypatch.delattr(scanners_pkg, class_name, raising=False)
+    status, detail = verify.check_scanner_imports()
+    assert status == verify.FAIL
+    assert "build_scanners" in detail
+
+
 def test_verify_clean_passes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

- Petasos built its scanner list twice by hand. `build_dashboard_pipeline` wired `presidio_entities`, `presidio_entities_extra`, `presidio_score_threshold`, and `decode_encoded_payloads` into the scanner constructors; the reference plugin's `_deferred_init`, which serves the Hermes hook that actually blocks tool calls, wired none of them. All four were honored by the pipeline that *renders* the console and dropped by the pipeline that *enforces*, through all five console posture presets.
- New base-install helper `petasos.scanners.build_scanners(config)` (plus `ScannerBuildStatus` and `ScannerOutcome`) is now the single config-to-scanner translation; both bootstraps route through it. Exported as published API for third-party embedders, who are hit by this bug identically.
- A structural (AST) test pins the routing so a third bootstrap cannot reintroduce the drift silently, and `verify.py` gains a pre-boot probe for the new plugin/library capability floor.

## Layered defense

The helper returns **data**, never logs: the two callers differ in logger name, wording, level for the not-installed case (WARNING vs INFO), and identifier vocabulary (display names vs snake ids), so each formats its own lines from the status records. Every message template, level, and the scanner ordering are byte-identical to before; the plugin's three not-installed strings moved verbatim into a `_NOT_INSTALLED_MSG` table read with `.get` and a generic fallback, so a future backend added inside the helper cannot `KeyError` inside `_deferred_init`'s outer `try` and boot the plugin unenforcing.

Build and probe sit in **separate** `try` blocks. An `ImportError` escaping a duck-typed availability probe classifies as `failed`, not `missing` - under one wide `try` a registered scanner that errors on every scan (and, under the default `fail_mode="degraded"`, blocks content) would be reported as "not installed" at INFO, the one arrangement where the operator-visible signal is the opposite of what is happening.

## Coordination with #156 (PET-169)

PR #156 (`chore/pet-169-config-surface-honesty`) is **still open** as of this PR, and its shipped Config Editor help text plus its `test_config_surface_inertness.py` classification assert the opposite of what this ships: the three Presidio keys are described as applying only to the scanner the console builds. Per the spec's coordination block, this PR **leaves `petasos/console/_config_meta.py`, `tests/adversarial/pipeline/test_config_surface_inertness.py`, and the `petasos/config.py` comment (which points at PET-173, the wrong ticket) untouched**. Whichever of the two merges second carries the reword: these keys move from Caveat to Thread, but only for the boot path - `Pipeline.reconfigure` has no Presidio setter, so a live edit or a profile switch still takes effect at the next restart, and the reword must keep that temporal qualifier.

## Files changed

| File | Change |
|------|--------|
| `petasos/scanners/bootstrap.py` | New. `build_scanners` + `ScannerBuildStatus` + `ScannerOutcome`; stdlib + `petasos.scanners.minimal` at import time, every backend import function-local |
| `petasos/scanners/__init__.py` | Exports the three new names unconditionally, after the extras blocks |
| `petasos/console/_standalone.py` | Inline loop replaced by a `build_scanners` call plus a status-formatting loop; the now-unused `importlib` import removed |
| `docs/deployment/reference_plugin/__init__.py` | Same in `_deferred_init`; adds `_NOT_INSTALLED_MSG`; docstring gains the capability floor |
| `docs/deployment/reference_plugin/verify.py` | `check_scanner_imports` probes `build_scanners` **first**, before the base-install `WARN` early return |
| `tests/test_scanner_bootstrap.py` | New. Helper behavior, caller formatting, and enforcement parity across both bootstraps |
| `tests/test_scanner_bootstrap_structure.py` | New. AST pin: both bootstraps route through the helper; no un-allowlisted construction under `petasos/` or `docs/deployment/` |
| `tests/test_verify.py` | One row for the skew probe, asserted on both the extras-present and base-install shapes |
| `docs/usage/scanners.md`, `docs/deployment/hermes-desktop.md`, `CLAUDE.md`, `CHANGELOG.md` | Embedder guidance, plugin-copy sync line, module row, `[Unreleased]` entry |

## Test plan

- [x] `C:\python310\python.exe -m pytest tests/test_scanner_bootstrap.py tests/test_scanner_bootstrap_structure.py tests/test_plugin_init_logging.py tests/test_presets.py tests/test_console_standalone_entrypoint.py tests/test_profile_rebind.py tests/test_reference_plugin_cold_start.py tests/test_presidio_entity_scoping.py tests/test_scanner_init.py tests/test_verify.py -q` - 185/185 pass
- [x] Full suite - 2315 passed, 42 skipped, 1 xfailed, with the single known pre-existing deselect (`test_console_validation.py::test_default_ignorable_rejected`, Unicode 13 vs 14 on the local 3.10 gate)
- [x] `ruff check .` / `ruff format --check .` / `mypy --strict .` - clean
- [x] Log-and-behavior preservation gate: `test_plugin_init_logging.py`, `test_presets.py`, `test_console_standalone_entrypoint.py`, `test_profile_rebind.py`, `test_reference_plugin_cold_start.py` all pass **unchanged**
- [x] Regression that would have caught this: `TestEnforcementParity::test_plugin_honors_decode_flag_at_startup` and `::test_both_bootstraps_construct_identically`

## Not in this PR

Live reconfigure of the Presidio settings, including a `reconfigure`-time tripwire. After this fix the three fields apply correctly at startup on both paths, but nothing reaching the live pipeline through `_apply_reconfigure` rebuilds scanners - neither a PET-126 config edit nor a PET-132 profile re-bind - and it does not warn either, unlike the `session_secret` precedent. Named in the spec's Out of scope; the follow-on owns the setter question, the warning (both producers), and the console restart-banner question together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared scanner setup process with status reporting for verified, degraded, missing, and failed backends.
  - Presidio configuration is now applied consistently when scanners are created.
  - Added public scanner-building utilities and result types.

- **Documentation**
  - Updated deployment and usage guidance for compatible plugin/library versions.
  - Added verification steps to detect incompatible installations before startup.

- **Bug Fixes**
  - Improved handling and messaging for unavailable or failed optional backends.
  - Ensured console and plugin pipelines use consistent scanner configuration and payload decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->