### PR TITLE
fix(pet-171): route the failed-init branch through the syntactic fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,27 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   wording, levels, and ordering on both paths are unchanged. These fields still
   apply at construction time only: a live config edit or a Hermes-profile
   re-bind takes effect at the next restart.
+- **A permanently failed scanner init no longer disables enforcement (PET-171).**
+  The reference plugin's `init_failed` branch now runs the zero-dependency syntactic
+  scanner and honors `fail_mode`, instead of allowing every tool call unscanned.
+  Operator-visible change: under the default `degraded` fail-mode, a process whose
+  scanner init failed now blocks every dangerous tool call until it is restarted,
+  while read-only tools are still allowed. Tool results remain unscanned on that
+  branch. The console marker, provenance line, drill-down explainer and badge were
+  corrected: they previously said enforcement was disabled and calls ran unscanned,
+  which is no longer true. Sync `petasos/console/static/petasos.js` with the plugin
+  files when you upgrade; an old console over a new plugin keeps showing the retired
+  copy.
 - **Plugin/library sync requirement.** The reference plugin now imports
   `build_scanners`, so it requires a `petasos` release that exports it. Copy the
-  plugin files and upgrade the library together; a newer plugin over an older
-  library fails init and leaves tool calls unenforced. `verify.py`'s
-  scanner-imports check FAILs on that skew before boot.
+  plugin files and upgrade the library together. `build_scanners` shipped before
+  `format_result_notice`, which the plugin imports at module level, so a library too old
+  for the plugin fails that import first: the plugin does not load at all and nothing is
+  enforced. An old-library skew therefore does not latch init; a library newer than a
+  stale plugin copy still can, and init also latches on a config or pipeline construction
+  error, in which case the session runs on the syntactic fallback. `verify.py`'s
+  scanner-imports check probes `build_scanners`, not the module-level floor, so confirm
+  from the log that the plugin loaded.
 
 ## [0.2.0] - 2026-06-30
 

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -166,6 +166,15 @@ tampering (that is PET-83's domain).
 | `closed` | Everything in `degraded`, plus early-exit block on CRITICAL findings from the syntactic pre-filter | Strictest posture; latency-sensitive blocking on the always-on layer |
 | `open` | ML failures ignored — content passes with whatever the remaining scanners say | Only if availability beats detection. **Warning:** `open` + an ML outage = syntactic-only coverage, silently. |
 
+**The reference plugin reads this same dial after a failed init.** A process whose scanner
+init failed permanently runs the syntactic fallback under `fail_mode`: under `degraded` it
+allows read-only tools and blocks every other tool call until the process is restarted, with
+no in-process recovery (`_deferred_init` returns early once `_init_error` latches,
+`docs/deployment/reference_plugin/__init__.py:505`). Note `search_files` is not in
+`READ_ONLY_TOOLS` (`petasos/session/guard.py:42-62`), so it is blocked too.
+
+**Checklist:**
+
 - [ ] Keep `degraded` unless you have a written reason not to.
 - [ ] If you choose `open`, pair it with alerting on scanner health so an
       outage is loud somewhere else.

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -449,10 +449,23 @@ minor update:
    ```
 
    The plugin files and the `petasos` library in Hermes's venv must move
-   together: the plugin requires a `petasos` release that exports
-   `petasos.scanners.build_scanners`, and a newer plugin over an older library
-   fails init and leaves every tool call unenforced. `verify.py`'s scanner-imports
-   check FAILs on that skew, so run it before restarting.
+   together. The plugin imports `format_result_notice` at module level and
+   `build_scanners` inside its deferred init, and `build_scanners` shipped
+   first, so any library too old for this plugin also misses
+   `format_result_notice`: the plugin does not import at all and nothing is
+   enforced. Check the host's plugin-load error, and treat the absence of the
+   `Petasos plugin registered` INFO line in the startup log above as the
+   reliable signal. An old-library skew therefore does not latch init. A
+   library *newer* than a stale plugin copy still can, if a symbol or
+   signature the deferred init uses has moved. Run `verify.py` before
+   restarting, but note its scanner-imports check probes `build_scanners`, not
+   the module-level floor: it FAILs a library too old for `build_scanners`,
+   and PASSes one that has `build_scanners` but still lacks
+   `format_result_notice`. Init otherwise latches on a config or pipeline
+   construction error, and the session then runs on the syntactic fallback:
+   dangerous tool calls are blocked under the default `degraded` fail-mode,
+   read-only tools are still allowed, until the process is restarted. The
+   latched error text appears in the console's `init_failed` row.
 
 3. Restart Hermes Desktop.
 

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -11,10 +11,14 @@ Deploy: copy this directory to the active Hermes profile's plugin dir:
 Config: add a top-level ``petasos:`` section to the profile's config.yaml
 Env:    PETASOS_LICENSE_KEY, PETASOS_SESSION_SECRET, PETASOS_HASH_KEY,
         PETASOS_AUDIT_FINDING
-Needs:  a ``petasos`` release that exports ``petasos.scanners.build_scanners``;
-        sync this file and the library together. Copying a newer plugin over an
-        older library fails init and leaves every tool call unenforced. Run
-        ``verify.py`` first: its scanner-imports check FAILs on that skew.
+Needs:  a ``petasos`` release exporting ``petasos.scanners.build_scanners`` AND the
+        module-level symbols imported below; sync this file and the library together.
+        ``build_scanners`` shipped first, so a library too old for this file also
+        misses ``format_result_notice``: it does not import at all and nothing is
+        enforced. An old-library skew therefore does not latch init; a library newer
+        than a stale copy of this file still can. ``verify.py`` probes
+        ``build_scanners``, not the module-level floor. Init otherwise latches on a
+        config or pipeline error, and the session runs on the syntactic fallback.
 
 Capture window (PET-136): to record per-finding tuning data, open a short
 capture window by setting ``PETASOS_AUDIT_FINDING=1`` (or flipping the
@@ -925,8 +929,12 @@ def _fallback_pre_tool_call(
             # MinimalScanner emits no PII findings (syntactic only), so no egress logic here.
             worst = _worst(result.findings)
             if _blocks(worst.severity):
+                # PET-171: cause-neutral. This callee now serves both cold-window branches
+                # and cannot know which one called it, so "init in progress" would be a lie
+                # on the init-failed branch. The operator correlates through the
+                # cold_start_degraded / init_failed marker row instead.
                 logger.warning(
-                    "PETASOS_FALLBACK_BLOCK tool=%s — init in progress, syntactic scan found: %s",
+                    "PETASOS_FALLBACK_BLOCK tool=%s — syntactic fallback, scan found: %s",
                     tool_name,
                     worst.rule_id,
                 )
@@ -953,6 +961,101 @@ def _fallback_pre_tool_call(
         return None
     _fallback_state.outcome = "clean"
     return None
+
+
+def _run_fallback_gate(
+    tool_name: str, args: dict, task_id: str, **kwargs
+) -> tuple[dict[str, str] | None, str | None]:
+    """PET-171: dispatch the syntactic fallback and take its out-of-band outcome.
+    Never raises ``Exception``.
+
+    ``_fallback_pre_tool_call`` evaluates ``_is_dangerous`` OUTSIDE its own ``try``,
+    so a non-string tool name raises there. Before this ticket that could not escape the
+    init-failed branch, because the branch returned before any dispatch; routing through
+    the fallback would newly let it reach the host, and the caller region has no ``try``
+    (see _release_cold_start_claim's docstring on why one must not be added).
+
+    The entry clear is what makes the swallow fail-secure. ``finally`` runs AFTER the
+    ``except`` body, so assigning ``outcome`` inside the arm would be overwritten; clearing
+    on entry instead guarantees the value read below is one THIS invocation wrote, never a
+    residue of the previous call on this pooled thread. Every value other than "clean"
+    fails secure downstream, and an unwritten outcome reads as None -> "unreadable".
+
+    ``BaseException`` is deliberately NOT swallowed -- ``SystemExit``, ``KeyboardInterrupt``
+    and ``asyncio.CancelledError`` (a ``BaseException`` since 3.8, reachable out of
+    ``_run_async``'s future) must propagate, matching ``_fallback_pre_tool_call``'s own
+    ``except Exception`` boundary.
+    """
+    out = None
+    _fallback_state.outcome = None
+    try:
+        out = _fallback_pre_tool_call(tool_name, args, task_id, **kwargs)
+    except Exception as exc:
+        logger.warning("PETASOS_FALLBACK_DISPATCH_FAILED tool=%r — %s", tool_name, exc)
+        out = None
+    finally:
+        outcome = getattr(_fallback_state, "outcome", None)
+        _fallback_state.outcome = None
+    return out, outcome
+
+
+def _fallback_decision(
+    tool_name: str,
+    outcome: str | None,
+    *,
+    session_id: str,
+    log_cause: str,
+    block_reason: str,
+) -> dict[str, str] | None:
+    """PET-171: the fail-secure gate shared by both cold-window branches.
+
+    ``log_cause`` and ``block_reason`` are separate so each caller keeps its own
+    operator-facing log wording while the enforcement event carries the branch-specific
+    reason. Homogenizing the two log lines would be an unrequested behavior change hiding
+    inside a parity fix (PET-174's recorded shape: a shared helper returns data, callers
+    keep their own message).
+    """
+    try:
+        dangerous = _is_dangerous(tool_name)
+    except Exception:
+        dangerous = True  # an unclassifiable name fails secure, it does not raise
+    if not dangerous:
+        # AHEAD of the outcome read, so the fail-secure default below can never
+        # mass-block read_file / search / web_search / list_directory.
+        return None
+    if outcome == "clean" and (_config or {}).get("fail_mode") == "open":
+        # Only `open` can allow a dangerous call, and only when the syntactic scan actually
+        # ran and came back clean. Any fail_mode value that is not exactly "open" is treated
+        # as degraded, mirroring _compute_safe's invalid-value fallback — garbage fails
+        # secure by construction. An unreadable outcome (None or unrecognized) is treated as
+        # errored and blocks under every fail_mode.
+        return None
+    logger.warning(
+        "PETASOS_QUARANTINE tool=%s session=%s — %s, scan outcome=%s",
+        tool_name,
+        session_id,
+        log_cause,
+        outcome if outcome in ("clean", "errored") else "unreadable",
+    )
+    # Block-class so the operator surface counts it: _BLOCK_EVENT_TYPES drives the blocked
+    # tile, the per-session tally and the red badge. Without it a real enforcement block
+    # renders as a green "safe" row. NOT emitted on the finding-driven path, which already
+    # emitted its own.
+    _emit_enforcement_event(
+        session_id=session_id,
+        tool=tool_name,
+        event_type="quarantine",
+        param_scan_degraded=True,
+        reason=block_reason,
+    )
+    return {
+        "action": "block",
+        # No finding to format on this sub-path. "degraded" is an existing ContentBlockPath
+        # whose reason is exactly this branch's semantics; a new token would encode a
+        # distinction that does not exist. The operator-facing distinction rides the
+        # enforcement event's reason instead.
+        "message": format_content_block("degraded", tool_name, ()),
+    }
 
 
 def _is_armed() -> bool:
@@ -1073,10 +1176,19 @@ _COLD_START_REASON_NO_INIT = (
     "scanners not up (no init in flight); tool results unscanned;"
     " syntactic only, dangerous tools only, params only (100k cap)"
 )
+# PET-171: the branch no longer allows unscanned, so the old "enforcement disabled" copy is
+# retired. "syntactic fallback only" is a SCOPE claim deliberately weaker than "enforcing":
+# the marker is emitted above the dispatch, before any outcome exists, so a claim that the
+# scan succeeded would be false in the errored steady state. The per-call PETASOS_QUARANTINE
+# line carries scan outcome=clean|errored|unreadable, which is where that is legible.
 _INIT_FAILED_REASON_PREFIX = (
-    "scanner init failed; enforcement disabled for this session; calls allowed unscanned: "
+    "scanner init failed; syntactic fallback only (dangerous tools, params, 100k cap);"
+    " tool results unscanned; no ML scanners: "
 )
 _COLD_BLOCK_REASON = "cold-window block: scanners not up, no finding; blocked by fail-mode policy"
+_INIT_FAILED_BLOCK_REASON = (
+    "init-failed block: scanners permanently unavailable, no finding; blocked by fail-mode policy"
+)
 _MAX_INIT_ERROR_CHARS = 60
 
 
@@ -1526,9 +1638,10 @@ def _pre_tool_call(
             None if (not task_id and kwargs.get("_agent") is None) else cold_session_id
         )
         if _init_error is not None:
-            logger.debug("Petasos init failed — allowing tool call")
-            # Allow/deny behavior on this branch is deliberately UNCHANGED; the record makes
-            # a total, silent enforcement loss visible, it does not start blocking.
+            logger.debug("Petasos init failed — running syntactic fallback")
+            # PET-171: the marker stays ABOVE the dispatch for the reason the cold branch
+            # below explains — the fallback returns early for read-only tools, so a
+            # read_file-only session would otherwise leave no record.
             _emit_cold_start_marker(
                 latch_key=latch_key,
                 session_id=cold_session_id,
@@ -1536,7 +1649,29 @@ def _pre_tool_call(
                 event_type="init_failed",
                 reason=(_INIT_FAILED_REASON_PREFIX + (_init_error or "")[:_MAX_INIT_ERROR_CHARS]),
             )
-            return None
+            # The cold branch's `_initialized` re-check is deliberately NOT carried here:
+            # `_deferred_init` returns early once `_init_error` latches, and `_initialized =
+            # True` is the last statement of its inner try, so the two globals are mutually
+            # exclusive by construction. The arm could never be taken, and if it somehow
+            # were it would fall through to the warm path with `_pipeline` still None.
+            #
+            # Latency residual, accepted: if the shared async loop is unusable every
+            # dangerous call takes the `errored` path, and `_run_async`'s default 15s
+            # timeout bounds each one — up to 15s per dangerous call before reaching a
+            # block that was foregone anyway. There is deliberately no demote-after-N
+            # circuit here (a wedged loop breaks the warm path too, so it is not specific
+            # to this branch). If it is ever observed in the field the fix is a shorter
+            # timeout on THIS call site, not a new state machine.
+            out, outcome = _run_fallback_gate(tool_name, args, task_id, **kwargs)
+            if out is not None:
+                return out
+            return _fallback_decision(
+                tool_name,
+                outcome,
+                session_id=cold_session_id,
+                log_cause="init failed",
+                block_reason=_INIT_FAILED_BLOCK_REASON,
+            )
 
         # Marker first, BEFORE the dispatch and independent of _is_dangerous — the fallback
         # returns early for read-only tools, so a read_file-only cold session would
@@ -1558,12 +1693,7 @@ def _pre_tool_call(
         # Init still in progress — use MinimalScanner fallback so we don't
         # silently allow during the cold-start window (fail_mode=closed
         # means we should be blocking, not passing through).
-        out = _fallback_pre_tool_call(tool_name, args, task_id, **kwargs)
-        # Read the out-of-band outcome, then CLEAR it on every exit: a stale value surviving
-        # on a pooled gateway thread would route the next cold-window call around the
-        # fail-secure default (a leftover "skipped" maps to allow).
-        outcome = getattr(_fallback_state, "outcome", None)
-        _fallback_state.outcome = None
+        out, outcome = _run_fallback_gate(tool_name, args, task_id, **kwargs)
         if out is not None:
             # A finding-driven block is returned UNCONDITIONALLY, even if init completed
             # mid-scan: it is justified by a real syntactic finding regardless of init
@@ -1571,48 +1701,15 @@ def _pre_tool_call(
             # Falling through here would discard the block while leaving a block-class row
             # on the console for a call that was allowed.
             return out
-        if _initialized:
-            pass  # init landed mid-scan: fall through to the main path rather than block
-        elif not _is_dangerous(tool_name):
-            # Read-only tools are allowed in the window exactly as the warm path allows
-            # them. This gate sits AHEAD of the outcome read, so the fail-secure default
-            # below can never mass-block read_file / search / web_search / list_directory.
-            return None
-        elif outcome == "clean" and (_config or {}).get("fail_mode") == "open":
-            # Only `open` can allow a dangerous call, and only when the syntactic scan
-            # actually ran and came back clean. Any fail_mode value that is not exactly
-            # "open" is treated as degraded, mirroring _compute_safe's invalid-value
-            # fallback — garbage fails secure by construction. An unreadable outcome
-            # (None or unrecognized) is treated as errored and blocks under every fail_mode.
-            return None
-        else:
-            logger.warning(
-                "PETASOS_QUARANTINE tool=%s session=%s — cold window, scan outcome=%s",
+        if not _initialized:
+            return _fallback_decision(
                 tool_name,
-                cold_session_id,
-                outcome if outcome in ("clean", "errored") else "unreadable",
-            )
-            # Block-class so the operator surface counts it: _BLOCK_EVENT_TYPES drives the
-            # blocked tile, the per-session tally and the red badge. Without it a real
-            # enforcement block renders as a green "safe" row. NOT emitted on the
-            # finding-driven path above, which already emitted its own.
-            _emit_enforcement_event(
+                outcome,
                 session_id=cold_session_id,
-                tool=tool_name,
-                event_type="quarantine",
-                param_scan_degraded=True,
-                reason=_COLD_BLOCK_REASON,
+                log_cause="cold window",
+                block_reason=_COLD_BLOCK_REASON,
             )
-            return {
-                "action": "block",
-                # No finding to format on this sub-path. "degraded" is an existing
-                # ContentBlockPath whose reason is exactly this branch's semantics; a new
-                # token would encode a distinction that does not exist (the warm-path
-                # param_scan_degraded block at the bottom of this function is the same
-                # decision under the same policy). The operator-facing distinction rides
-                # the enforcement event instead.
-                "message": format_content_block("degraded", tool_name, ()),
-            }
+        # init landed mid-scan: fall through to the main path rather than block
 
     # PET-126: initialized here — pick up any live config.yaml change before this
     # call is evaluated. Self-guarded and fail-safe; never blocks the tool call.

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -1130,8 +1130,10 @@
     else if (isSelfmod) scanRan = "n/a (tool argument classification, not a content scan)";
     // PET-167: this chain is separate from the body branches below, so a body-only edit
     // would leave a row whose entire purpose is to state scan coverage reading "unknown".
+    // PET-171: init_failed now runs the syntactic fallback, so "no (enforcement disabled)"
+    // became false. Both arms state partial coverage; the difference is permanence.
     else if (isColdStart) scanRan = (et === "init_failed")
-      ? "no (enforcement disabled; init failed)"
+      ? "partial (syntactic scan only; ML scanners unavailable)"
       : "partial (syntactic scan only; ML scanners still starting)";
     // PET-170: same reason the chain above needed its own arm. A row whose whole purpose
     // is to state ingestion-scan coverage must never read "unknown" here.
@@ -1199,9 +1201,14 @@
       // coverage this session actually got, it is not itself a decision.
       wrap.appendChild(Pet.h("div", { className: "sd-heartbeat" },
         Pet.h("div", {}, (et === "init_failed")
-          ? "Scanner startup failed: enforcement was disabled for this session and calls ran unscanned."
+          ? "Scanner startup failed permanently: this session runs on the fast pattern scan only."
           : "Scanners were still starting: this session ran on the fast pattern scan only."),
-        Pet.h("div", { className: "sd-sub" }, "One record per session, not per call. It marks coverage; blocks made during the window appear as their own rows.")));
+        // PET-171: the sub-line is SHARED. "during the window" was false for init_failed,
+        // whose blocks continue for the process lifetime with no window. And with no
+        // task_id and no _agent the latch is a pair of process-wide booleans while every
+        // call mints a fresh anon session, so "one per session" alone would tell an
+        // operator that the neighbouring marker-less sessions ran fine.
+        Pet.h("div", { className: "sd-sub" }, "At most one such record per session, and one per process when calls cannot be correlated. It marks coverage; blocks appear as their own rows.")));
       wrap.appendChild(fld("tool", e.tool));
       wrap.appendChild(fld("reason", e.reason));
       wrap.appendChild(fld("session", e.session_id));
@@ -1356,7 +1363,9 @@
         : (isSelfmodRow
             ? ("self-tamper" + (selfmodSev ? (" (" + selfmodSev + ")") : ""))
             : (isColdStart
-                ? (et === "init_failed" ? "unenforced" : "degraded")
+                // PET-171: "unenforced" is now false. Not reused as "degraded" either:
+                // that would erase the transient-versus-permanent distinction at a glance.
+                ? (et === "init_failed" ? "syntactic only" : "degraded")
                 : (isFlagged
                     ? (et === "ingest_unscanned" ? "unscanned" : "flagged")
                     : (isBlocked ? "blocked" : "safe"))));

--- a/tests/js/cold-start-row.test.mjs
+++ b/tests/js/cold-start-row.test.mjs
@@ -108,8 +108,11 @@ const ENF_DEGRADED = {
 const ENF_INIT_FAILED = {
   ...ENF_DEGRADED,
   event_type: "init_failed",
+  // PET-171: refreshed in lockstep with the shim's _INIT_FAILED_REASON_PREFIX. The branch
+  // now runs the syntactic fallback, so "enforcement disabled ... allowed unscanned" is
+  // false. Test INPUT carrying the Python-side prefix, not a fourth JS string.
   reason:
-    "scanner init failed; enforcement disabled for this session; calls allowed unscanned: No module named 'x'",
+    "scanner init failed; syntactic fallback only (dangerous tools, params, 100k cap); tool results unscanned; no ML scanners: No module named 'x'",
   scan_id: "e-cs2",
 };
 
@@ -118,7 +121,9 @@ const ENF_INIT_FAILED = {
 test("cold-start badges are amber and never the green safe pill", () => {
   for (const [row, label] of [
     [ENF_DEGRADED, "degraded"],
-    [ENF_INIT_FAILED, "unenforced"],
+    // PET-171: was "unenforced". Not folded into "degraded" either: that would erase the
+    // transient-versus-permanent distinction an operator scanning history most needs.
+    [ENF_INIT_FAILED, "syntactic only"],
   ]) {
     const tree = Pet.scanHistoryRows([row]);
     assert.equal(
@@ -152,8 +157,8 @@ test("cold-start provenance states coverage, never 'unknown'", () => {
 
   const failed = text(Pet.scanDetailPanel(ENF_INIT_FAILED));
   assert.ok(
-    failed.includes("scan ran: no (enforcement disabled; init failed)"),
-    "init_failed states that nothing was scanned"
+    failed.includes("scan ran: partial (syntactic scan only; ML scanners unavailable)"),
+    "init_failed states the partial coverage the session actually got"
   );
   assert.ok(!failed.includes("scan ran: unknown"), "never falls through to 'unknown'");
 });
@@ -173,7 +178,9 @@ test("cold-start detail renders the reason, not the unknown-row fallback", () =>
     "degraded explainer rendered"
   );
   assert.ok(
-    text(Pet.scanDetailPanel(ENF_INIT_FAILED)).includes("enforcement was disabled"),
+    text(Pet.scanDetailPanel(ENF_INIT_FAILED)).includes(
+      "Scanner startup failed permanently: this session runs on the fast pattern scan only."
+    ),
     "init_failed explainer rendered"
   );
 });

--- a/tests/test_reference_plugin_cold_start.py
+++ b/tests/test_reference_plugin_cold_start.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import json
+import logging
 import math
 import threading
 import time
@@ -667,7 +668,9 @@ def test_degraded_then_init_failed_records_both(monkeypatch: pytest.MonkeyPatch)
     assert len(_of_type("init_failed")) == 1
 
 
-def test_blocking_cold_call_emits_block_class_event(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_blocking_cold_call_emits_block_class_event(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     # Regression for PET-167: block-class or the console renders a real enforcement block
     # as a green "safe" row. _BLOCK_EVENT_TYPES drives the blocked tile, the per-session
     # block tally and the red badge.
@@ -675,12 +678,18 @@ def test_blocking_cold_call_emits_block_class_event(monkeypatch: pytest.MonkeyPa
     _open_window(monkeypatch, ref, fail_mode="degraded")
     _install_fallback_scanner(monkeypatch, ref)
 
+    caplog.set_level(logging.WARNING)
     out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
     assert out is not None and out["action"] == "block"
     quarantines = _of_type("quarantine")
     assert len(quarantines) == 1
     assert quarantines[0]["param_scan_degraded"] is True
     assert quarantines[0]["tool"] == "write_file"
+    # PET-171: the cold branch's own operator-facing log text and reason constant are
+    # UNCHANGED by the extraction. `log_cause` is a separate parameter from `block_reason`
+    # precisely so a shared helper cannot silently rewrite this string.
+    assert "cold window, scan outcome=clean" in caplog.text
+    assert quarantines[0]["reason"] == ref._COLD_BLOCK_REASON
 
 
 def test_syntactic_finding_block_emits_exactly_one_quarantine(
@@ -697,17 +706,243 @@ def test_syntactic_finding_block_emits_exactly_one_quarantine(
     assert len(_of_type("quarantine")) == 1
 
 
-def test_init_failed_emits_record_and_still_allows(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The allow/deny behavior of this branch is UNCHANGED: this makes a total, silent
-    # enforcement loss visible, it does not start blocking.
+# ---------------------------------------------------------------------------
+# PET-171: the latched branch runs the syntactic fallback instead of allowing
+# ---------------------------------------------------------------------------
+
+
+def test_init_failed_blocks_on_finding(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Regression for PET-171: this test previously asserted the OPPOSITE — that a latched
+    # _init_error allows every tool call unscanned. A process whose scanner init failed
+    # enforced nothing for its whole lifetime, which is strictly weaker than the sibling
+    # cold_start_degraded branch handling the LESS severe condition.
     ref = _import_reference_plugin()
     _open_window(monkeypatch, ref)
+    _install_fallback_scanner(monkeypatch, ref, findings=(_finding(),))
     _set(ref, "_init_error", "No module named 'x'")
 
-    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    caplog.set_level(logging.WARNING)
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert "Top finding:" in out["message"], "routed through format_content_block('init', ...)"
+
     records = _of_type("init_failed")
-    assert len(records) == 1
+    assert len(records) == 1, "the marker is still once per session"
     assert "No module named 'x'" in records[0]["reason"]
+
+    quarantines = _of_type("quarantine")
+    assert len(quarantines) == 1, "the fallback emitted its own; the gate must not double it"
+    assert quarantines[0]["reason"] == "injection finding"
+
+    # The only test that reaches the shared callee's block log line.
+    assert "PETASOS_FALLBACK_BLOCK" in caplog.text
+    assert "syntactic fallback, scan found:" in caplog.text
+    assert "init in progress" not in caplog.text, "the shared callee's copy is cause-neutral now"
+
+
+def test_init_failed_policy_block_carries_its_own_reason(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The no-finding sub-path: a clean scan under the DEFAULT fail_mode still blocks a
+    # dangerous call, and it must be attributable to the latch rather than to the cold
+    # window — the two are the same shape but only one is permanent.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    caplog.set_level(logging.WARNING)
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+    assert out["message"].startswith("[BLOCKED by Petasos]")
+
+    quarantines = _of_type("quarantine")
+    assert len(quarantines) == 1
+    assert quarantines[0]["reason"] == ref._INIT_FAILED_BLOCK_REASON
+    assert quarantines[0]["reason"] != ref._COLD_BLOCK_REASON, (
+        "a shared helper must not homogenize the two branches' operator-facing reasons"
+    )
+    assert quarantines[0]["param_scan_degraded"] is True
+    assert "init failed, scan outcome=clean" in caplog.text
+
+
+def test_degenerate_tool_names_fail_secure_on_both_branches(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Two behavior flips, both fail-secure. `_is_dangerous("")` is True (the empty string is
+    # not in _READ_ONLY_CANON), so an empty name flips allow -> block on the latched branch.
+    # A non-string name raises inside `_is_dangerous`, which `_fallback_pre_tool_call`
+    # evaluates OUTSIDE its own try: on the latched branch that is allow -> block, and on the
+    # cold branch raise -> block. The caller region has no try, so an unswallowed raise would
+    # reach the host.
+    #
+    # Stage A: fail_mode at its degraded default.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    caplog.set_level(logging.WARNING)
+    empty = ref._pre_tool_call("", {"text": "x"}, task_id="s1")
+    assert empty is not None and empty["action"] == "block"
+
+    bad = ref._pre_tool_call(123, {"text": "x"}, task_id="s1")
+    assert bad is not None and bad["action"] == "block", "a non-string name must not propagate"
+    assert getattr(ref._fallback_state, "outcome", None) is None, "cleared on every exit"
+    assert "PETASOS_FALLBACK_DISPATCH_FAILED" in caplog.text
+
+    # Same two names on the COLD branch, where the non-string case is raise -> block.
+    cold = _import_reference_plugin()
+    _open_window(monkeypatch, cold, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, cold)
+    assert cold._init_error is None, "this stage must exercise the cold branch, not the latch"
+    cold_empty = cold._pre_tool_call("", {"text": "x"}, task_id="s2")
+    assert cold_empty is not None and cold_empty["action"] == "block"
+    cold_bad = cold._pre_tool_call(123, {"text": "x"}, task_id="s2")
+    assert cold_bad is not None and cold_bad["action"] == "block"
+
+    # Stage B: fail_mode `open`, patching _config ALONE. Re-calling _open_window would run
+    # _reset_init_state(), clearing _init_error and silently moving this row onto the cold
+    # branch where it passes for the wrong reason. `open` is load-bearing: under `degraded` a
+    # stale "clean" blocks anyway, so this row would pin nothing without it.
+    monkeypatch.setattr(ref, "_config", {"fail_mode": "open", "init_wait_timeout_seconds": 0.05})
+    assert ref._init_error is not None, "still on the latched branch"
+    ref._fallback_state.outcome = "clean"
+    stale = ref._pre_tool_call(123, {"text": "x"}, task_id="s1")
+    assert stale is not None and stale["action"] == "block", (
+        "the entry clear must discard a residue left on this pooled thread"
+    )
+
+
+def test_init_failed_read_only_tools_still_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The carve-out sits AHEAD of the outcome read, so the new fail-secure default can never
+    # mass-block the read-only class for the process lifetime. NOT `search_files`, which is
+    # absent from READ_ONLY_TOOLS and is therefore dangerous today (PET-179's work).
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    for tool in ("read_file", "search", "list_directory", "web_search"):
+        assert ref._pre_tool_call(tool, {"path": "x"}, task_id="s1") is None, tool
+    assert _of_type("quarantine") == [], "no read-only call may produce a block-class row"
+    assert len(_of_type("init_failed")) == 1, "a read-only-only session still leaves a record"
+
+
+def test_realistic_latch_blocks_dangerous_and_allows_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Driven through the real _deferred_init rather than a hand-set global: it raises at the
+    # `raw_config.pop` AFTER its two imports resolved from cache, which is the shape every
+    # reachable latch has (config validation, build_scanners internals, Pipeline /
+    # ToolCallGuard construction). A broken petasos install does NOT reach here — it takes
+    # `import petasos` down at the plugin's module-level imports, so the plugin never loads.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+
+    class _BoomConfig(dict):  # type: ignore[type-arg]
+        def pop(self, *args: Any, **kwargs: Any) -> Any:
+            raise ValueError("bad config section")
+
+    monkeypatch.setattr(ref, "_config", _BoomConfig({"x": 1}))
+    ref._deferred_init()
+    assert ref._init_error is not None and "bad config section" in ref._init_error
+
+    monkeypatch.setattr(ref, "_config", {"fail_mode": "degraded"})
+    _install_fallback_scanner(monkeypatch, ref)
+
+    blocked = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert blocked is not None and blocked["action"] == "block"
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+
+
+def test_unusable_fallback_scanner_fails_secure_forever(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Option (a): let `errored` block. The feared "petasos itself is unimportable" state is
+    # unreachable in-process — petasos.scanners is cached before any test body runs, because
+    # the plugin's module-level `from petasos._types import ...` initializes it — so this
+    # drives the residual that IS reachable: a raising MinimalScanner() constructor. Every
+    # dangerous call re-attempts construction and blocks; read-only calls are unaffected.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+
+    def boom() -> Any:
+        raise ImportError("No module named 'petasos.scanners'")
+
+    monkeypatch.setattr(ref, "_get_fallback_scanner", boom)
+    _set(ref, "_init_error", "boom")
+
+    for _ in range(3):
+        out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+        assert out is not None and out["action"] == "block"
+    assert ref._pre_tool_call("read_file", {"path": "x"}, task_id="s1") is None
+    assert len(_of_type("quarantine")) == 3, "one block-class row per dangerous call"
+
+
+def test_init_failed_open_allows_clean_dangerous_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="open")
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    assert _of_type("quarantine") == []
+
+
+@pytest.mark.parametrize("fail_mode", ["degraded", "closed", "garbage"])
+def test_init_failed_non_open_fail_modes_fail_secure(
+    monkeypatch: pytest.MonkeyPatch, fail_mode: str
+) -> None:
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode=fail_mode)
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
+
+
+def test_init_failed_open_still_blocks_non_clean_outcomes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The `open` axis crossed with a non-clean outcome, which is where the fail-secure
+    # default is load-bearing rather than incidental: a regression here allows every
+    # dangerous call unscanned for the PROCESS LIFETIME, restoring the ticket's original
+    # defect under a config this ticket newly makes reachable.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="open")
+    _install_fallback_scanner(monkeypatch, ref, raises=True)
+    _set(ref, "_init_error", "boom")
+
+    errored = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert errored is not None and errored["action"] == "block", "open + raising scanner"
+
+    ref2 = _import_reference_plugin()
+    _open_window(monkeypatch, ref2, fail_mode="open")
+
+    def dispatch_boom(*a: Any, **k: Any) -> Any:
+        raise RuntimeError("dispatch boom")
+
+    monkeypatch.setattr(ref2, "_fallback_pre_tool_call", dispatch_boom)
+    _set(ref2, "_init_error", "boom")
+    failed = ref2._pre_tool_call("write_file", {"text": "x"}, task_id="s2")
+    assert failed is not None and failed["action"] == "block", "open + dispatch failure"
+
+
+def test_init_failed_marker_once_but_every_block_visible(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The marker is still latched to one record, but it is now ACCOMPANIED by per-call
+    # blocks: the console's blocked tile counts per row, so suppressing them would
+    # under-report enforcement.
+    ref = _import_reference_plugin()
+    _open_window(monkeypatch, ref, fail_mode="degraded")
+    _install_fallback_scanner(monkeypatch, ref)
+    _set(ref, "_init_error", "boom")
+
+    for _ in range(4):
+        out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+        assert out is not None and out["action"] == "block"
+
+    assert len(_of_type("init_failed")) == 1
+    assert len(_of_type("quarantine")) == 4
 
 
 def test_empty_exception_message_still_latches_visibly(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -729,7 +964,12 @@ def test_empty_exception_message_still_latches_visibly(monkeypatch: pytest.Monke
     assert ref._init_done.is_set(), "the finally wraps the WHOLE body, including this exit"
 
     monkeypatch.setattr(ref, "_config", {})
-    assert ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1") is None
+    # PET-171: was `is None`. Deliberately keeps the REAL MinimalScanner and the real
+    # _run_async — this test installs no fallback stub — so it is the end-to-end companion
+    # to the realistic-latch test: a genuine clean syntactic pass under an absent fail_mode
+    # still blocks. Do not "fix" it by adding _install_fallback_scanner.
+    out = ref._pre_tool_call("write_file", {"text": "x"}, task_id="s1")
+    assert out is not None and out["action"] == "block"
     assert len(_of_type("init_failed")) == 1
     assert _of_type("cold_start_degraded") == [], "a failed init is not 'still starting'"
 
@@ -790,8 +1030,25 @@ def test_record_reason_fits_and_states_caveats(monkeypatch: pytest.MonkeyPatch) 
             assert len(reason) <= 200
             assert "—" not in reason
 
-    # The caveats are carried by the two cold_start_degraded variants only; init_failed and
-    # the 4a quarantine carry none by design.
+    # PET-171: the reason-length budget, pinned as arithmetic rather than as an observed
+    # row, so a later copy edit fails loudly instead of silently amputating the operator's
+    # only copy of the init error (_enforcement_summary truncates as a PREFIX).
+    assert len(ref._INIT_FAILED_REASON_PREFIX) + ref._MAX_INIT_ERROR_CHARS <= 200
+
+    # PET-171: init_failed now runs the syntactic fallback, so its prefix states the
+    # coverage that scan actually gives. "only" is the clause that keeps the marker honest
+    # in the errored steady state, where no scan succeeded: an edit dropping it turns a
+    # scope claim into a false success claim.
+    init_failed_reason = str(by_type["init_failed"][0]["reason"])
+    assert "syntactic fallback only" in init_failed_reason
+    assert "tool results unscanned" in init_failed_reason
+    assert "100k cap" in init_failed_reason
+    assert "enforcement disabled" not in init_failed_reason, "retired by PET-171"
+
+    # The five cold-window caveat clauses are carried by the two cold_start_degraded
+    # variants only. The loop is deliberately NOT widened to init_failed: three of the five
+    # are cold-window-specific copy the new prefix does not carry, and its own clauses are
+    # asserted directly above.
     for row in by_type["cold_start_degraded"]:
         reason = str(row["reason"])
         # PET-170 re-worded this assertion; PET-167's Done-when 8 is RESTATED, not dropped.


### PR DESCRIPTION
## Summary

- A latched `_init_error` no longer means "allow everything unscanned". The reference plugin's `init_failed` branch now runs the same zero-dependency `MinimalScanner` fallback the `cold_start_degraded` sibling already runs, consults `fail_mode`, and keeps the read-only carve-out ahead of the fail-secure default.
- The asymmetry this closes: the **more** severe condition (init permanently failed, no scanners will ever arrive) previously received **weaker** treatment than the less severe one (init merely slow).
- Seven shipped copy surfaces that asserted a failed init leaves calls unscanned are corrected, since that claim is now false. Operator-visible consequence, stated plainly in the CHANGELOG and `hardening.md`: under the default `degraded` fail-mode a latched process blocks every dangerous tool call until restart, while read-only tools keep working.

## The decision the ticket flagged as hard

The ticket asked what to do when the fallback scanner itself is unavailable, and offered three options. Answer: **(a) route through and let `errored` block**, because the feared state is unreachable.

`petasos/__init__.py:16` imports `petasos.scanners.minimal`, which initializes the parent `petasos.scanners` package and executes all three re-raising extras blocks. The plugin's module-level `from petasos._types import Severity` runs that before the plugin module finishes loading. So a broken install (the venv-missing-`packaging` case) takes `import petasos` down, the plugin never loads, `_pre_tool_call` is never registered, and `_init_error` never exists. A broken install does not produce a latched failed init; it produces a plugin the host cannot load at all.

What *can* latch is everything inside `_deferred_init`'s inner try after its imports resolved from cache: config validation, `build_scanners` internals, `Pipeline` / `ToolCallGuard` construction, the taint-store setup. Every one of those leaves `petasos.scanners` cached, so `MinimalScanner` resolves. Options (b) one-shot probe and (c) config toggle are both rejected: (b) is machinery for a state the import graph cannot produce, (c) adds a config surface for a choice whose second setting is the defect itself.

## Two-branch interaction

The extraction splits at Decision 2's dead arm. `_run_fallback_gate` dispatches and takes the out-of-band outcome; `_fallback_decision` is the shared fail-secure gate. Between them sits the cold branch's `_initialized` re-check, which is provably dead on the latched branch (`_deferred_init` returns early once `_init_error` is set, and `_initialized = True` is the last statement of the inner try, so the two globals are mutually exclusive) and is therefore not carried.

The cold branch's shipped `PETASOS_QUARANTINE` text stays byte-identical because `log_cause` is a separate parameter from `block_reason` — a shared helper returns data, each caller keeps its own wording. `test_blocking_cold_call_emits_block_class_event` pins that it did not change.

Two degenerate-name flips, both fail-secure and both driven by tests: `_is_dangerous("")` is True, so an empty name flips allow to block; a non-string name raises inside `_is_dangerous` (evaluated outside `_fallback_pre_tool_call`'s own try), which the two `except` arms convert to a block. On the cold branch that second one is **raise to block** — the one place cold-branch behavior is not preserved exactly.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/__init__.py` | Rewrites the `init_failed` branch; adds `_run_fallback_gate` + `_fallback_decision`; refactors the cold tail onto them; corrects the reason prefix, adds `_INIT_FAILED_BLOCK_REASON`, makes the shared `PETASOS_FALLBACK_BLOCK` log cause-neutral; rewrites the module docstring |
| `petasos/console/static/petasos.js` | Corrects the `scanRan` provenance arm, the drill-down explainer, the badge text (`unenforced` to `syntactic only`) and the shared drill-down sub-line |
| `CHANGELOG.md` | New `### Fixed` entry; corrects the existing unreleased sync-requirement bullet in place (Keep a Changelog: it is unreleased) |
| `docs/deployment/hermes-desktop.md` | Corrects the skew paragraph and `verify.py`'s claimed coverage |
| `docs/deployment/hardening.md` | New bold-led paragraph in section 4 carrying the restart requirement as a standing fact |
| `tests/test_reference_plugin_cold_start.py` | 11 new cases; rewrites `test_init_failed_emits_record_and_still_allows`, updates two more |
| `tests/js/cold-start-row.test.mjs` | Refreshes the `ENF_INIT_FAILED` fixture and four assertions |

## Notes for the reviewer

- **Not test-gated, reviewer-verified only:** the five prose edits (module docstring, `hermes-desktop.md`, both CHANGELOG edits, the `hardening.md` paragraph) and the shared drill-down sub-line, which the JS explainer test renders but does not assert on.
- **No new event field and no new `event_type`.** The branch has three observable outcomes but only one coverage story worth a console state, so no discriminator is needed. This also avoids a silent-drop class: `_enforcement_summary` projects a fixed key list, so an unprojected field would vanish while the hand-built JS fixtures stayed green.
- **Reason-length budget:** the new prefix is 122 chars, plus `_MAX_INIT_ERROR_CHARS` (60) is 182 against the 200-char `_enforcement_summary` prefix slice. Pinned as arithmetic so a later copy edit fails loudly instead of amputating the operator's only copy of the init error.
- **Sync coupling:** this touches both the plugin and the static console asset, which are hand-synced separately. Old JS over a new plugin keeps rendering the retired "enforcement disabled" copy. The CHANGELOG entry carries that requirement.
- **The formatter call-site pin stays at exactly 10** (`test_reference_plugin_block_messages.py:485`). Moving `format_content_block("degraded", ...)` into the shared helper leaves the count unchanged; inlining a second call on the new branch would land on 11 and fail, which is the pin working as designed.
- **Deliberately out of scope,** all recorded in the spec: making `_deferred_init` retryable (restart is the only exit, documented in two durable homes), widening `verify.py`'s probe (PET-174's mechanism), reclassifying `search_files` (PET-179), and any demote-after-N circuit / rate-limiting of the per-call quarantine events / shortening of the 15s `_run_async` timeout. The latency residual and the absence of a circuit are recorded in a call-site comment.

## Test plan

- [x] `C:\python310\python.exe -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 2521 passed, 47 skipped, 1 deselected, 1 xfailed
- [x] Per-change: the four reference-plugin suites — 226/226 pass
- [x] `node --test tests/js/*.test.mjs` — 268/268 pass
- [x] `ruff check .` — clean; `ruff format --check .` — 169 files already formatted
- [x] `mypy --strict .` — no issues in 169 source files (note: `pyproject.toml:127-129` sets `ignore_errors = true` for `reference_plugin.*`, so the new helpers are annotated to match the module's local style, not to satisfy a gate)

The one deselect is the pre-existing master failure (`test_default_ignorable_rejected`, Unicode 13 vs 14 on the 3.10 gate interpreter), unrelated to this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior when scanner initialization fails by continuing syntactic scanning.
  * Dangerous tool calls are now blocked according to fail-mode settings, while read-only tools remain available.
  * Updated status messages to accurately indicate limited scanning and unavailable ML scanners.
  * Improved handling and diagnostics for plugin and library version mismatches.

* **Documentation**
  * Added deployment guidance for degraded operation, startup failures, version skew, and verification procedures.

* **Tests**
  * Expanded coverage for fallback enforcement, blocked calls, read-only exemptions, failure handling, and event visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->