### PR TITLE
feat(pet-166): profile-scope the console read surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Added
 
+- **Profile-scoped console read surfaces (PET-166).** Scan history, the armed
+  indicator, health, and the live event stream now take the host-selected
+  profile as an explicit, validated read scope, so selecting profile X in the
+  Hermes switcher shows X's enforcement data instead of the process binding's
+  under X's name. A selection that is not the equipped profile is rendered
+  honestly: read-only rows served from that profile's own files and marked
+  `foreign` in the drill-down (not a tamper verdict; this process holds no key
+  for them), an idle labelled event stream with a new SCOPED connection state,
+  a 30 second history refresh, arming refused with a 409, and the history
+  subtitle naming the profile with a client-derived freshness label. Unknown,
+  deleted, blank, or config-less profile names return a structured 422 on
+  every scoped surface. Requests that send no profile are byte-identical to
+  before, so standalone consoles and existing embedders see no change; the
+  write binding never moves with the selector. The embedded bridge logs a
+  one-shot `PETASOS_SCOPE_UNSCOPED_READ` token when a stale bundle stops
+  sending the scope on a multi-profile box.
+
 - **The ingestion-path session backstop (PET-176).** Flagged tool-result reads now
   accumulate session weight through the same `FrequencyTracker` the tool-call
   guard enforces on, so the escalation ladder underneath PET-170's annotation

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -114,6 +114,14 @@ below with class `sig-mismatch`.
 surfaced and counted exactly as before PET-139. Setting the secret is opt-in;
 not setting it is the documented no-regression posture, not a downgrade.
 
+**Rows read under a profile scope.** A console read scoped to a profile this
+dashboard is not bound to (PET-166) marks every returned row `foreign`: rows
+read from a profile this dashboard is not bound to, signed with a key we do not
+hold, so not verifiable from here. `foreign` is not a tamper verdict and never
+feeds the integrity window or the trusted-block tally; verifying properly would
+mean reading another profile's secret material into this process, which the
+read scope deliberately does not do.
+
 **Upgrade step (do this once, when first enabling integrity).** On a host that
 has already been running, the spool on disk still holds pre-PET-139 unsigned
 events. Those are genuine but unattestable, so they would surface as a one-time

--- a/docs/deployment/profile-resolution-model.md
+++ b/docs/deployment/profile-resolution-model.md
@@ -100,3 +100,28 @@ must extend to **all** profile homes (every `profiles/*/config.yaml` plus the
 v0.15 root and any `$HERMES_HOME`), not only the active one: a read-only mount or
 write-denying ACL that covers just the equipped profile leaves the pre-stage
 vector open. Treat the whole `profiles/` tree as security-bearing.
+
+## Read scope vs write binding (PET-166)
+
+The console's read surfaces (scan history, armed indicator, health, the event
+stream) take an optional `profile` read scope: the client sends the
+host-selected profile and the server serves that profile's on-disk state,
+validated through the same membership gate the Config Editor uses. The scope
+selects only what the operator is shown. Every write keeps resolving the
+process binding: the enforcement pipeline, the drain, spool rotation, and the
+armed write never move with the selector, and arming a non-equipped profile is
+refused with a 409. A non-equipped read is served read-only from that profile's
+files, marked `foreign` in the drill-down, and its live event stream stays
+idle (this process holds no other profile's events).
+
+**The `PETASOS_SCOPE_UNSCOPED_READ` tripwire.** The embedded bridge logs this
+INFO token once per run the first time a scoped route is called with no
+`profile` selector while the box has more than one profile and one of them is
+active. That combination usually means the hand-synced console bundle predates
+profile-scoped reads, so the panel may attribute the equipped profile's data to
+whichever profile the host sidebar shows. Remediation: re-sync the hand-synced
+plugin bundle. Excluded case: a host that reports no named profile (a
+`HERMES_HOME` or root binding with no active member) legitimately omits the
+selector; the tripwire requires an active member precisely so that supported
+configuration never trips it, and operators in that configuration should know
+the tripwire is not watching for them.

--- a/docs/usage/hermes-agent-profiles.md
+++ b/docs/usage/hermes-agent-profiles.md
@@ -29,10 +29,12 @@ config; changing one never touches another.
 ## Where it is
 
 The selector sits at the top of the **Config Editor** tab, above the Strength
-dial. Under it, a binding read-out names exactly what you are editing:
+dial. Under it, a resolution read-out states how the edited path was resolved
+(PET-166 renamed this line from `binding:` so the identity claim lives with the
+scope panel, and this line answers the diagnostic question instead):
 
 ```text
-binding: gibson · tier profile · ~\AppData\Local\hermes\profiles\gibson
+resolved via: gibson · tier profile · ~\AppData\Local\hermes\profiles\gibson
 ```
 
 `tier` is `profile` (a `profiles/<name>/config.yaml`), `hermes_home`

--- a/petasos/console/_armed.py
+++ b/petasos/console/_armed.py
@@ -8,14 +8,21 @@ arm. Never raises out of ``read_armed``/``write_armed``.
 PET-130: ``read_armed`` takes an optional ``res`` resolution. The gateway passes
 its boot-pinned resolution so a profile session never re-resolves to the global
 config mid-session; the standalone console passes ``None`` and re-resolves from
-environment. Precondition: the ``(mtime_ns, size)`` cache is keyed by stat
-metadata, not path, so a single process must use one binding consistently
-(gateway always pinned, console always ``None``). If a future surface ever runs
-both in one process, the cache must be re-keyed to include ``res.path``.
+environment. PET-166 D5: the cache is keyed by ``(normcase(path), mtime_ns,
+size)`` and bounded, because the console now serves scoped reads of non-equipped
+profiles in the same process as the equipped armed poll — two profiles' configs
+can share a ``(mtime_ns, size)`` stat key (a copied or templated profile home is
+ordinary), so path is part of the key. Raw ``os.path.normcase``, deliberately not
+``_resolved_normcase``: a raw key can only cause an extra cache miss (one extra
+YAML parse), never a false hit, and ``read_armed`` sits on the gateway's
+per-tool-call path whose documented budget is one ``os.stat`` per call. The
+sibling ``_reload.py`` cache keeps stat-only keying because no surface reads a
+non-equipped profile's reload state; re-key it if one ever does.
 """
 
 from __future__ import annotations
 
+import os.path
 import threading
 import time
 from typing import Any
@@ -28,15 +35,27 @@ from petasos.console._paths import (
 
 _ARMED_LOCK = threading.Lock()
 _ARMED_TTL_S = 1.0
-# (key, armed, monotonic_ts) | None  — key is (st_mtime_ns, st_size)
-_ARMED_CACHE: tuple[tuple[int, int], bool, float] | None = None
+# PET-166 D5: bounded so alternating equipped/scoped reads cannot grow the dict
+# without bound; drop-oldest by insertion order under _ARMED_LOCK (mirrors the
+# _MAX_TALLY_SESSIONS discipline — the repo does not ship inline cap literals).
+_ARMED_CACHE_MAX = 8
+# {(normcase(path), st_mtime_ns, st_size): (armed, monotonic_ts)}
+_ARMED_CACHE: dict[tuple[str, int, int], tuple[bool, float]] = {}
 
 
 def _reset_armed_cache() -> None:
-    """Test seam: drop the cache so a new (mtime, size) key can't be served stale."""
-    global _ARMED_CACHE
+    """Test seam: drop the cache so a new key can't be served stale."""
     with _ARMED_LOCK:
-        _ARMED_CACHE = None
+        _ARMED_CACHE.clear()
+
+
+def _cache_store(key: tuple[str, int, int], armed: bool, now: float) -> None:
+    """Store under _ARMED_LOCK, evicting oldest-inserted past _ARMED_CACHE_MAX."""
+    with _ARMED_LOCK:
+        _ARMED_CACHE.pop(key, None)
+        _ARMED_CACHE[key] = (armed, now)
+        while len(_ARMED_CACHE) > _ARMED_CACHE_MAX:
+            _ARMED_CACHE.pop(next(iter(_ARMED_CACHE)))
 
 
 def read_armed(res: HermesConfigResolution | None = None) -> bool:
@@ -51,23 +70,21 @@ def read_armed(res: HermesConfigResolution | None = None) -> bool:
     boot-pinned resolution and skips the per-call ambient resolve. When ``None``
     (the standalone console path), it re-resolves from environment as before.
     """
-    global _ARMED_CACHE
     res = res if res is not None else resolve_hermes_config_path()
     try:
         st = res.path.stat()
-        key = (st.st_mtime_ns, st.st_size)
+        key = (os.path.normcase(str(res.path)), st.st_mtime_ns, st.st_size)
     except OSError:
         return True  # cannot stat (missing/locked) -> armed (Decision 5)
     now = time.monotonic()
     with _ARMED_LOCK:
-        c = _ARMED_CACHE
-        if c is not None and c[0] == key and (now - c[2]) < _ARMED_TTL_S:
-            return c[1]
+        c = _ARMED_CACHE.get(key)
+        if c is not None and (now - c[1]) < _ARMED_TTL_S:
+            return c[0]
     section = read_petasos_section(res)  # never raises (D3)
     raw = section.get("enabled", True)
     armed = raw if isinstance(raw, bool) else True  # non-bool -> armed
-    with _ARMED_LOCK:
-        _ARMED_CACHE = (key, armed, now)
+    _cache_store(key, armed, now)
     return armed
 
 
@@ -77,7 +94,6 @@ def write_armed(armed: bool) -> bool:
     Returns ``True`` on success, ``False`` on any failure (Windows file lock,
     missing parent dir, etc.) — never raises out to the caller.
     """
-    global _ARMED_CACHE
     import contextlib
     import os
     import tempfile
@@ -114,8 +130,8 @@ def write_armed(armed: bool) -> bool:
     # Refresh this process's cache so a same-process read reflects the write at once.
     try:
         st = res.path.stat()
-        with _ARMED_LOCK:
-            _ARMED_CACHE = ((st.st_mtime_ns, st.st_size), bool(armed), time.monotonic())
+        key = (os.path.normcase(str(res.path)), st.st_mtime_ns, st.st_size)
+        _cache_store(key, bool(armed), time.monotonic())
     except OSError:
         _reset_armed_cache()
     return True

--- a/petasos/console/_history.py
+++ b/petasos/console/_history.py
@@ -39,12 +39,16 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import os
 import time
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from petasos.console._paths import resolve_hermes_config_path
+
+if TYPE_CHECKING:
+    from petasos.console._paths import HermesConfigResolution
 
 _HISTORY_FILENAME = "petasos-scan-history.jsonl"
 _ROT_SUFFIX = ".rot"
@@ -63,12 +67,17 @@ _HISTORY_CAP_BYTES = 2_000_000
 _HISTORY_PATH_OVERRIDE: str | None = None
 
 
-def _history_path() -> str:
-    """Resolve the sink path beside the active config (recomputed per call)."""
+def _history_path(res: HermesConfigResolution | None = None) -> str:
+    """Resolve the sink path beside the active config (recomputed per call).
+
+    *res* replaces the source of the resolution for read-scoped callers
+    (PET-166 D1); it never introduces a cache, and the test override keeps
+    winning unconditionally.
+    """
     if _HISTORY_PATH_OVERRIDE is not None:
         return _HISTORY_PATH_OVERRIDE
-    res = resolve_hermes_config_path()
-    return os.path.join(str(res.path.parent), _HISTORY_FILENAME)
+    r = res if res is not None else resolve_hermes_config_path()
+    return os.path.join(str(r.path.parent), _HISTORY_FILENAME)
 
 
 def _reset_history_state(path: str | None = None, cap: int | None = None) -> None:
@@ -206,7 +215,17 @@ def read_history_page(
                 continue
             if not isinstance(sid, str):
                 continue
-            key = (float(ts), sid)
+            # PET-166 D4: this helper is now pointed at bytes written by processes
+            # we do not control (a non-equipped profile's sink), so an
+            # arbitrary-precision int (float() raises OverflowError) or an
+            # inf/nan timestamp must drop the row, not raise out of the GET.
+            try:
+                ts_f = float(ts)
+            except OverflowError:
+                continue
+            if not math.isfinite(ts_f):
+                continue
+            key = (ts_f, sid)
             if global_oldest is None or key < global_oldest:
                 global_oldest = key
             if before is None or key < before:

--- a/petasos/console/_paths.py
+++ b/petasos/console/_paths.py
@@ -278,22 +278,24 @@ def read_petasos_section(res: HermesConfigResolution) -> dict[str, Any]:
     return section
 
 
-def spool_path() -> str:
+def spool_path(res: HermesConfigResolution | None = None) -> str:
     """Resolve the enforcement-spool path beside the active config.
 
     Recomputed per call so a transient active_profile fallback cannot leave
     writer and reader on different files.  Shared single source for the guard
-    owned-set, the spool writer, and tests.
+    owned-set, the spool writer, and tests.  *res* replaces the source of the
+    resolution for read-scoped callers (PET-166 D1); it never introduces a
+    cache, and the test override keeps winning unconditionally.
     """
     if _SPOOL_PATH_OVERRIDE is not None:
         return _SPOOL_PATH_OVERRIDE
-    res = resolve_hermes_config_path()
-    return os.path.join(str(res.path.parent), _SPOOL_FILENAME)
+    r = res if res is not None else resolve_hermes_config_path()
+    return os.path.join(str(r.path.parent), _SPOOL_FILENAME)
 
 
-def spool_rot_path() -> str:
+def spool_rot_path(res: HermesConfigResolution | None = None) -> str:
     """The ``.rot`` sibling of the resolved spool path."""
-    return spool_path() + _ROT_SUFFIX
+    return spool_path(res) + _ROT_SUFFIX
 
 
 def display_path(path: Path | str) -> str:

--- a/petasos/console/_sse.py
+++ b/petasos/console/_sse.py
@@ -15,14 +15,23 @@ _logger = logging.getLogger(__name__)
 
 _SENTINEL = object()
 
+# PET-166 D9: named so the idle-stream counter reads the live pool bound
+# rather than a shared literal that could drift from it.
+DEFAULT_MAX_SUBSCRIBERS = 10
+
 
 class SSEBroadcaster:
     """Fan-out SSE events to multiple subscriber queues."""
 
-    def __init__(self, *, max_subscribers: int = 10) -> None:
+    def __init__(self, *, max_subscribers: int = DEFAULT_MAX_SUBSCRIBERS) -> None:
         self._subscribers: list[asyncio.Queue[Any]] = []
         self._max_subscribers = max_subscribers
         self._seq = 0
+
+    @property
+    def max_subscribers(self) -> int:
+        """The constructed subscriber bound (read-only; PET-166 D9)."""
+        return self._max_subscribers
 
     def subscribe(self) -> asyncio.Queue[Any]:
         if len(self._subscribers) >= self._max_subscribers:

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -36,6 +36,11 @@ def init_handlers(pipeline: Any) -> None:
     from petasos.console.server import ConsoleHandlers
 
     _handlers = ConsoleHandlers(pipeline)
+    # PET-166 (D20): mark the handlers as embedded so the shared
+    # PETASOS_SCOPE_UNSCOPED_READ tripwire can fire only through this bridge —
+    # build_app never sets this, so the standalone console (which legitimately
+    # never sends a scope) can never false-positive.
+    _handlers._embedded = True
 
 
 def _load_config() -> dict[str, Any]:
@@ -181,14 +186,46 @@ async def run_scan(request: Request) -> Any:
 
 
 @router.get("/health")
-async def get_health() -> Any:
-    return await _require_handlers().get_health()
+async def get_health(profile: str | None = None) -> Any:
+    # PET-166 (D13): the embedded bridge is the primary operator surface, so every
+    # scoped surface forwards the selector — a selector the bridge does not forward
+    # silently no-ops exactly where it matters most (the PET-146 edge F-1 precedent).
+    from fastapi.responses import JSONResponse
+
+    from petasos.console.server import ProfileNotFoundError
+
+    try:
+        return await _require_handlers().get_health(profile=profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
 
 
 @router.get("/scan-history")
-async def get_scan_history(limit: int = 100, before: str | None = None) -> Any:
+async def get_scan_history(
+    limit: int = 100, before: str | None = None, profile: str | None = None
+) -> Any:
     # PET-148: additive `before` cursor for back-pages; absent => today's live window.
-    return await _require_handlers().get_scan_history(limit, before)
+    # PET-166 (D13): forwards the read scope; a non-member 422s, a cross-scope cursor
+    # 422s on `before`.
+    from fastapi.responses import JSONResponse
+
+    from petasos.console.server import CursorScopeMismatchError, ProfileNotFoundError
+
+    try:
+        return await _require_handlers().get_scan_history(limit, before, profile=profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
+    except CursorScopeMismatchError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "before", "message": str(exc)}]},
+        )
 
 
 @router.get("/profiles")
@@ -197,11 +234,46 @@ async def get_profiles() -> Any:
 
 
 @router.get("/events")
-async def events() -> Any:
-    from fastapi.responses import StreamingResponse
+async def events(profile: str | None = None) -> Any:
+    # PET-166 (D9/D13): both route surfaces move in lockstep — the 422, the idle arm
+    # (with its slot check against the SHARED handlers counter), and the RuntimeError
+    # -> 503 mapping (both routes 500 on a full pool today) are all present here, not
+    # only on the standalone route. A bridge that checked without incrementing would
+    # admit unbounded idle generators; the increment lives inside the shared
+    # idle_scope_stream generator, so both routes feed one counter.
+    from fastapi.responses import JSONResponse, StreamingResponse
+
+    from petasos.console.server import ProfileNotFoundError
 
     h = _require_handlers()
-    q = h.sse.subscribe()
+    try:
+        scope = h.resolve_events_scope(profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
+    if scope.state != "equipped":
+        if h._idle_stream_count >= h.sse.max_subscribers:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": [{"field": "profile", "message": "idle scope streams at capacity"}],
+                    "scope_refusal": "capacity",
+                },
+            )
+        return StreamingResponse(
+            h.idle_scope_stream(scope),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+    try:
+        q = h.sse.subscribe()
+    except RuntimeError:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": [{"field": "profile", "message": "event stream at capacity"}]},
+        )
     return StreamingResponse(
         h.sse.stream(q),
         media_type="text/event-stream",
@@ -215,14 +287,38 @@ async def get_about() -> Any:
 
 
 @router.get("/armed")
-async def get_armed() -> Any:
-    return await _require_handlers().get_armed()
+async def get_armed(profile: str | None = None) -> Any:
+    from fastapi.responses import JSONResponse
+
+    from petasos.console.server import ProfileNotFoundError
+
+    try:
+        return await _require_handlers().get_armed(profile=profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
 
 
 @router.post("/armed")
-async def set_armed(request: Request) -> Any:
+async def set_armed(request: Request, profile: str | None = None) -> Any:
     from fastapi.responses import JSONResponse
 
+    from petasos.console.server import ProfileNotEquippedError, ProfileNotFoundError
+
+    # PET-166 (D6): the selector rides in the BODY on a write; a query-borne selector
+    # is itself a 422 — silently ignoring it would resolve the scope to equipped and
+    # disarm the running agent while the UI names another profile.
+    if profile is not None:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "detail": [
+                    {"field": "profile", "message": "selector must ride in the request body"}
+                ]
+            },
+        )
     h = _require_handlers()
     try:
         body = await request.json()
@@ -236,7 +332,24 @@ async def set_armed(request: Request) -> Any:
             status_code=422,
             content={"detail": [{"field": "armed", "message": "Must be a boolean"}]},
         )
-    result, ok = await h.set_armed(body["armed"])
+    body_profile = body.get("profile")
+    if body_profile is not None and not isinstance(body_profile, str):
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": "Must be a string"}]},
+        )
+    try:
+        result, ok = await h.set_armed(body["armed"], profile=body_profile)
+    except ProfileNotFoundError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
+    except ProfileNotEquippedError as exc:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
     if not ok:
         return JSONResponse(
             status_code=503,

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -1721,12 +1721,24 @@ class ConsoleHandlers:
             rot = spool_rot_path(scope.resolution)
 
             # limit=sys.maxsize, NOT 0/-1 (the helper slices those to an empty page).
-            # The sink read is deliberately uncapped — a named residual (D3): its bound
-            # is enforced only by the process bound to that profile.
-            sink_rows, _ = _history.read_history_page(sink, before=None, limit=sys.maxsize)
+            # The sink read is size-gated per segment like the spool reads (closes the
+            # D3 residual): an over-cap foreign sink is skipped rather than loaded
+            # whole — read_history_page has no tail mode, and a partial parse of an
+            # attacker-grown file buys nothing — and the loss is reported through
+            # `spool_truncated` like the capped spool reads.
+            sink_over_cap = False
+            for seg in (sink, sink + _history._ROT_SUFFIX):
+                try:
+                    if os.path.getsize(seg) > _FOREIGN_SPOOL_READ_CAP:
+                        sink_over_cap = True
+                except OSError:
+                    pass  # absent segment: nothing to read, nothing to cap
+            sink_rows: list[dict[str, Any]] = []
+            if not sink_over_cap:
+                sink_rows, _ = _history.read_history_page(sink, before=None, limit=sys.maxsize)
             live_ev, trunc_a = read_spool_tail(spool)
             rot_ev, trunc_b = read_spool_tail(rot)
-            spool_truncated = trunc_a or trunc_b
+            spool_truncated = trunc_a or trunc_b or sink_over_cap
 
             # D15: every row on this branch is `foreign` — this process holds no key
             # for these rows (they may legitimately be signed with another profile's

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -15,10 +15,15 @@ import hashlib
 import hmac
 import json
 import logging
+import math
+import os
+import sys
 import time
 import uuid
 from collections import deque
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote, unquote
 
 from petasos.console import _history
 from petasos.console._config_meta import generate_config_metadata, generate_section_metadata
@@ -29,6 +34,8 @@ from petasos.console._paths import (
     read_petasos_section_checked,
     resolve_hermes_config_path,
     resolve_profile_config_path,
+    spool_path,
+    spool_rot_path,
 )
 from petasos.console._presets import generate_preset_metadata, resolve_active_preset
 from petasos.console._ring_buffer import RingBuffer
@@ -37,6 +44,7 @@ from petasos.console._validation import SessionIdError, sanitize_session_id
 from petasos.normalize import normalize
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from fastapi import FastAPI
@@ -109,6 +117,13 @@ _INTEGRITY_KEY_OFF_NOTE = (
 # long decoded-payload message cannot bloat the ring buffer / SSE frame — matching the
 # 200-char block-message truncation in petasos/session/formatting.py.
 _MAX_REASON_LEN = 200
+
+# PET-166 (D3): byte cap on each non-equipped enforcement-spool segment read. A
+# non-equipped profile's live spool has no enforced bound (SPOOL_CAP_BYTES is honored
+# only by a running dashboard, which a non-equipped profile by definition lacks), so
+# the foreign read is tail-windowed. Mirrors SPOOL_CAP_BYTES's value; module-level so
+# a test seam can shrink it (the same reason _events.SPOOL_CAP_BYTES is settable).
+_FOREIGN_SPOOL_READ_CAP = 2_000_000
 
 # PET-148 (D-DRIFT): single source of truth for the in-memory scan-history ring capacity.
 # Promoted from the inline `RingBuffer(maxlen=500)` literal so the ring window and the
@@ -266,6 +281,11 @@ def _enforcement_summary(ev: dict[str, Any], *, provenance: str = "unattested") 
     spool-integrity verdict to the drill-down "is this legit?" line. Keyword-only and
     DEFAULTED so existing callers (playground summaries, the PET-131/137/138 enforcement
     tests) stay green untouched — the default reflects "no key configured".
+
+    PET-166 (D15): a fourth value, "foreign", marks rows read from a profile this
+    dashboard is not bound to — signed with a key we do not hold, so not verifiable from
+    here. Never a tamper verdict; the non-equipped merged read passes it directly and
+    never routes those rows through the live verifier.
     """
     event_type = ev.get("event_type")
     is_block = event_type in _BLOCK_EVENT_TYPES
@@ -335,11 +355,73 @@ def _history_disk_row(summary: dict[str, Any]) -> dict[str, Any]:
     return row
 
 
-def _history_cursor_token(row: dict[str, Any]) -> str | None:
+def read_spool_tail(path: str) -> tuple[list[dict[str, Any]], bool]:
+    """Bounded, non-destructive tail read of a foreign enforcement-spool segment (PET-166 D3).
+
+    A small local reader, deliberately not a change to ``_events``:
+    ``drain_enforcement_events`` is the live path's reader and advances offsets; this one
+    stores nothing and never mutates. Reads at most ``_FOREIGN_SPOOL_READ_CAP`` trailing
+    bytes; when the window did not start at byte 0 the leading partial line is sliced off
+    explicitly at the first newline, and a window holding no newline at all yields no
+    events (no line in it is known-complete). Returns ``(events, truncated)`` where
+    ``truncated`` is ``size > cap`` and only that — a sub-cap file holding one in-flight
+    partial line yields no events but is NOT truncated (the live sibling treats exactly
+    those bytes as benign). The stat-then-read is a benign TOCTOU: a concurrent foreign
+    rotation degrades to the fail-safe empty read. Never raises.
+    """
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return [], False
+    truncated = size > _FOREIGN_SPOOL_READ_CAP
+    try:
+        with open(path, "rb") as f:
+            f.seek(max(0, size - _FOREIGN_SPOOL_READ_CAP))
+            data = f.read()
+    except OSError:
+        return [], truncated
+    if truncated:
+        nl = data.find(b"\n")
+        if nl < 0:
+            return [], True
+        data = data[nl + 1 :]
+    events: list[dict[str, Any]] = []
+    for raw in data.split(b"\n")[:-1]:  # drop the trailing partial, as the live reader does
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw.decode("utf-8"))
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events, truncated
+
+
+def _cursor_esc(s: str) -> str:
+    """Escape one cursor segment (PET-166 D18). ``quote`` alone does not do it: ``~`` is in
+    ``_ALWAYS_SAFE`` (RFC 3986 unreserved) and ``safe=`` only adds to that set, so the
+    structural separator would survive unescaped. The ``.replace`` is unambiguous because
+    ``quote(safe="")`` has already turned every literal ``%`` into ``%25``."""
+    return quote(s, safe="").replace("~", "%7E")
+
+
+def _cursor_unesc(s: str) -> str:
+    """Reverse ``_cursor_esc`` in a single pass."""
+    return unquote(s)
+
+
+def _history_cursor_token(row: dict[str, Any], scope_name: str | None = None) -> str | None:
     """Mint the opaque ``before`` cursor token for *row* (PET-148 D-CURSOR), or None.
 
-    Format ``f"{timestamp!r}~{scan_id}"``: a float repr contains no ``~`` and ``scan_id``
-    (``s-<hex>`` / ``e-<hex>``) is ``~``-free, so ``rsplit("~", 1)`` round-trips cleanly.
+    Unscoped format ``f"{timestamp!r}~{scan_id}"``: a float repr contains no ``~`` and our
+    own writers' ``scan_id`` (``s-<hex>`` / ``e-<hex>``) is ``~``-free, so ``rsplit("~", 1)``
+    round-trips cleanly. PET-166 D18: when *scope_name* is set (a ``profile`` parameter was
+    sent — equipped or not), the token is scope-bound:
+    ``f"{esc(name)}|{timestamp!r}~{esc(scan_id)}"`` with BOTH variable segments escaped,
+    because the merged read is the first path that mints a cursor from a row written by a
+    process we do not control (a foreign ``scan_id`` may carry ``~`` or ``|``). With both
+    segments escaped the token has exactly one structural ``|`` and one structural ``~``.
     Returns None for a row that cannot be ordered (non-numeric ``timestamp`` or non-string
     ``scan_id``) so the caller emits ``next_before: null`` rather than a broken token.
     """
@@ -347,28 +429,49 @@ def _history_cursor_token(row: dict[str, Any]) -> str | None:
     sid = row.get("scan_id")
     if isinstance(ts, bool) or not isinstance(ts, (int, float)) or not isinstance(sid, str):
         return None
-    return f"{float(ts)!r}~{sid}"
+    if scope_name is None:
+        return f"{float(ts)!r}~{sid}"
+    return f"{_cursor_esc(scope_name)}|{float(ts)!r}~{_cursor_esc(sid)}"
 
 
-def _parse_history_cursor(before: str | None) -> tuple[tuple[float, str] | None, bool]:
+def _parse_history_cursor(
+    before: str | None, scope_name: str | None = None
+) -> tuple[tuple[float, str] | None, str]:
     """Parse a ``before`` cursor token fail-safe (PET-148 D-CURSOR). Never raises.
 
-    Returns ``(cursor, malformed)``: ``(None, False)`` when *before* is absent (the live
-    window — the intended default); ``(None, True)`` when it is present but unparseable (an
-    empty page, NOT a snap-back to the live head — a teleport from deep history to the newest
-    500 is a wrong answer the operator did not ask for); ``((timestamp, scan_id), False)``
-    for a valid token. The arity check (exactly one ``~`` split into two parts) plus the
-    ``float()`` try are the only two ways a token is rejected.
+    Returns ``(cursor, status)`` with a THREE-way status (PET-166 D18):
+
+    - ``"ok"`` — absent (the live window) or a valid token for this scope.
+    - ``"malformed"`` — present but unparseable: an empty page at 200, NOT a snap-back to
+      the live head (a teleport from deep history to the newest 500 is a wrong answer the
+      operator did not ask for).
+    - ``"scope_mismatch"`` — the token's scope prefix does not match the request's scope,
+      in EITHER direction (a prefixed token with no ``profile`` parameter, an unprefixed
+      token under one, or a prefix naming a different profile). Mapped to a 422 on
+      ``before`` by the routes — never a plausible, non-contiguous page under a scope the
+      token was not minted for.
+
+    The three ways a token is rejected: the scope check above, the arity check (exactly one
+    ``~`` split into two parts), and the ``float()`` try.
     """
     if before is None:
-        return None, False
-    parts = before.rsplit("~", 1)
+        return None, "ok"
+    prefix: str | None = None
+    body = before
+    if "|" in before:
+        head, body = before.split("|", 1)
+        prefix = _cursor_unesc(head)
+    if (prefix is None) != (scope_name is None) or (prefix is not None and prefix != scope_name):
+        return None, "scope_mismatch"
+    parts = body.rsplit("~", 1)
     if len(parts) != 2:
-        return None, True
+        return None, "malformed"
     try:
-        return (float(parts[0]), parts[1]), False
+        ts = float(parts[0])
     except (ValueError, TypeError):
-        return None, True
+        return None, "malformed"
+    sid = _cursor_unesc(parts[1]) if prefix is not None else parts[1]
+    return (ts, sid), "ok"
 
 
 def _persist_config(validated_config: Any, *, target_path: "Path | None" = None) -> bool:
@@ -455,6 +558,86 @@ class ProfileNotFoundError(Exception):
     A plain ``Exception`` (not ``ValueError``) so it is never swallowed by the
     ``from_dict`` ``(ValueError, TypeError)`` handlers downstream.
     """
+
+
+class ProfileNotEquippedError(Exception):
+    """An arm/disarm targeted a profile that is not the equipped binding (PET-166 D6).
+
+    Carries the equipped name so the 409 body can state what arming would actually
+    act on. Raised by ``set_armed``; both routes catch it into a 409 BEFORE the
+    ``ok`` check, so a policy refusal can never surface as the 503 persistence body.
+    """
+
+    def __init__(self, selected: str, equipped: str | None) -> None:
+        self.equipped = equipped
+        target = f"the equipped profile {equipped!r}" if equipped else "this dashboard's binding"
+        super().__init__(
+            f"Profile {selected!r} is not the equipped profile; arming targets {target}"
+        )
+
+
+class CursorScopeMismatchError(Exception):
+    """A ``before`` token's scope prefix does not match the request's scope (PET-166 D18).
+
+    Mapped by the routes to a 422 on the ``before`` field — never the PET-148
+    empty-page 200, which would serve a plausible, non-contiguous page under a scope
+    the token was not minted for.
+    """
+
+
+@dataclass(frozen=True)
+class _ReadScope:
+    """The resolved read scope of one request (PET-166 D10). Internal; the wire payload
+    is built by ``_read_scope_payload`` and does not carry ``profile_count``."""
+
+    name: str | None  # None => no selector sent
+    resolution: "HermesConfigResolution"  # equipped binding when name is None
+    equipped_name: str | None  # the is_active enumeration entry, or None
+    equipped_tier: str  # "profile" | "hermes_home" | "root"
+    state: str  # "equipped" | "not_equipped" | "unknown"
+    profile_count: int  # len(list_hermes_profiles()), for D20
+
+
+def _resolve_read_scope(profile: str | None) -> "_ReadScope":
+    """Resolve a request's read scope, once per request (PET-166 D10).
+
+    Raises ``ProfileNotFoundError`` for a named non-member (routes map to 422).
+    ``state`` is decided by ORDERED checks, never a flat comparison: with both sides
+    unresolvable a flat equality would evaluate ``None == None`` as equipped and let
+    a scoped disarm through the D6 guard into a write against the running agent.
+    """
+    equipped_res = resolve_hermes_config_path()
+    profiles = list_hermes_profiles()
+    equipped_entry = next((p for p in profiles if p.get("is_active")), None)
+    equipped_name = equipped_entry["name"] if equipped_entry is not None else None
+    equipped_tier = "profile" if equipped_entry is not None else equipped_res.tier
+    count = len(profiles)
+    if profile is None:
+        return _ReadScope(None, equipped_res, equipped_name, equipped_tier, "equipped", count)
+    target = resolve_profile_config_path(profile)
+    if target is None:
+        raise ProfileNotFoundError(f"Profile {profile!r} not found")
+    equipped_norm = _resolved_normcase(equipped_res.path)
+    if equipped_norm is None:
+        state = "unknown"
+    else:
+        target_norm = _resolved_normcase(target.path)
+        if target_norm is None or target_norm != equipped_norm:
+            state = "not_equipped"
+        else:
+            state = "equipped"
+    return _ReadScope(profile, target, equipped_name, equipped_tier, state, count)
+
+
+def _read_scope_payload(scope: "_ReadScope") -> dict[str, Any]:
+    """The one wire object every scoped surface reports (PET-166 D19)."""
+    return {
+        "selected": scope.name,
+        "equipped": scope.equipped_name,
+        "equipped_tier": scope.equipped_tier,
+        "live": scope.state == "equipped",
+        "state": scope.state,
+    }
 
 
 def _hermes_profile_label(res: "HermesConfigResolution") -> str:
@@ -598,6 +781,17 @@ class ConsoleHandlers:
         # boot/preflight WARNING (D7), mirroring `_ring_overflow_warned`/`_history_sink_warned`.
         self._integrity_recent: deque[tuple[str, str | None]] = deque(maxlen=_INTEGRITY_WINDOW)
         self._integrity_preflight_emitted = False
+        # PET-166 (D20): set to True by plugin_api at registration and never by
+        # build_app, so the unscoped-read tripwire below cannot fire on the
+        # standalone console (which legitimately never sends a scope).
+        self._embedded = False
+        # One-shot guard for PETASOS_SCOPE_UNSCOPED_READ (the shipped one-shot
+        # convention; an instance attribute so console-suite fixtures reset it).
+        self._unscoped_read_warned = False
+        # PET-166 (D9): idle (non-equipped) SSE stream counter. Instance attribute so
+        # both route surfaces share the bound through the shared handlers object; the
+        # limit is handlers.sse.max_subscribers so the two arms cannot drift.
+        self._idle_stream_count = 0
 
         pipeline.add_audit_listener(self._on_audit)
         pipeline.add_alert_listener(self._on_alert)
@@ -888,6 +1082,22 @@ class ConsoleHandlers:
             # switch). Stale byte offsets index a different (possibly smaller) file and
             # would skip its events, so reset to 0 and read the new spool from the start.
             if path != self._enforcement_spool_path:
+                # PET-166 (D17): a binding change also clears the ring — after an
+                # equipped flip the equipped head read would otherwise serve the OLD
+                # binding's rows under the new profile's name, and the client's
+                # invalidation re-seed would actively repaint them. Guarded on the
+                # attribute read BEFORE the reassignment below: it is None on every
+                # process's FIRST drain by construction, and an unguarded clear would
+                # wipe pre-drain playground rows in embedded mode (standalone is
+                # masked by build_app's preflight drain; embedded has none). Named
+                # residual: a binding that moves before the first drain is invisible
+                # to this guard. Reassignment, not a clear() method — RingBuffer
+                # exposes exactly push/to_list/__len__ and nothing else holds a
+                # reference (every use is an attribute access off self).
+                if self._enforcement_spool_path is not None:
+                    self.scan_history = RingBuffer[dict[str, Any]](
+                        maxlen=_SCAN_HISTORY_RING_CAPACITY
+                    )
                 self._enforcement_offset = 0
                 self._rot_offset = 0
                 self._enforcement_spool_path = path
@@ -953,6 +1163,67 @@ class ConsoleHandlers:
                 loop.create_task(self.sse.broadcast("alert", data))
         except Exception:
             _logger.debug("Console alert broadcast failed", exc_info=True)
+
+    def _note_unscoped_read(self, scope: "_ReadScope") -> None:
+        """PET-166 (D20): one-shot INFO tripwire for the direction the client cannot see.
+
+        Fires the first time a scoped route is hit through the embedded bridge with no
+        ``profile`` while the box has more than one profile AND one of them is active —
+        the stale-bundle-against-a-fresh-backend leg lives here because the detector
+        cannot live in the artifact that is stale. Requiring an active member (not
+        merely two entries) excludes D16's legitimate ``equipped_name is null``
+        configuration, where the client correctly omits the parameter. Reads the count
+        and the active flag off the ``_ReadScope`` the request already built, so the
+        predicate costs no extra enumeration. Never raises.
+        """
+        if (
+            self._unscoped_read_warned
+            or not self._embedded
+            or scope.name is not None
+            or scope.profile_count <= 1
+            or scope.equipped_name is None
+        ):
+            return
+        self._unscoped_read_warned = True
+        _logger.info(
+            "PETASOS_SCOPE_UNSCOPED_READ a scoped console route was called with no profile "
+            "selector on a multi-profile box with an active profile; the console bundle may "
+            "predate profile-scoped reads. Remediation: re-sync the hand-synced plugin bundle. "
+            "Logged once per run."
+        )
+
+    def resolve_events_scope(self, profile: str | None) -> "_ReadScope":
+        """Shared scope resolution for BOTH ``/api/events`` routes (PET-166 D13/D20).
+
+        Keeps the D10 once-per-request rule (the routes hold the returned scope) and
+        gives the events surface its tripwire call site in shared code rather than
+        two per-route copies. Raises ``ProfileNotFoundError`` for a non-member.
+        """
+        scope = _resolve_read_scope(profile)
+        self._note_unscoped_read(scope)
+        return scope
+
+    async def idle_scope_stream(self, scope: "_ReadScope") -> "AsyncIterator[str]":
+        """The non-equipped SSE stream (PET-166 D9): one ``read_scope`` frame, then a bare
+        keepalive loop that never completes and never touches the live subscriber pool.
+
+        The slot is acquired in the generator's preamble and released in ``finally`` —
+        never in the route — because in the installed starlette a client disconnect
+        between ``http.response.start`` and the first body pull raises out of ``send``
+        with the generator never started: its ``finally`` would never run, and a slot
+        acquired at the route would leak permanently, once per aborted open. A
+        never-started generator never acquired, so the counter is self-healing; the
+        cost is a transient over-admit bounded by concurrent opens.
+        """
+        self._idle_stream_count += 1
+        try:
+            frame = json.dumps(_read_scope_payload(scope))
+            yield f"event: read_scope\ndata: {frame}\n\n"
+            while True:
+                await asyncio.sleep(15.0)
+                yield ":keepalive\n\n"
+        finally:
+            self._idle_stream_count -= 1
 
     async def get_config(self, profile: str | None = None) -> dict[str, Any]:
         # PET-146 D1: the active binding identity + its (possibly dangling-pointer)
@@ -1342,13 +1613,20 @@ class ConsoleHandlers:
             "remediation": remediation,
         }
 
-    async def get_health(self) -> dict[str, Any]:
+    async def get_health(self, profile: str | None = None) -> dict[str, Any]:
+        # PET-166 (D8): health stays PROCESS-scoped — every field below describes the
+        # running pipeline, none of which is knowable for a non-equipped profile, and
+        # synthesizing it would substitute a new lie for the one being removed. The
+        # route accepts and validates `profile` (D7) and reports its scope honestly
+        # via the D19 object; it never fabricates per-profile health.
+        scope = _resolve_read_scope(profile)
+        self._note_unscoped_read(scope)
         cfg = self.pipeline.config
         config_hash = hashlib.sha256(
             json.dumps(cfg.to_dict(redact_secrets=True), sort_keys=True, default=str).encode()
         ).hexdigest()[:16]
 
-        return {
+        payload: dict[str, Any] = {
             "pipeline": {
                 "fail_mode": cfg.fail_mode,
                 "scanner_count": len(self.pipeline.scanner_health()),
@@ -1368,9 +1646,12 @@ class ConsoleHandlers:
             # keys; no change to any other field or HTTP response shape.
             "integrity": self._integrity_health(),
         }
+        if profile is not None:  # D2/D19: scope-gated; an unscoped body is byte-identical
+            payload["read_scope"] = _read_scope_payload(scope)
+        return payload
 
     async def get_scan_history(
-        self, limit: int = 100, before: str | None = None
+        self, limit: int = 100, before: str | None = None, profile: str | None = None
     ) -> dict[str, Any]:
         # PET-131: drain-on-read is the floor that surfaces live enforcement on the
         # gated-mode polling fallback (PET-83) and in the embedded Hermes plugin path
@@ -1378,41 +1659,165 @@ class ConsoleHandlers:
         # latency optimization on top; both share the exactly-once drain. PET-148: the
         # drain now also rotates the history sink (in its own _history_lock block, after
         # its _enforcement_lock body), bounding growth on the tailer + read paths.
+        # PET-166 (D3): hoisted ABOVE the scope branch — we always drain our own
+        # binding, we never drain anyone else's. The client's 30 s scoped poll keeps
+        # calling this route while parked on a foreign profile, which is what keeps
+        # our own fold and spool rotation alive in embedded mode (no background tailer).
         await self._drain_enforcement_into_history()
+        scope = _resolve_read_scope(profile)  # D7/D10: raises for a non-member -> 422
+        self._note_unscoped_read(scope)
         clamped = min(max(1, limit), 1000)
-        # PET-148 (D-CURSOR): additive `before` cursor. Absent => today's live window
-        # (byte-identical `entries`); present => reverse-scan the on-disk sink for rows
-        # strictly older than the cursor. The response gains additive `next_before` +
-        # `older_truncated` keys; PET-144's `entries`/`scans_total` shape is preserved, so
-        # existing consumers ignore the new keys.
+        cursor, status = _parse_history_cursor(before, scope.name)
+        if status == "scope_mismatch":
+            # D18: a token replayed across scopes (either direction) is a 422 on
+            # `before`, never a plausible, non-contiguous page.
+            raise CursorScopeMismatchError(
+                "before cursor was minted under a different scope; re-page from the head"
+            )
+        malformed = status == "malformed"
         rows: list[dict[str, Any]]
         older_truncated: bool
-        cursor, malformed = _parse_history_cursor(before)
-        if malformed:
-            # Present-but-unparseable: an EMPTY page, never a snap-back to the live head
-            # (a teleport from deep history to the newest 500 is a wrong answer; edge F-4).
-            _logger.debug(
-                "PETASOS_HISTORY malformed before cursor %r; returning empty page", before
-            )
-            rows = []
-            older_truncated = False
-        elif cursor is not None:
-            # Paged-back: key-ordered reverse-scan of live + .rot, under _history_lock so a
-            # concurrent rotate cannot interleave the read (closes the os.replace race).
-            async with self._history_lock:
-                rows, older_truncated = _history.read_history_page(
-                    _history._history_path(), before=cursor, limit=clamped
+        spool_truncated = False
+        has_older = False
+        if scope.state == "equipped":
+            # PET-148 (D-CURSOR): additive `before` cursor. Absent => today's live window
+            # (byte-identical `entries`); present => reverse-scan the on-disk sink for rows
+            # strictly older than the cursor. The response gains additive `next_before` +
+            # `older_truncated` keys; PET-144's `entries`/`scans_total` shape is preserved,
+            # so existing consumers ignore the new keys.
+            if malformed:
+                # Present-but-unparseable: an EMPTY page, never a snap-back to the live
+                # head (a teleport from deep history to the newest 500 is a wrong answer;
+                # edge F-4).
+                _logger.debug(
+                    "PETASOS_HISTORY malformed before cursor %r; returning empty page", before
                 )
-            rows = [self._attach_history_provenance(r) for r in rows]
+                rows = []
+                older_truncated = False
+            elif cursor is not None:
+                # Paged-back: key-ordered reverse-scan of live + .rot, under _history_lock
+                # so a concurrent rotate cannot interleave the read (os.replace race).
+                async with self._history_lock:
+                    rows, older_truncated = _history.read_history_page(
+                        _history._history_path(), before=cursor, limit=clamped
+                    )
+                rows = [self._attach_history_provenance(r) for r in rows]
+            else:
+                # Default (before absent): byte-identical to today — most-recent-first
+                # ring window.
+                rows = list(reversed(self.scan_history.to_list(clamped)))
+                older_truncated = False
         else:
-            # Default (before absent): byte-identical to today — most-recent-first ring window.
-            rows = list(reversed(self.scan_history.to_list(clamped)))
-            older_truncated = False
+            # PET-166 (D3/D4): the non-equipped merged read. Read-only, drain-free, four
+            # segments (sink live+rot via read_history_page, spool live and rot via two
+            # explicit read_spool_tail calls — drain_enforcement_events has no .rot
+            # awareness and .rot recovery on the live path unlinks). Nothing here
+            # advances an offset, rotates, unlinks, or appends. Deliberately does NOT
+            # take _history_lock: that lock serializes OUR rotation against OUR drain; a
+            # foreign sink shares no state with either, and taking it would couple an
+            # uncapped foreign read to our own rotation's availability.
+            sink = _history._history_path(scope.resolution)
+            spool = spool_path(scope.resolution)
+            rot = spool_rot_path(scope.resolution)
+
+            # limit=sys.maxsize, NOT 0/-1 (the helper slices those to an empty page).
+            # The sink read is deliberately uncapped — a named residual (D3): its bound
+            # is enforced only by the process bound to that profile.
+            sink_rows, _ = _history.read_history_page(sink, before=None, limit=sys.maxsize)
+            live_ev, trunc_a = read_spool_tail(spool)
+            rot_ev, trunc_b = read_spool_tail(rot)
+            spool_truncated = trunc_a or trunc_b
+
+            # D15: every row on this branch is `foreign` — this process holds no key
+            # for these rows (they may legitimately be signed with another profile's
+            # secret), so verifying here would assert forgery about an innocent file.
+            # _attach_history_provenance is NOT called; the sink row's internal sig is
+            # stripped explicitly. Nothing feeds _integrity_recent or _selfmod_total.
+            merged: list[dict[str, Any]] = []
+            for r in sink_rows:
+                fr = dict(r)
+                fr.pop("sig", None)
+                fr["provenance"] = "foreign"
+                merged.append(fr)
+            merged.extend(_enforcement_summary(e, provenance="foreign") for e in live_ev + rot_ev)
+
+            # D4 step 2: EXACTLY read_history_page's orderability predicate plus its
+            # OverflowError/isfinite guard, so the two branches cannot drift. Rows
+            # failing it are dropped (foreign spools admit any JSON object; a string
+            # timestamp must not 500 a GET).
+            keyed: list[tuple[tuple[float, str], dict[str, Any]]] = []
+            for r in merged:
+                ts = r.get("timestamp")
+                sid = r.get("scan_id")
+                if isinstance(ts, bool) or not isinstance(ts, (int, float)):
+                    continue
+                if not isinstance(sid, str):
+                    continue
+                try:
+                    ts_f = float(ts)
+                except OverflowError:
+                    continue
+                if not math.isfinite(ts_f):
+                    continue
+                keyed.append(((ts_f, sid), r))
+
+            # D4 step 3: dedup by scan_id across the ENTIRE merged set, sink row wins
+            # (sink rows were appended first, so keep-first is sink-wins) — chosen for
+            # determinism, the two sides being equivalent by construction.
+            seen: set[str] = set()
+            deduped: list[tuple[tuple[float, str], dict[str, Any]]] = []
+            for key, r in keyed:
+                if key[1] in seen:
+                    continue
+                seen.add(key[1])
+                deduped.append((key, r))
+            # D4 step 4: the same (timestamp, scan_id) descending order the sink
+            # reader uses.
+            deduped.sort(key=lambda kv: kv[0], reverse=True)
+
+            if malformed:
+                _logger.debug(
+                    "PETASOS_HISTORY malformed before cursor %r; returning empty page", before
+                )
+                rows = []
+                older_truncated = False
+            else:
+                global_oldest = deduped[-1][0] if deduped else None
+                if cursor is not None:
+                    post_filter = [kv for kv in deduped if kv[0] < cursor]
+                else:
+                    post_filter = deduped
+                rows = [r for _, r in post_filter[:clamped]]
+                # D12: has_older is true iff the POST-cursor-filter merged list
+                # exceeded `limit` before the clamp — a different fact from
+                # older_truncated (rotation loss): a head read can be
+                # has_older=True, older_truncated=False.
+                has_older = len(post_filter) > clamped
+                # older_truncated over the MERGED set (the helper's own flag would
+                # report a true bottom whenever the older rows live in the spool).
+                older_truncated = (
+                    cursor is not None
+                    and not rows
+                    and global_oldest is not None
+                    and cursor < global_oldest
+                )
         # next_before = cursor token of the oldest returned row (rows are most-recent-first),
         # or null when the page is empty — so the frontend's first "Older" click off the live
         # head has a cursor without minting one client-side (float-repr parity, edge F-4).
-        next_before = _history_cursor_token(rows[-1]) if rows else None
-        return {"entries": rows, "next_before": next_before, "older_truncated": older_truncated}
+        # PET-166 (D18): scope-bound — prefixed iff a `profile` parameter was sent (equipped
+        # or not), so the embedded console's ordinary case mints what its parser expects.
+        next_before = _history_cursor_token(rows[-1], scope.name) if rows else None
+        payload: dict[str, Any] = {
+            "entries": rows,
+            "next_before": next_before,
+            "older_truncated": older_truncated,
+        }
+        if profile is not None:  # D2/D19: every new key is scope-gated
+            payload["read_scope"] = _read_scope_payload(scope)
+            payload["spool_truncated"] = spool_truncated
+            if scope.state != "equipped":  # D12: merged non-equipped branch only
+                payload["has_older"] = has_older
+        return payload
 
     async def get_profiles(self) -> dict[str, Any]:
         return {"profiles": self.pipeline.list_profiles()}
@@ -1443,16 +1848,34 @@ class ConsoleHandlers:
             ],
         }
 
-    async def get_armed(self) -> dict[str, Any]:
+    async def get_armed(self, profile: str | None = None) -> dict[str, Any]:
         # PET-111: the Equipped/Unequipped master bit. File-backed (petasos.enabled)
         # via the shared _paths resolver — the dashboard reads what the gateway reads.
+        # PET-166 (D1): a scoped read serves the SELECTED profile's bit from its own
+        # config.yaml; the write binding never moves.
         from petasos.console._armed import read_armed
 
-        return {"armed": read_armed()}
+        scope = _resolve_read_scope(profile)
+        self._note_unscoped_read(scope)
+        payload: dict[str, Any] = {"armed": read_armed(scope.resolution)}
+        if profile is not None:  # D2/D19: scope-gated
+            payload["read_scope"] = _read_scope_payload(scope)
+        return payload
 
-    async def set_armed(self, armed: bool) -> tuple[dict[str, Any], bool]:
+    async def set_armed(
+        self, armed: bool, profile: str | None = None
+    ) -> tuple[dict[str, Any], bool]:
         from petasos.console._armed import write_armed
 
+        # PET-166 (D6): arming a non-equipped profile is REFUSED. Raised (not returned
+        # as ok=False) so the routes map it to a 409 BEFORE the ok check — the 503
+        # persistence body must never dress up a deliberate policy refusal. `unknown`
+        # also refuses a NAMED scope: when the equipped path cannot be resolved, a
+        # scoped write cannot be proven to target what the operator sees (D10 step 4).
+        scope = _resolve_read_scope(profile)
+        self._note_unscoped_read(scope)
+        if profile is not None and scope.state != "equipped":
+            raise ProfileNotEquippedError(profile, scope.equipped_name)
         ok = write_armed(armed)
         if ok:
             # PET-116: live cross-tab sync. Broadcast the authoritative value only
@@ -1464,7 +1887,10 @@ class ConsoleHandlers:
             # payload is trivially serializable and broadcast suppresses QueueFull
             # internally over a list() snapshot, so it cannot raise here.
             await self.sse.broadcast("armed", {"armed": armed})
-        return {"armed": armed, "persisted": ok}, ok
+        result: dict[str, Any] = {"armed": armed, "persisted": ok}
+        if profile is not None:  # D2/D19: scope-gated; the {armed, persisted} shape holds
+            result["read_scope"] = _read_scope_payload(scope)
+        return result, ok
 
 
 def _extract_field_from_error(msg: str, body: dict[str, Any]) -> str:
@@ -1700,21 +2126,83 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
             )
 
     @app.get("/api/health")
-    async def api_get_health() -> dict[str, Any]:
-        return await handlers.get_health()
+    async def api_get_health(profile: str | None = None) -> Any:
+        # PET-166 (D7/D8): validates the selector; health itself stays process-scoped.
+        try:
+            return await handlers.get_health(profile=profile)
+        except ProfileNotFoundError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
 
     @app.get("/api/scan-history")
-    async def api_get_scan_history(limit: int = 100, before: str | None = None) -> dict[str, Any]:
+    async def api_get_scan_history(
+        limit: int = 100, before: str | None = None, profile: str | None = None
+    ) -> Any:
         # PET-148: additive `before` cursor for back-pages; absent => today's live window.
-        return await handlers.get_scan_history(limit, before)
+        # PET-166: optional read scope; a non-member 422s, a cross-scope cursor 422s on
+        # `before` (D7/D18).
+        try:
+            return await handlers.get_scan_history(limit, before, profile=profile)
+        except ProfileNotFoundError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
+        except CursorScopeMismatchError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "before", "message": str(exc)}]},
+            )
 
     @app.get("/api/profiles")
     async def api_get_profiles() -> dict[str, Any]:
         return await handlers.get_profiles()
 
     @app.get("/api/events")
-    async def api_events() -> StreamingResponse:
-        q = handlers.sse.subscribe()
+    async def api_events(profile: str | None = None) -> Any:
+        # PET-166 (D7/D9): validation happens BEFORE any stream object is built, so a
+        # failure is an ordinary JSON response, never an error frame inside a
+        # text/event-stream.
+        try:
+            scope = handlers.resolve_events_scope(profile)
+        except ProfileNotFoundError as exc:
+            # Both arguments by keyword, matching every shipped 422 site.
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
+        if scope.state != "equipped":
+            # D9: check here (so the refusal is a JSON 503, not a frame in a stream),
+            # but the slot is acquired INSIDE the generator — a never-started generator
+            # must not hold a slot. scope_refusal is the terminal marker; the
+            # equipped-arm 503 below stays unmarked so the shipped client
+            # retry-then-fallback path is preserved there.
+            if handlers._idle_stream_count >= handlers.sse.max_subscribers:
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "detail": [
+                            {"field": "profile", "message": "idle scope streams at capacity"}
+                        ],
+                        "scope_refusal": "capacity",
+                    },
+                )
+            return StreamingResponse(
+                handlers.idle_scope_stream(scope),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+        try:
+            q = handlers.sse.subscribe()
+        except RuntimeError:
+            # PET-166: today a full subscriber pool 500s out of this route; map it to
+            # an honest 503 (unmarked — the client's shipped retry path is correct here).
+            return JSONResponse(
+                status_code=503,
+                content={"detail": [{"field": "profile", "message": "event stream at capacity"}]},
+            )
         return StreamingResponse(
             handlers.sse.stream(q),
             media_type="text/event-stream",
@@ -1726,11 +2214,30 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
         return await handlers.get_about()
 
     @app.get("/api/armed")
-    async def api_get_armed() -> dict[str, Any]:
-        return await handlers.get_armed()
+    async def api_get_armed(profile: str | None = None) -> Any:
+        try:
+            return await handlers.get_armed(profile=profile)
+        except ProfileNotFoundError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
 
     @app.post("/api/armed")
-    async def api_set_armed(request: Request) -> Any:
+    async def api_set_armed(request: Request, profile: str | None = None) -> Any:
+        # PET-166 (D6): the selector rides in the BODY on a write (the PET-146
+        # update_config precedent). A query-borne selector is itself a 422 — silently
+        # ignoring it would resolve the scope to equipped and disarm the running agent
+        # while the UI names another profile.
+        if profile is not None:
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "detail": [
+                        {"field": "profile", "message": "selector must ride in the request body"}
+                    ]
+                },
+            )
         try:
             body = await request.json()
         except Exception:
@@ -1745,7 +2252,26 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
                 status_code=422,
                 content={"detail": [{"field": "armed", "message": "Must be a boolean"}]},
             )
-        result, ok = await handlers.set_armed(body["armed"])
+        body_profile = body.get("profile")
+        if body_profile is not None and not isinstance(body_profile, str):
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": "Must be a string"}]},
+            )
+        try:
+            result, ok = await handlers.set_armed(body["armed"], profile=body_profile)
+        except ProfileNotFoundError as exc:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
+        except ProfileNotEquippedError as exc:
+            # D6: caught BEFORE the ok check — a policy refusal never wears the 503
+            # persistence body.
+            return JSONResponse(
+                status_code=409,
+                content={"detail": [{"field": "profile", "message": str(exc)}]},
+            )
         if not ok:
             return JSONResponse(
                 status_code=503,

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -175,6 +175,11 @@
 /* PET-13: connection state. Streaming = green LIVE (pulse); SSE-fallback = amber POLLING (steady). */
 .pet .live.polling { color: var(--warn); }
 .pet .live.polling .blip { background: var(--warn); box-shadow: none; animation: none; }
+/* PET-166 (D9): scoped (non-equipped) stream = muted SCOPED with a static blip. A
+   deliberate state, not an outage, so NOT --warn; and never the LIVE green or its
+   pulsing dot, which would keep saying "live" on a permanently silent connection. */
+.pet .live.scoped { color: var(--tx-faint); }
+.pet .live.scoped .blip { background: var(--tx-faint); box-shadow: none; animation: none; }
 /* PET-13: protection-weakening Apply confirm — mirrors the disarm banner's amber confirm register. */
 .pet .btn-primary.confirm-weaken { background: var(--med-soft); color: var(--warn); border-color: var(--warn); }
 
@@ -437,6 +442,9 @@
 .pet .sd-prov-genuine { color: var(--ok); border-color: rgba(63,185,80,.3); background: var(--ok-soft); }
 .pet .sd-prov-unverifiable { color: var(--warn); border-color: rgba(232,177,58,.3); background: var(--med-soft); }
 .pet .sd-prov-unattested { color: var(--tx-faint); }
+/* PET-166 (D15): rows read from a profile this dashboard is not bound to. Muted like
+   unattested, never the warn tone: this is not a tamper signal. */
+.pet .sd-prov-foreign { color: var(--tx-faint); }
 .pet .sd-section { font-size: 10px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--tx-faint); margin-top: 4px; }
 .pet .sd-field { display: flex; gap: 8px; align-items: baseline; font-size: 12px; }
 .pet .sd-k { flex: 0 0 84px; color: var(--tx-faint); }

--- a/petasos/console/static/petasos.css
+++ b/petasos/console/static/petasos.css
@@ -177,9 +177,11 @@
 .pet .live.polling .blip { background: var(--warn); box-shadow: none; animation: none; }
 /* PET-166 (D9): scoped (non-equipped) stream = muted SCOPED with a static blip. A
    deliberate state, not an outage, so NOT --warn; and never the LIVE green or its
-   pulsing dot, which would keep saying "live" on a permanently silent connection. */
-.pet .live.scoped { color: var(--tx-faint); }
-.pet .live.scoped .blip { background: var(--tx-faint); box-shadow: none; animation: none; }
+   pulsing dot, which would keep saying "live" on a permanently silent connection.
+   --tx-mut, not --tx-faint: the chip is a status readout, so it must clear WCAG
+   1.4.3 (4.5:1) against the pane header; faint's 65% alpha lands near 2.25:1. */
+.pet .live.scoped { color: var(--tx-mut); }
+.pet .live.scoped .blip { background: var(--tx-mut); box-shadow: none; animation: none; }
 /* PET-13: protection-weakening Apply confirm — mirrors the disarm banner's amber confirm register. */
 .pet .btn-primary.confirm-weaken { background: var(--med-soft); color: var(--warn); border-color: var(--warn); }
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -339,10 +339,25 @@
     // past the oldest seeded row, so the first "Older" click skipped the band between the current
     // oldest buffered row and the stale boundary. The head boundary is now re-minted via a fresh
     // server round-trip on every head->older transition, and the "Older" affordance off the head
-    // gates on scanHistoryHasOlder(buffered, scans_total). The single "of N" total stays
-    // /health.scans_total (D-RESTART); paged views never compute a competing total.
+    // gates on scanHistoryHasOlder(buffered, scans_total) on the equipped branch; a
+    // non-equipped scope reads the server's has_older (PET-166 D12). The single "of N"
+    // total stays /health.scans_total (D-RESTART); paged views never compute a competing total.
     historyAtHead: true,
     historyStack: [],
+    // PET-166 (D19): payload-derived read-scope facts. readScope is the cross-surface
+    // scope object (null = the equipped form; all of standalone stays null);
+    // historyReadScope is the history panel's OWN copy, written only by scan-history
+    // 200s, because its two facts arrive on different endpoints. historyHasOlder is
+    // the server-emitted "Older" gate for the non-equipped branch; spoolTruncated is
+    // the D3 retention fact; scopeError is the D7 coherent 422 state; scopeNotice is
+    // the D20 "showing: equipped binding" client notice. All reset on scope change
+    // and unmount (D17).
+    readScope: null,
+    historyReadScope: null,
+    historyHasOlder: false,
+    spoolTruncated: false,
+    scopeError: null,
+    scopeNotice: false,
     // PET-138: session_id -> cumulative count of tool calls bypassed while disarmed.
     // Dedicated, eviction-proof state (the count rides a single rate-limited
     // heartbeat row that ages out of scanHistory); fed by Pet.accrueBypass.
@@ -456,6 +471,9 @@
       Pet.state.authRequired = true;
       stopPolling();
       stopFallbackPolling();
+      // PET-166 (D3): the scoped 30 s poll stops with the other transports; the gate
+      // in _syncScopePoll reads authRequired, so this clears the singleton timer.
+      if (typeof _syncScopePoll === "function") _syncScopePoll();
       if (Pet.sse) Pet.sse.disconnect(); // aborts SSE, resets _usingFallback, stops the fallback poll
       _armedSeeded = false;   // force a re-seed from server truth after re-auth (edge F-3)
       _historySeeded = false; // ditto for the scan-history buffer
@@ -575,15 +593,51 @@
     _put: function (path, body) {
       return this._req(path, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
     },
+    // PET-166 (D10): the ONE derivation of the read scope the client sends. Empty
+    // string means "omit the parameter entirely" — all of standalone (source "none"),
+    // and an embedded host reporting no named profile, send nothing. The sole source
+    // is Pet.state.selectedHermesProfile (two writers, host path + in-console picker);
+    // reading hostProfile.profile directly would be a second derivation that diverges
+    // under the picker.
+    _scopeParam: function () {
+      if (!Pet.hostProfile || Pet.hostProfile.source === "none") return "";
+      var v = Pet.state.selectedHermesProfile;
+      return String(v == null ? "" : v).trim();
+    },
     getConfig: function (profile) { return this._get("/config" + (profile ? ("?profile=" + encodeURIComponent(profile)) : "")); },
     putConfig: function (patch) { return this._put("/config", patch); },
+    // postScan is deliberately NOT scoped (D10): a playground scan is a write against
+    // the equipped binding; the playground renders a note instead.
     postScan: function (text, dir, sid) { return this._post("/scan", { text: text, direction: dir, session_id: sid }); },
-    getHealth: function () { return this._get("/health"); },
-    getScanHistory: function (limit, before) { return this._get("/scan-history?limit=" + (limit || 100) + (before ? "&before=" + encodeURIComponent(before) : "")); },
+    getHealth: function () {
+      var p = this._scopeParam();
+      return this._get("/health" + (p ? "?profile=" + encodeURIComponent(p) : ""));
+    },
+    // PET-166 (D10): profile ALWAYS joins with "&" here — the path already carries
+    // "?limit=", so a "?profile=" append would parse as part of the before value (or
+    // limit) and silently fall back to the equipped scope on the primary surface.
+    getScanHistory: function (limit, before) {
+      var p = this._scopeParam();
+      return this._get("/scan-history?limit=" + (limit || 100)
+        + (before ? "&before=" + encodeURIComponent(before) : "")
+        + (p ? "&profile=" + encodeURIComponent(p) : ""));
+    },
     getProfiles: function () { return this._get("/profiles"); },
     getAbout: function () { return this._get("/about"); },
-    getArmed: function () { return this._get("/armed"); },
-    setArmed: function (a) { return this._post("/armed", { armed: a }); },
+    getArmed: function () {
+      var p = this._scopeParam();
+      return this._get("/armed" + (p ? "?profile=" + encodeURIComponent(p) : ""));
+    },
+    // PET-166 (D6): the write's selector rides in the BODY (never the query — the
+    // server 422s a query-borne one). opts.unscoped sends no selector: D16's
+    // equipped-name-null and unknown-binding states arm the process binding directly.
+    setArmed: function (a, opts) {
+      opts = opts || {};
+      var body = { armed: a };
+      var p = opts.unscoped ? "" : this._scopeParam();
+      if (p) body.profile = p;
+      return this._post("/armed", body);
+    },
   };
 
   // ── SSE client (fetch-based for auth header support) ──
@@ -599,6 +653,8 @@
     _reader: null,
     _abortCtrl: null,
     _usingFallback: false,        // D8: "polling is currently active" — true during transient backoff AND terminal concede
+    _scopeLive: true,             // PET-166 D9: false while the open stream is the idle (non-equipped) one
+    _scopeRefusal: null,          // PET-166 D9: "profile" | "capacity" | null — why a terminal refusal downgraded the chip
     _reconnectTimer: null,        // pending reconnect setTimeout handle, or null
     _reconnectAttempts: 0,        // consecutive failed attempts since the last durable stream
     _healthyTimer: null,          // pending durable-reset setTimeout handle (D11), or null
@@ -620,7 +676,18 @@
       var self = this;
       var gen = (self._gen += 1);                    // D12: this connection's generation
       if (self._abortCtrl) self._abortCtrl.abort();  // defensive; inert on the reconnect path (disconnect nulled it)
+      // PET-166 (D9): the reset point lives HERE, not in connect() — _scheduleReconnect
+      // calls _openStream directly (bypassing connect), and with the reset in connect()
+      // only, a reconnect landing on an equipped stream would leave the chip reading
+      // SCOPED over a live stream forever (the read_scope frame that clears it is
+      // emitted only on the non-equipped stream). Repainted before the fetch resolves.
+      self._scopeLive = true;
+      self._scopeRefusal = null;
+      if (Pet.updateConnStatus) Pet.updateConnStatus();
+      if (typeof _syncScopePoll === "function") _syncScopePoll();
       var url = Pet.api.baseUrl + "/events";
+      var _sp = Pet.api._scopeParam();
+      if (_sp) url += "?profile=" + encodeURIComponent(_sp);
       var headers = { "Accept": "text/event-stream" };
       // PET-129 D1/D5 (edge F-7): sse.connect is the single SSE client for both modes,
       // so exactly ONE credential is attached, keyed on the SAME embedded predicate as
@@ -651,6 +718,36 @@
           // reject or a non-401 non-ok status) still throws below -> the .catch keeps
           // PET-142's bounded-backoff reconnect, so the live/polling indicator is intact.
           if (resp.status === 401) { Pet.auth.on401({ _status: 401 }); return; }
+          // PET-166 (D9): a 422 (profile deleted between renders, D7) is TERMINAL —
+          // no reconnect, no fallback — and must itself downgrade the chip, because
+          // no stream opens so the read_scope frame that would clear _scopeLive
+          // never arrives. Same for the idle-arm 503 below, which is discriminated
+          // by its scope_refusal:"capacity" body marker; an UNMARKED 503 (the
+          // equipped stream's subscriber-cap refusal) keeps the shipped
+          // retry-then-fallback path.
+          if (resp.status === 422) {
+            self._scopeLive = false;
+            self._scopeRefusal = "profile";
+            if (Pet.updateConnStatus) Pet.updateConnStatus();
+            if (typeof _syncScopePoll === "function") _syncScopePoll();
+            return;
+          }
+          if (resp.status === 503) {
+            resp.json().then(function (b) {
+              if (gen !== self._gen) return;
+              if (b && b.scope_refusal === "capacity") {
+                self._scopeLive = false;
+                self._scopeRefusal = "capacity";
+                if (Pet.updateConnStatus) Pet.updateConnStatus();
+                if (typeof _syncScopePoll === "function") _syncScopePoll();
+                return;                        // terminal: an idle stream refused for capacity is not an outage
+              }
+              self._scheduleReconnect();       // unmarked 503: shipped retry-then-fallback
+            }).catch(function () {
+              if (gen === self._gen) self._scheduleReconnect();
+            });
+            return;
+          }
           if (!resp.ok) throw new Error(resp.status);
           if (!resp.body) throw new Error("no response body");
           var reader = resp.body.getReader();
@@ -794,6 +891,19 @@
       } else if (evType === "alert") {
         Pet.state.alerts.unshift(d);
         if (Pet.state.alerts.length > 200) Pet.state.alerts.length = 200;
+      } else if (evType === "read_scope") {
+        // PET-166 (D9/D19): the idle (non-equipped) stream's first frame. live:false
+        // downgrades the chip to SCOPED and starts the D3 scoped poll; the frame
+        // carries exactly the read_scope object, so it is adopted as-is.
+        if (d && typeof d === "object") {
+          Pet.state.readScope = d;
+          if (d.live === false) {
+            this._scopeLive = false;
+            this._scopeRefusal = null;
+            if (Pet.updateConnStatus) Pet.updateConnStatus();
+            if (typeof _syncScopePoll === "function") _syncScopePoll();
+          }
+        }
       } else if (evType === "armed") {
         // PET-116: live cross-tab sync of the Equipped/Unequipped bit. _dispatch
         // cannot call paintBanner (a renderDashboard-local closure); it adopts the
@@ -840,10 +950,21 @@
   function startPolling() {
     if (_pollInterval) return;
     _pollInterval = setInterval(function () {
+      var gen = _scopeGen; // PET-166 D17: captured at send time
       Pet.api.getHealth().then(function (d) {
-        if (Pet.auth.on401(d)) return; // PET-129 D3/D4: first statement; a 401 stops the poll, never an empty-success no-op
+        if (Pet.auth.on401(d)) return; // PET-129 D3/D4/§1: first statement; a 401 stops the poll, never an empty-success no-op
+        if (gen !== _scopeGen) return; // PET-166: superseded scope
+        if (Pet.isProfile422(d)) {
+          // PET-166 D7: a 422 body carries no `error`; without this branch the shape
+          // gate below would wipe the health/integrity panels every 10 s.
+          var e0 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
+          Pet.state.scopeError = { surface: "health", message: (e0 && e0.message) || "profile not found" };
+          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+          return;
+        }
         if (!d.error) {
           _healthLoaded = true;  // PET-127: a poll settle that beats a slow in-render fetch flips the gate, not the skeleton
+          _adoptReadScope(d);    // PET-166 D19: health 200s are a readScope writer
           Pet.state.scannerHealth = d.scanners || [];
           Pet.state.pipelineHealth = d.pipeline || null;
           Pet.state.integrityHealth = d.integrity || null; // PET-157: mirror pipelineHealth (recurring poll)
@@ -859,32 +980,158 @@
 
   function startFallbackPolling() {
     if (_fallbackPollInterval) return;
+    function onHistory(d) {
+      if (Pet.auth.on401(d)) return; // PET-129 D4: on401 nulls _fallbackPollInterval before the reschedule .then runs, so the re-arm below no-ops
+      if (_scopeGuardHistory(d)) return; // PET-166 D7/D17: gen drop + coherent 422 state
+      if (!d.error && d.entries && Array.isArray(d.entries)) {
+        Pet.state.scanHistory = d.entries;
+        Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
+        _adoptHistoryScope(d);       // PET-166 D19: fallback assignments are writer sites too
+        if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+      }
+    }
     function schedule() {
       _fallbackPollInterval = setTimeout(function () {
-        Pet.api.getScanHistory(100).then(function (d) {
-          if (Pet.auth.on401(d)) return; // PET-129 D4: on401 nulls _fallbackPollInterval before the reschedule .then runs, so the re-arm below no-ops
-          if (!d.error && d.entries && Array.isArray(d.entries)) {
-            Pet.state.scanHistory = d.entries;
-            Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
-            if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
-          }
-        }).then(function () {
+        Pet.api.getScanHistory(100).then(onHistory).then(function () {
           if (_fallbackPollInterval) schedule();
         });
       }, 10000);
     }
-    Pet.api.getScanHistory(100).then(function (d) {
-      if (Pet.auth.on401(d)) return; // PET-129 D4: a 401 on the initial fallback read enters the authenticate state
-      if (!d.error && d.entries && Array.isArray(d.entries)) {
-        Pet.state.scanHistory = d.entries;
-        Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
-        if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
-      }
-    });
+    Pet.api.getScanHistory(100).then(onHistory);
     schedule();
   }
   function stopFallbackPolling() {
     if (_fallbackPollInterval) { clearTimeout(_fallbackPollInterval); _fallbackPollInterval = null; }
+  }
+
+  // ── PET-166: read-scope plumbing (D3/D17/D19/D20) ──
+
+  // Scope generation: bumped on every scope change (either axis); captured by every
+  // scoped fetch at send time so a superseded resolve is dropped (_cfgRenderGen pattern
+  // extended to all five new surfaces).
+  var _scopeGen = 0;
+
+  // D3: the 30 s scoped history poll. A SINGLETON with an idempotent start (the
+  // startFallbackPolling / _scheduleReconnect guard pattern): a scope change re-uses
+  // the running timer rather than starting a second — the poll is keyed on "a foreign
+  // scope is on screen", not on which profile it is. Gate: !_scopeLive || foreign.
+  // Keyed on the stream's own liveness as well as the scope so the SDK-fallback
+  // equipped flip (which triggers no rebind and no reconnect) cannot strand a frozen
+  // panel: the poll keeps running until a stream that is actually live replaces the
+  // idle one. The hoisted server drain rides every one of these calls, keeping our
+  // own fold and rotation alive while parked on a foreign profile.
+  var _scopePollTimer = null;
+  var _SCOPE_POLL_MS = 30000;
+  function _syncScopePoll() {
+    var want = !Pet.state.authRequired
+      && Pet.hostProfile && Pet.hostProfile.source !== "none"
+      && (!(Pet.sse && Pet.sse._scopeLive) || Pet.isForeignScope());
+    if (!want) {
+      if (_scopePollTimer) { clearInterval(_scopePollTimer); _scopePollTimer = null; }
+      return;
+    }
+    if (_scopePollTimer) return; // singleton: one timer regardless of switch count
+    _scopePollTimer = setInterval(function () {
+      var gen = _scopeGen;
+      Pet.api.getScanHistory(100).then(function (d) {
+        if (Pet.auth.on401(d)) return;            // PET-129 §1: on401 first, always
+        if (gen !== _scopeGen) return;            // superseded scope: drop
+        if (_scopeGuardHistory(d)) return;
+        if (!d.error && d.entries && Array.isArray(d.entries)) {
+          Pet.state.scanHistory = d.entries;
+          Pet.accrueBypass(d.entries);
+          _adoptHistoryScope(d);
+          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+        }
+      });
+    }, _SCOPE_POLL_MS);
+  }
+
+  // D19: adopt a scan-history 200's scope facts. Called from ALL FOUR scan-history
+  // writer sites (mount seed, both fallback assignments, the 30 s scoped poll) —
+  // never a subset. "Believes it scoped" is derived per call from the same
+  // _scopeParam the request was built with (the request and this adoption run
+  // within one scope generation; a moved generation was dropped above).
+  function _adoptHistoryScope(d) {
+    if (!d || typeof d !== "object") return;
+    var sentScoped = Pet.api._scopeParam() !== "";
+    var rs = d.read_scope;
+    if (rs && typeof rs === "object") {
+      Pet.state.readScope = rs;
+      // Written on EVERY carrying 200, equipped included — a label that can only
+      // hold a foreign value has no way back to equipped (D19).
+      Pet.state.historyReadScope = rs;
+      Pet.state.spoolTruncated = d.spool_truncated === true;
+      if (rs.state !== "equipped" && typeof d.has_older === "boolean") {
+        Pet.state.historyHasOlder = d.has_older; // non-equipped writer only (D12)
+      }
+      if (sentScoped) Pet.state.scopeNotice = rs.selected == null; // D20 (defensive arm)
+    } else if (sentScoped) {
+      // A 200 the client believes it scoped that carries no read_scope clears the
+      // fields (stale backend / bundle skew) and raises the D20 notice.
+      Pet.state.readScope = null;
+      Pet.state.historyReadScope = null;
+      Pet.state.spoolTruncated = false;
+      Pet.state.historyHasOlder = false;
+      Pet.state.scopeNotice = true;
+    }
+    Pet.state.scopeError = null; // a 200 on this surface clears the D7 error state
+    _syncScopePoll();
+  }
+
+  // D19: the health/armed flavor of the adoption above (those payloads carry only
+  // read_scope). Only 200s call this; a 422/409/503 leaves readScope untouched.
+  function _adoptReadScope(d) {
+    if (!d || typeof d !== "object") return;
+    var sentScoped = Pet.api._scopeParam() !== "";
+    if (d.read_scope && typeof d.read_scope === "object") {
+      Pet.state.readScope = d.read_scope;
+      if (sentScoped) Pet.state.scopeNotice = d.read_scope.selected == null;
+    } else if (sentScoped) {
+      Pet.state.readScope = null;
+      Pet.state.scopeNotice = true;
+    }
+    Pet.state.scopeError = null;
+    _syncScopePoll();
+  }
+
+  // D7: shared 422 branch for the scoped readers. Sets the ONE coherent error state
+  // (never four independent error boxes) and reports true so the caller returns
+  // before its shape-guarded body can wipe healthy panels with a detail-only body.
+  function _scopeGuardHistory(d) {
+    if (!Pet.isProfile422(d)) return false;
+    var e0 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
+    Pet.state.scopeError = { surface: "scan-history", message: (e0 && e0.message) || "profile not found" };
+    if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+    return true;
+  }
+
+  // D17: invalidate every scoped surface on a host-profile change, on EITHER axis
+  // (management selection or equipped flip). Pet.state.armed deliberately does NOT
+  // reset (a null paints a false EQUIPPED); Pet.state.historyFilter deliberately
+  // survives (a view preference, not profile data).
+  function _invalidateScopeState() {
+    _scopeGen++;
+    _historySeeded = false;
+    _armedSeeded = false;
+    _historyPaging = false;
+    _historyPagingGen++;         // drop an in-flight PET-152 two-fetch re-mint chain
+    clearArmedConfirm();         // a confirm window formed about the previous profile
+    Pet.state.scanHistory = [];
+    Pet.state.bypassBySession = {};
+    Pet.state.historyStack = [];
+    Pet.state.historyAtHead = true;
+    Pet.state.readScope = null;           // null = the equipped form until the first 200 lands
+    Pet.state.historyReadScope = null;
+    Pet.state.historyHasOlder = false;
+    Pet.state.spoolTruncated = false;
+    Pet.state.scopeError = null;
+    Pet.state.scopeNotice = false;
+    if (!Pet.state.authRequired) {
+      Pet.sse.connect();         // disconnect + reconnect with the new scope, exactly once
+    }
+    _syncScopePoll();
+    if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
   }
 
   // PET-129 D4: read-only testability seam over the module-private poll timers
@@ -900,6 +1147,14 @@
   };
   // Convenience alias for the read-only probe (some call sites reference Pet._pollState).
   Pet._pollState = Pet._poll.state;
+
+  // PET-166: read-only testability seam over the IIFE-private armed latches (the
+  // PET-129 D4 poll-timer seam pattern: exposes state, adds no behavior), plus the
+  // scoped-poll probe so js/scope-poll-is-singleton can count timers.
+  Pet._armedTestState = function () {
+    return { busy: _armedBusy, seeded: _armedSeeded, confirmPending: _armedConfirmPending };
+  };
+  Pet._scopePollState = function () { return { running: !!_scopePollTimer }; };
 
   // ── Surface renderers ──
 
@@ -1160,8 +1415,11 @@
       // "genuine" / "unverifiable" map through — an absent / non-string / unknown value
       // renders as "unattested" (not a crash, not a false "genuine"), gated the way the
       // PET-138 bypassed_count path guards its input. No-em-dash house style for the copy.
+      // PET-166 (D15): `foreign` joins the map — rows read from a profile this
+      // dashboard is not bound to, signed with a key we do not hold. Muted copy,
+      // never tamper copy; an unknown value still collapses to unattested.
       var prv = e.provenance;
-      var provState = (prv === "genuine" || prv === "unverifiable") ? prv : "unattested";
+      var provState = (prv === "genuine" || prv === "unverifiable" || prv === "foreign") ? prv : "unattested";
       var attClass, attText;
       if (provState === "genuine") {
         attClass = "sd-prov-att sd-prov-genuine";
@@ -1169,6 +1427,9 @@
       } else if (provState === "unverifiable") {
         attClass = "sd-prov-att sd-prov-unverifiable";
         attText = "Unverified: signature missing or invalid; this row may not be a genuine Petasos decision.";
+      } else if (provState === "foreign") {
+        attClass = "sd-prov-att sd-prov-foreign";
+        attText = "Signed by another profile's key; not verifiable from here.";
       } else {
         attClass = "sd-prov-att sd-prov-unattested";
         attText = "Integrity not configured: no signing key is set, so this row cannot be attested.";
@@ -1588,6 +1849,181 @@
     return Number.isFinite(b) && Number.isFinite(t) && b > 0 && t > b;
   };
 
+  // ── PET-166: read-scope pure seams ──
+  // Every one of these is pure over its arguments (no DOM, no network), matching the
+  // discipline of every other history label in this file, and for the same stated
+  // reason: no tests/js module drives renderDashboard, so a decision living inline
+  // at the render site would be unassertable.
+
+  // D19: THE one non-equipped predicate. Zero-arg form reads Pet.state.readScope; the
+  // history panel passes Pet.state.historyReadScope explicitly (its facts arrive on a
+  // different endpoint). null/undefined (all of standalone; the pre-first-200 window)
+  // is the equipped form — never a bare .state dereference anywhere else.
+  Pet.isForeignScope = function (scope) {
+    if (arguments.length === 0) scope = Pet.state.readScope;
+    return !!scope && scope.state !== "equipped";
+  };
+
+  // D7: the shared "is this a scoped-profile 422" test. Status-keyed (a 422 body
+  // carries no `error`, so the readers' `!d.error` gates would treat it as an empty
+  // success and wipe healthy panels). Checked AFTER Pet.auth.on401 in every reader.
+  Pet.isProfile422 = function (d) {
+    return !!(d && d._status === 422 && Array.isArray(d.detail)
+      && d.detail.some(function (e) { return e && e.field === "profile"; }));
+  };
+
+  // D12: staleness derived client-side from the newest row of the UNFILTERED head
+  // buffer. Returns null (age clause dropped) for no rows or a non-numeric
+  // timestamp; a future timestamp clamps to "just now" rather than taking the fresh
+  // branch off a bogus negative age. { label, stale } with stale at >= 1 h.
+  Pet.scanHistoryAge = function (rows) {
+    if (!rows || !rows.length) return null;
+    var r = rows[0];
+    var ts = (r && typeof r === "object") ? r.timestamp : null;
+    if (typeof ts !== "number" || !isFinite(ts)) return null;
+    var age = (Date.now() / 1000) - ts;
+    if (age < 0) age = 0; // skewed profile clocks: clamp, never a negative "freshest" age
+    var d = new Date(ts * 1000);
+    var hh = ("0" + d.getHours()).slice(-2), mm = ("0" + d.getMinutes()).slice(-2);
+    var ago;
+    if (age < 60) ago = "just now";
+    else if (age < 3600) ago = Math.floor(age / 60) + "m ago";
+    else if (age < 86400) ago = Math.floor(age / 3600) + "h ago";
+    else ago = Math.floor(age / 86400) + "d ago";
+    return { label: "newest " + hh + ":" + mm + " (" + ago + ")", stale: age >= 3600 };
+  };
+
+  // D12: the scoped subtitle seam beside the shipped scanHistorySubtitle (whose
+  // two-argument signature is deliberately NOT widened). `body` is a string, not a
+  // count, so one seam mints both foreign forms: "showing last 12" at head and the
+  // historyPageLabel when paged. It emits the trailing self-tamper clause ITSELF
+  // from filterOn — the render site skips PET-165's append on the seam arms so the
+  // clause can never render twice.
+  Pet.scopedHistorySubtitle = function (body, profileName, ageLabel, stale, filterOn) {
+    var s = String(body == null ? "" : body) + " for " + String(profileName == null ? "" : profileName);
+    if (ageLabel) s += " · " + ageLabel;
+    if (stale) s += " · stale";
+    if (filterOn) s += " · self-tamper only";
+    return s;
+  };
+
+  // D12: the foreign "Older" gate. Keeps scanHistoryHasOlder's b > 0 term (a
+  // transiently-empty buffer is a per-switch event now, and paging off it re-mints
+  // from the Nth-newest row and silently omits the head band — PET-152 E-2/E-4);
+  // only the total moves to the server-emitted has_older boolean.
+  Pet.scopedHistoryHasOlder = function (bufferLength, hasOlder) {
+    var b = Number(bufferLength);
+    return Number.isFinite(b) && b > 0 && hasOlder === true;
+  };
+
+  // D12: the empty-state ladder, PET-165's arm order preserved exactly with one new
+  // arm appended and scope-aware copy inside. Returns { arm, text } when the render
+  // site should print an empty-state body, and null when it should call
+  // Pet.scanHistoryRows — null for arm 4 AND arm 3's equipped branch, which is what
+  // keeps the "no scans yet" literal owned solely by scanHistoryRows. The !histPaged
+  // guard on arm 3 is load-bearing: while paged, the live buffer emptying underneath
+  // must not replace fetched rows with an empty-state sentence (PET-148).
+  Pet.historyEmptyState = function (hist, histRowsData, histPaged, histEffFilter, isForeign, profileName) {
+    hist = hist || [];
+    histRowsData = histRowsData || [];
+    if (histPaged && histRowsData.length === 0) {
+      return { arm: 1, text: Pet.historyPageLabel(histPaged) }; // positional, never named (D12)
+    }
+    if (histEffFilter === "selfmod" && histRowsData.length === 0) {
+      if (isForeign) {
+        if (hist.length === 0) {
+          // the filter is not why anything is missing; the copy is arm 3's
+          return { arm: 3, text: "no scans retained for " + String(profileName || "") };
+        }
+        return { arm: 2, text: "no self-tamper events among the rows retained for " + String(profileName || "") };
+      }
+      return { arm: 2, text: "No self-tamper events in the buffered window." }; // PET-165 verbatim
+    }
+    if (!histPaged && hist.length === 0 && isForeign) {
+      return { arm: 3, text: "no scans retained for " + String(profileName || "") };
+    }
+    return null;
+  };
+
+  // D8: the self-tamper tile keeps its value under a foreign scope and RELABELS to
+  // name the binding it counts — it is a lifetime fact about the process that is
+  // actually enforcing, and suppressing it would hide a live security signal to
+  // avoid a labelling problem. The HelpTip is amended in the same seam because
+  // "the scan history below" is another profile's file under a foreign scope.
+  Pet.selfmodTileLabel = function (isForeign) {
+    if (isForeign) {
+      return {
+        label: "self-tamper (this dashboard's binding)",
+        help: "<b>Self-tamper</b>: tool calls that tried to write or read Petasos's own config, profile homes, or enforcement spool. Counted since this console started, for the profile this dashboard is bound to; the scan history below shows the selected profile instead. Detection only: these calls were not blocked.",
+      };
+    }
+    return {
+      label: "self-tamper",
+      help: "<b>Self-tamper</b>: tool calls that tried to write or read Petasos's own config, profile homes, or enforcement spool. Counted since this console started, so it does not fall when older rows age out of the scan history below. Detection only: these calls were not blocked.",
+    };
+  };
+
+  // D9: the connection chip's three-state decision, in a fixed order: POLLING
+  // outranks SCOPED (a dead connection is the more urgent fact), else SCOPED, else
+  // LIVE. The refusal titles never name the refused profile — the SCOPED tooltip
+  // must not assert a scoped read of a name the server just declined to resolve.
+  Pet.connChipView = function (usingFallback, scopeLive, refusal) {
+    if (usingFallback) {
+      return { className: "live polling", label: "POLLING", title: "Live stream unavailable; polling every 10s." };
+    }
+    if (!scopeLive) {
+      var title;
+      if (refusal === "profile") title = "live stream refused: profile not found";
+      else if (refusal === "capacity") title = "live stream refused: event stream at capacity";
+      else {
+        var sel = Pet.state.selectedHermesProfile;
+        title = "Viewing " + (sel ? String(sel) : "another profile") + "; live events stream only for the equipped profile. History refreshes every 30s.";
+      }
+      return { className: "live scoped", label: "SCOPED", title: title };
+    }
+    return { className: "live", label: "LIVE", title: "Live updates streaming." };
+  };
+
+  // D10: the playground note decision. A playground scan runs through the live
+  // pipeline (a write against the equipped binding), so a foreign read scope gets a
+  // one-line note instead of a result that never appears in the panel below.
+  Pet.playgroundScopeNote = function (scope) {
+    return Pet.isForeignScope(scope)
+      ? "this scan ran against the equipped binding; it will not appear in the selected profile's history"
+      : null;
+  };
+
+  // D17: the armed-write resolution decision (the PET-129 D3 bannerView extraction
+  // pattern: the decision is a pure seam, paintBanner stays the render-local
+  // painter). The caller clears _armedBusy FIRST and routes 401 SECOND; this seam
+  // then decides. On a moved scope generation it says drop-and-re-read: never
+  // reconcile the stale optimistic bit, never banner the prior scope's message.
+  Pet.armedWriteView = function (ctx) {
+    ctx = ctx || {};
+    var d = ctx.response || {};
+    if (ctx.scopeMoved) {
+      return { action: "drop", armedSeeded: false, banner: null, reread: true };
+    }
+    if (d._status === 409) {
+      var e0 = Array.isArray(d.detail) ? d.detail[0] : null;
+      return {
+        action: "refused", armedSeeded: false, reread: true,
+        banner: (e0 && e0.message) || "arming refused: not the equipped profile",
+        armed: !ctx.next, // revert the optimistic bit; the re-read lands server truth
+      };
+    }
+    if (Pet.isProfile422(d)) {
+      var e1 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
+      return {
+        action: "rejected", armedSeeded: false, reread: true,
+        banner: (e1 && e1.message) || "profile rejected",
+        armed: !ctx.next,
+      };
+    }
+    var ok = d && !d.error && (!d._status || d._status < 400) && typeof d.armed === "boolean";
+    return { action: "reconcile", armedSeeded: true, banner: null, reread: false, armed: ok ? d.armed : !ctx.next };
+  };
+
   // PET-148: positional label for a paged-back history view (D-RESTART). NEVER a numeric
   // total — the only "of N" headline anywhere stays scanHistorySubtitle (scans_total from
   // /health). An empty page is retention-honest: "no older retained history" when the
@@ -1816,9 +2252,21 @@
       var mark = b.querySelector(".equip-mark");
       if (mark) mark.src = Pet.asset(view.on ? "img/petasos-equipped.png" : "img/petasos-unequipped.png");
     };
+    // PET-166 (D16): the arm control is the ONE consumer that reads scope state
+    // directly (it discriminates three states, not two), through a null guard so the
+    // absent case (all of standalone) takes the ordinary equipped affordance.
+    var _armScope = Pet.state.readScope || {};
+    var _armSt = _armScope.state;
+    var _armDisabled = _armSt === "not_equipped" && _armScope.equipped != null;
+    // equipped_name null (a HERMES_HOME/root binding outside profiles/) or an
+    // unresolvable equipped path: keep the toggle ENABLED but send NO scope — an
+    // unscoped arm targets the process binding, the only arming target that exists.
+    var _armUnscoped = (Pet.state.readScope != null)
+      && (_armSt === "unknown" || _armScope.equipped == null);
     var doToggle = function () {
       if (Pet.state.authRequired) return; // PET-129 D3: no toggling (or EQUIPPED repaint) while unauthenticated
       if (_armedBusy) return;  // ignore rapid re-clicks while a write is in flight
+      if (_armDisabled) return; // PET-166 D6/D16: arming a non-equipped profile is refused client-side too
       var on = Pet.state.armed !== false;
       // Disarming is the high-stakes direction: require a confirming 2nd click.
       // Arming protection back ON stays one click.
@@ -1831,16 +2279,44 @@
       clearArmedConfirm();
       var next = !on;
       _armedBusy = true;
+      var gen = _scopeGen; // PET-166 D17: captured at send time, checked at resolve
       Pet.state.armed = next; paintBanner();  // optimistic (live re-query, survives re-render)
-      Pet.api.setArmed(next).then(function (d) {
+      Pet.api.setArmed(next, { unscoped: _armUnscoped }).then(function (d) {
+        // PET-166 D17: the order below is the deliverable. (1) the latch clears
+        // unconditionally — a return above this line strands the toggle dead for the
+        // rest of the mount; (2) 401 enters the authenticate state even on a
+        // superseded scope (PET-129 §1); (3) the scope-generation drop; (4) reconcile.
         _armedBusy = false; // cleared on EVERY path (incl. the 401 route below) so re-auth can re-seed
-        // PET-129 D3: a toggle that 401s also enters the authenticate state (on401
-        // already re-renders); route it through the chokepoint before reconciling.
         if (Pet.auth.on401(d)) return;
-        _armedSeeded = true;  // a settled write IS a fresh seed -> no spurious follow-up GET
-        var ok = d && !d.error && (!d._status || d._status < 400) && typeof d.armed === "boolean";
-        Pet.state.armed = ok ? d.armed : !next;  // reconcile to authoritative value, else revert
-        paintBanner();
+        var view = Pet.armedWriteView({ scopeMoved: gen !== _scopeGen, response: d, next: next });
+        _armedSeeded = view.armedSeeded;
+        if (view.action === "drop") {
+          // leave the re-seed to the render path (:re-seed guard) so the new scope's
+          // bit is re-read from the server rather than inherited or reconciled.
+          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+          return;
+        }
+        if (view.armed !== undefined) Pet.state.armed = view.armed;
+        if (view.banner) {
+          // D16/D6: render the refusal in the banner sub line and announce for AT.
+          var subEl = _container && _container.querySelector(".equip-banner .equip-sub");
+          if (subEl) subEl.textContent = view.banner;
+          if (Pet.announce) Pet.announce(view.banner);
+        } else {
+          paintBanner();
+        }
+        if (view.reread) {
+          Pet.api.getArmed().then(function (rd) {
+            if (Pet.auth.on401(rd)) return;
+            if (gen !== _scopeGen) return;
+            if (_armedBusy) return;
+            _adoptReadScope(rd);
+            if (rd && !rd.error && typeof rd.armed === "boolean") {
+              Pet.state.armed = rd.armed;
+              paintBanner();
+            }
+          });
+        }
       });
     };
     var armedOn = Pet.state.armed !== false;
@@ -1850,6 +2326,7 @@
       role: "switch", ariaChecked: armedOn ? "true" : "false",
       ariaLabel: "Petasos enforcement: " + (armedOn ? "equipped, click to unequip" : "unequipped, click to equip")
     });
+    if (_armDisabled) armedSwitch.disabled = true;
     armedSwitch.addEventListener("keydown", function (e) {
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); doToggle(); }
     });
@@ -1862,6 +2339,35 @@
       Pet.HelpTip("<b>Equipped</b>: master switch. <b>Unequipped</b> disables <b>all</b> Petasos enforcement (scan, guard, audit) for this and running sessions, applied by the next tool call. Backed by <code>petasos.enabled</code>."),
       armedSwitch
     ));
+    // PET-166 (D16): label the arm control with what it will act on. Three states:
+    // not_equipped with a named equipped profile -> disabled with a reason; equipped
+    // name null -> enabled, unscoped, labelled; binding unresolvable -> same.
+    if (_armDisabled) {
+      wrapper.appendChild(Pet.h("div", { className: "mono", role: "status", style: { fontSize: "11px", color: "var(--tx-faint)" } },
+        "arming is disabled here: " + String(_armScope.selected || "the selected profile") + " is not the equipped profile (" + String(_armScope.equipped) + " is)"));
+    } else if (_armUnscoped) {
+      wrapper.appendChild(Pet.h("div", { className: "mono", role: "status", style: { fontSize: "11px", color: "var(--tx-faint)" } },
+        _armSt === "unknown"
+          ? "could not verify this dashboard's binding; arming targets it directly"
+          : "arming targets this dashboard's binding, not the selected profile"));
+    }
+    // PET-166 (D20): the client-side scope notice — a 200 the client believes it
+    // scoped came back without a confirmed scope, so what is shown below is the
+    // equipped binding's data, said out loud rather than misattributed.
+    if (Pet.state.scopeNotice) {
+      wrapper.appendChild(Pet.h("div", { role: "status", className: "notice" },
+        Pet.Icon("warn"),
+        Pet.h("span", {}, "showing: equipped binding. The backend did not confirm the selected profile scope; re-sync the console bundle if this persists.")));
+    }
+    // PET-166 (D7): the coherent scoped-422 state — ONE box, not four independent
+    // error panels, and the stale panels below are not painted under it.
+    if (Pet.state.scopeError) {
+      wrapper.appendChild(Pet.h("div", { role: "alert", className: "notice" },
+        Pet.Icon("warn"),
+        Pet.h("span", {}, "this profile has no Petasos configuration yet (" + String(Pet.state.scopeError.message || "profile not resolved") + ")")));
+      container.appendChild(wrapper);
+      return;
+    }
 
     // ── Metric tiles, computed from the in-memory scan-history buffer ──
     // (PET-102) The SSE scan_result handler maintains Pet.state.scanHistory and
@@ -1939,9 +2445,14 @@
     // counters in the row, so the buffer-scoped four read as a block and the two
     // differently-scaled ones are neighbours rather than scattered among them. The
     // HelpTip carries the scale, since a bare number cannot say which window it counts.
-    metricsRow.appendChild(valueTile("self-tamper", selfmodTotal, selfmodTotal > 0, {
+    // PET-166 (D8): under a foreign scope the tile keeps its value and RELABELS to
+    // name the binding it counts (a lifetime fact about the process actually
+    // enforcing); the HelpTip is amended in the same seam because "the scan history
+    // below" is another profile's file there.
+    var selfmodView = Pet.selfmodTileLabel(Pet.isForeignScope());
+    metricsRow.appendChild(valueTile(selfmodView.label, selfmodTotal, selfmodTotal > 0, {
       tone: "amber",
-      help: Pet.HelpTip("<b>Self-tamper</b>: tool calls that tried to write or read Petasos's own config, profile homes, or enforcement spool. Counted since this console started, so it does not fall when older rows age out of the scan history below. Detection only: these calls were not blocked."),
+      help: Pet.HelpTip(selfmodView.help),
     }));
     wrapper.appendChild(metricsRow);
 
@@ -1992,28 +2503,63 @@
     var histRowsData = histPaged
       ? (Array.isArray(histPaged.entries) ? histPaged.entries : [])
       : Pet.filterHistoryRows(hist, histEffFilter);
-    var histSubtitle = histPaged
-      ? Pet.historyPageLabel(histPaged)
-      : Pet.scanHistorySubtitle(
-          hist.length,
-          Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
-        );
+    // PET-166 (D19): the WHOLE history panel reads one source — the scan-history
+    // payload's own scope copy — never Pet.state.readScope, whose health-poll writer
+    // can land first after a switch and would paint "no scans retained for beta"
+    // over a buffer D17 just emptied.
+    var histForeign = Pet.isForeignScope(Pet.state.historyReadScope);
+    var histProfileName = histForeign && Pet.state.historyReadScope && Pet.state.historyReadScope.selected
+      ? String(Pet.state.historyReadScope.selected) : "";
+    // D12: the age label is computed over the UNFILTERED head buffer, never the
+    // filtered rows (a fresh profile with no selfmod rows must not read stale), and
+    // it is head-only (a back-page is older than the head by construction).
+    var histAge = histPaged ? null : Pet.scanHistoryAge(hist);
+    // PET-166 (D12): four-state subtitle selector. paged+equipped -> the positional
+    // page label (unchanged); paged+foreign -> the scoped seam with the page label
+    // as body (the view reaching furthest into another profile's data must say
+    // whose it is); head+foreign -> the scoped seam with the count as body (no
+    // "of N" — we have no lifetime count for a process we are not); head+equipped ->
+    // the shipped seam, with the age clause appended at the render site so its
+    // two-argument signature stays untouched.
+    var histFilterOn = histEffFilter === "selfmod";
+    var histSubtitle;
+    if (histPaged) {
+      histSubtitle = histForeign
+        ? Pet.scopedHistorySubtitle(Pet.historyPageLabel(histPaged), histProfileName, null, false, histFilterOn)
+        : Pet.historyPageLabel(histPaged);
+    } else if (histForeign) {
+      histSubtitle = Pet.scopedHistorySubtitle(
+        "showing last " + hist.length, histProfileName,
+        histAge && histAge.label, !!(histAge && histAge.stale), histFilterOn
+      );
+    } else {
+      histSubtitle = Pet.scanHistorySubtitle(
+        hist.length,
+        Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
+      );
+      if (histAge) histSubtitle = histSubtitle + " · " + histAge.label + (histAge.stale ? " · stale" : "");
+    }
     // PET-165: the filter APPENDS to the subtitle, never rewrites it. The counts stay the
     // unfiltered window's (so "showing last 500 of 1200" keeps meaning what PET-144 made
     // it mean), but a list showing 2 of 500 buffered rows under a bare "recent evaluations"
     // would misdescribe itself. One trailing clause fixes that without minting a second,
     // filter-scoped total the operator would have to reconcile against the tile.
-    if (histEffFilter === "selfmod") histSubtitle = histSubtitle + " · self-tamper only";
+    // PET-166 (D12): SKIPPED on the scopedHistorySubtitle arms — the seam emits the
+    // clause itself from filterOn, so appending here would render it twice.
+    if (histFilterOn && !histForeign) histSubtitle = histSubtitle + " · self-tamper only";
     // PET-152: "Older" is offered when an older cursor exists (the paged view's next_before) or,
     // off the live head, when scanHistoryHasOlder reports retained rows older than the live window
-    // — gated on the SAME lifetime scans_total the subtitle reads (:1631), never a cached seed
+    // — gated on the SAME lifetime scans_total the subtitle reads on the equipped branch; a
+    // non-equipped scope reads the server's has_older (PET-166 D12) — never a cached seed
     // cursor that goes stale after ring eviction. "Newer" only when paged back.
     var histCanOlder = histPaged
-      ? (histPaged.nextBefore != null)
-      : Pet.scanHistoryHasOlder(
-          hist.length,
-          Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
-        );
+      ? (histPaged.nextBefore != null)                       // shipped paged arm, unchanged
+      : Pet.isForeignScope(Pet.state.historyReadScope)       // D19: the panel's own scope copy
+        ? Pet.scopedHistoryHasOlder(hist.length, Pet.state.historyHasOlder)
+        : Pet.scanHistoryHasOlder(
+            hist.length,
+            Pet.state.pipelineHealth && Pet.state.pipelineHealth.scans_total
+          );
 
     // PET-152: the "Older"/"Newer" handlers are now module-scoped (Pet.pageHistoryOlder /
     // Pet.pageHistoryNewer), defined once rather than rebuilt per render so they provably share
@@ -2031,16 +2577,14 @@
         ariaLabel: "Show newer scan history", onClick: Pet.pageHistoryNewer,
       }, "Newer"));
     }
-    // Body: rows for the active view, or the retention-honest empty state when a paged-back
-    // view came back empty (never "no scans yet" — that is the live-head empty state).
+    // Body: rows for the active view, or the empty-state ladder (PET-166 D12 —
+    // PET-165's arm order preserved exactly, scope-aware copy inside, one new arm
+    // for the foreign nothing-retained state; the seam owns the copy so tests/js
+    // can drive the full matrix without renderDashboard).
     var histBody;
-    if (histPaged && histRowsData.length === 0) {
-      histBody = Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, Pet.historyPageLabel(histPaged));
-    } else if (histEffFilter === "selfmod" && histRowsData.length === 0) {
-      // PET-165: filtered-empty is its own honest state, distinct from the loading skeleton
-      // and from "no scans yet". Phrased against the WINDOW because the PET-144 eviction
-      // subtitle still applies: this is a view of the <=500-row buffer, not of all history.
-      histBody = Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, "No self-tamper events in the buffered window.");
+    var histEmpty = Pet.historyEmptyState(hist, histRowsData, histPaged, histEffFilter, histForeign, histProfileName);
+    if (histEmpty) {
+      histBody = Pet.h("div", { className: "mono", style: { color: "var(--tx-faint)", fontSize: "12px" } }, histEmpty.text);
     } else {
       histBody = Pet.scanHistoryRows(histRowsData);
     }
@@ -2069,7 +2613,12 @@
       // rewrites the eviction headline into a false "showing last 3 of N".
       place: histSubtitle,
       right: histFilterSeg,
-      help: Pet.HelpTip("<b>Scan History</b>: recent pipeline scans with severity, direction, and timing. Each row is one <code>Pipeline.evaluate()</code> call. <b>Older</b>/<b>Newer</b> page through retained history beyond the live window."),
+      // PET-166 (D3): the spool retention notice rides the shipped HelpTip (the
+      // established idiom for a scope/scale disclosure) rather than a new note element.
+      help: Pet.HelpTip("<b>Scan History</b>: recent pipeline scans with severity, direction, and timing. Each row is one <code>Pipeline.evaluate()</code> call. <b>Older</b>/<b>Newer</b> page through retained history beyond the live window."
+        + (histForeign && Pet.state.spoolTruncated
+          ? " Older enforcement events for this profile were not read (spool exceeds the read cap)."
+          : "")),
       content: Pet.h("div", { style: { padding: "12px" } }, histBody, histControls),
     });
     wrapper.appendChild(historyPanel);
@@ -2082,9 +2631,20 @@
     // optimistic value; paintBanner re-queries the live node.
     if (!_armedSeeded && !_armedBusy) {
       _armedSeeded = true;
+      var _armedGen = _scopeGen; // PET-166 D17: captured at send time
       Pet.api.getArmed().then(function (d) {
-        if (Pet.auth.on401(d)) return; // PET-129 D3: first statement; a 401 here must not be read as armed
+        if (Pet.auth.on401(d)) return; // PET-129 D3/§1: first statement; a 401 here must not be read as armed
+        if (_armedGen !== _scopeGen) { _armedSeeded = false; return; } // superseded scope: leave un-seeded for the new scope's render
+        if (Pet.isProfile422(d)) {
+          // PET-166 D7: the coherent error state; never leave the prior bit painted
+          // as this profile's (the guard below would silently drop the 422).
+          var _e0 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
+          Pet.state.scopeError = { surface: "armed", message: (_e0 && _e0.message) || "profile not found" };
+          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+          return;
+        }
         if (_armedBusy) return;
+        _adoptReadScope(d); // PET-166 D19: armed 200s are a readScope writer
         if (d && !d.error && typeof d.armed === "boolean") {
           Pet.state.armed = d.armed;
           paintBanner();
@@ -2093,10 +2653,21 @@
     }
 
     // Fetch initial data and render scanner health
+    var _healthGen = _scopeGen; // PET-166 D17: captured at send time
     Pet.api.getHealth().then(function (d) {
-      if (Pet.auth.on401(d)) return; // PET-129 D3: first statement, before the _healthLoaded flip / shape gate
+      if (Pet.auth.on401(d)) return; // PET-129 D3/§1: first statement, before the _healthLoaded flip / shape gate
+      if (_healthGen !== _scopeGen) return; // PET-166: superseded scope
+      if (Pet.isProfile422(d)) {
+        // PET-166 D7: a 422 body carries no `error`, so without this the shape gate
+        // below would wipe scannerHealth/pipelineHealth/integrityHealth every render.
+        var _e0 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
+        Pet.state.scopeError = { surface: "health", message: (_e0 && _e0.message) || "profile not found" };
+        if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+        return;
+      }
       _healthLoaded = true;  // PET-127: settled (either arm) -> stop painting the skeleton
       if (!d.error) {
+        _adoptReadScope(d); // PET-166 D19: health 200s are a readScope writer
         // PET-144: capture BEFORE the assignment whether this settle is the first to
         // populate pipelineHealth, so the cold-mount re-render below fires on the
         // null->set transition only.
@@ -2143,12 +2714,16 @@
       // prior mount/profile (a `before` cursor is only meaningful within its own profile).
       Pet.state.historyAtHead = true;
       Pet.state.historyStack = [];
+      var _seedGen = _scopeGen; // PET-166 D17: captured at send time
       Pet.api.getScanHistory(500).then(function (d) {
-        if (Pet.auth.on401(d)) return; // PET-129 D3: first statement, before the shape-guarded seed-merge
+        if (Pet.auth.on401(d)) return; // PET-129 D3/§1: first statement, before the shape-guarded seed-merge
+        if (_seedGen !== _scopeGen) { _historySeeded = false; return; } // PET-166: superseded scope
+        if (_scopeGuardHistory(d)) return; // PET-166 D7
         // startFallbackPolling response-shape guard, NOT the bare !d.error check:
         // _req never rejects on HTTP error (it resolves an error envelope), and a
         // 200 {} body lacking .entries would make the merge throw on .scan_id.
         if (!d.error && d.entries && Array.isArray(d.entries)) {
+          _adoptHistoryScope(d); // PET-166 D19: the mount seed is a writer site
           // PET-148/PET-152: the seed merges the live-head window but no longer captures a head
           // cursor. PET-152 dropped that cached cursor: it went stale once the ring evicted past
           // the oldest seeded row, so the first "Older" click skipped the band between the current
@@ -2463,6 +3038,13 @@
   Pet.renderPlayground = function (container) {
     container.innerHTML = "";
     var wrapper = Pet.h("div", { style: { display: "flex", flexDirection: "column", gap: "16px", height: "100%" } });
+    // PET-166 (D10): a playground scan runs through the live pipeline — a write
+    // against the equipped binding — so under a foreign read scope the result would
+    // never appear in the selected profile's history. Say so, once, up front.
+    var _pgNote = Pet.playgroundScopeNote(Pet.state.readScope);
+    if (_pgNote) {
+      wrapper.appendChild(Pet.h("div", { role: "status", className: "mono", style: { fontSize: "11px", color: "var(--tx-faint)" } }, _pgNote));
+    }
 
     var textArea = Pet.h("textarea", {
       className: "input mono",
@@ -3007,11 +3589,13 @@
     );
     host.appendChild(row);
 
-    // ── binding read-out: which config.yaml, which tier ──
+    // ── resolution read-out: HOW the path was resolved (PET-166 D16: relabelled from
+    // "binding:" so it reads as a resolution-mechanism line and no longer competes
+    // with the scope panel's identity claim on the HERMES_HOME-aliasing config) ──
     var tier = d && d.config_tier ? String(d.config_tier) : "root";
     var home = d && d.profile_home ? String(d.profile_home) : "";
     host.appendChild(Pet.h("div", { className: "pet-hermes-binding mono" },
-      "binding: " + (d && d.hermes_profile ? String(d.hermes_profile) : "root") + " · tier " + tier + (home ? (" · " + home) : "")));
+      "resolved via: " + (d && d.hermes_profile ? String(d.hermes_profile) : "root") + " · tier " + tier + (home ? (" · " + home) : "")));
 
     // ── dangling-pointer warning, labeled as the ACTIVE binding (edge round-2 F-7) ──
     if (d && d.config_warning) {
@@ -3073,11 +3657,12 @@
       Pet.h("label", { className: "pet-hermes-label" }, "Hermes agent profile"),
       Pet.h("span", { className: "pet-hermes-bound mono" }, display)));
 
-    // ── binding read-out: which config.yaml, which tier (reused from PET-146) ──
+    // ── resolution read-out (reused from PET-146; PET-166 D16 relabel, see the
+    // twin site in renderHermesProfileSelector) ──
     var tier = d && d.config_tier ? String(d.config_tier) : "root";
     var home = d && d.profile_home ? String(d.profile_home) : "";
     host.appendChild(Pet.h("div", { className: "pet-hermes-binding mono" },
-      "binding: " + (d && d.hermes_profile ? String(d.hermes_profile) : "root") + " · tier " + tier + (home ? (" · " + home) : "")));
+      "resolved via: " + (d && d.hermes_profile ? String(d.hermes_profile) : "root") + " · tier " + tier + (home ? (" · " + home) : "")));
 
     // ── read-only safety warnings (dangling active-binding pointer / selected-profile parse) ──
     if (d && d.config_warning) {
@@ -3307,6 +3892,9 @@
         self.profiles = Array.isArray(scope.profiles) ? scope.profiles.slice() : self.profiles;
         Pet.state.selectedHermesProfile = np;
         self._gen++;
+        // PET-166 (D17): a change on EITHER axis (management selection or equipped
+        // flip) invalidates every scoped read surface and re-subscribes SSE.
+        _invalidateScopeState();
         if (Pet.state.tab === "cfg" && _container) Pet.renderConfig(_container);
         return;
       }
@@ -3319,6 +3907,7 @@
       self.profile = newProfile;
       Pet.state.selectedHermesProfile = newProfile;
       self._gen++;
+      _invalidateScopeState(); // PET-166 (D17)
       // refresh equipped/current for the new selection, then settle the banner.
       self.refreshCurrent().then(function () {
         if (Pet.state.tab === "cfg" && _container) Pet.renderConfig(_container);
@@ -4158,6 +4747,19 @@
     _healthLoaded = false;   // PET-127: re-show the scanner-health skeleton on (re-)mount
     _armedSeeded = false;    // PET-111: re-fetch the armed bit on (re-)mount
     clearArmedConfirm();     // drop any stale disarm-confirm + timer from a skipped unmount
+    // PET-166 (D17/D19): a re-mount that skipped unmount must not inherit stale scope
+    // facts (a foreign readScope from the prior mount would render another profile's
+    // name before the first 200 lands).
+    _scopeGen++;
+    if (_scopePollTimer) { clearInterval(_scopePollTimer); _scopePollTimer = null; }
+    Pet.sse._scopeLive = true;
+    Pet.sse._scopeRefusal = null;
+    Pet.state.readScope = null;
+    Pet.state.historyReadScope = null;
+    Pet.state.historyHasOlder = false;
+    Pet.state.spoolTruncated = false;
+    Pet.state.scopeError = null;
+    Pet.state.scopeNotice = false;
     // PET-155: resolve the host profile + arm the switcher observer once per mount, so
     // a sidebar flip is observed even before the Config tab is first opened (§E).
     // attach() is idempotent — it tears down a stale patch left by a skipped unmount.
@@ -4231,13 +4833,19 @@
   // it survives the dashboard's per-frame re-render of _container.
   Pet.updateConnStatus = function () {
     if (!_connStatus) return;
-    var polling = !!(Pet.sse && Pet.sse._usingFallback);
-    _connStatus.className = "live" + (polling ? " polling" : "");
+    // PET-166 (D9): three states in a fixed order — POLLING outranks SCOPED (a dead
+    // connection is the more urgent fact), else SCOPED (an idle non-equipped stream
+    // or a terminal refusal), else LIVE. The decision is the pure Pet.connChipView
+    // seam; this stays the painter.
+    var v = Pet.connChipView(
+      !!(Pet.sse && Pet.sse._usingFallback),
+      !(Pet.sse && Pet.sse._scopeLive === false),
+      Pet.sse ? Pet.sse._scopeRefusal : null
+    );
+    _connStatus.className = v.className;
     var lbl = _connStatus.querySelector(".live-label");
-    if (lbl) lbl.textContent = polling ? "POLLING" : "LIVE";
-    _connStatus.setAttribute("title", polling
-      ? "Live stream unavailable; polling every 10s."
-      : "Live updates streaming.");
+    if (lbl) lbl.textContent = v.label;
+    _connStatus.setAttribute("title", v.title);
   };
 
   // PET-13: push a short message into the off-screen live region for AT.
@@ -4249,6 +4857,18 @@
     _cfgRenderGen += 1;      // PET-155: supersede any in-flight renderConfig/save continuation so a late /config or PUT resolve can't mutate state after teardown
     Pet.sse.disconnect();
     stopPolling();
+    // PET-166 (D3/D17/D19): stop the scoped poll and reset the payload-derived scope
+    // facts on teardown (the D19 reset set is the D17 list AND unmount).
+    _scopeGen++;
+    if (_scopePollTimer) { clearInterval(_scopePollTimer); _scopePollTimer = null; }
+    Pet.sse._scopeLive = true;
+    Pet.sse._scopeRefusal = null;
+    Pet.state.readScope = null;
+    Pet.state.historyReadScope = null;
+    Pet.state.historyHasOlder = false;
+    Pet.state.spoolTruncated = false;
+    Pet.state.scopeError = null;
+    Pet.state.scopeNotice = false;
     Pet.hostProfile.detach();   // PET-155: un-patch history / unsubscribe (§E); idempotent + foreign-safe
     _container = null;
     _tabStrip = null;

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -980,24 +980,30 @@
 
   function startFallbackPolling() {
     if (_fallbackPollInterval) return;
-    function onHistory(d) {
-      if (Pet.auth.on401(d)) return; // PET-129 D4: on401 nulls _fallbackPollInterval before the reschedule .then runs, so the re-arm below no-ops
-      if (_scopeGuardHistory(d)) return; // PET-166 D7/D17: gen drop + coherent 422 state
-      if (!d.error && d.entries && Array.isArray(d.entries)) {
-        Pet.state.scanHistory = d.entries;
-        Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
-        _adoptHistoryScope(d);       // PET-166 D19: fallback assignments are writer sites too
-        if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
-      }
+    function send() {
+      var gen = _scopeGen; // PET-166 D17: captured at send time, per request
+      return Pet.api.getScanHistory(100).then(function (d) {
+        if (Pet.auth.on401(d)) return; // PET-129 D4: on401 nulls _fallbackPollInterval before the reschedule .then runs, so the re-arm below no-ops
+        if (gen !== _scopeGen) return; // PET-166 D17: superseded scope — drop
+        if (_scopeGuardHistory(d)) return; // PET-166 D7: coherent 422 state
+        if (!d.error && d.entries && Array.isArray(d.entries)) {
+          Pet.state.scanHistory = d.entries;
+          Pet.accrueBypass(d.entries); // PET-138: SSE-down path also feeds bypass state
+          _adoptHistoryScope(d);       // PET-166 D19: fallback assignments are writer sites too
+          if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
+        }
+      });
     }
+    // Both arms re-arm: a rejected tick (render throw, network reject) must not end
+    // the chain for the rest of the mount — the setInterval form it replaced survived
+    // a failed tick, and the 401 stop already runs through the nulled-interval guard.
+    function rearm() { if (_fallbackPollInterval) schedule(); }
     function schedule() {
       _fallbackPollInterval = setTimeout(function () {
-        Pet.api.getScanHistory(100).then(onHistory).then(function () {
-          if (_fallbackPollInterval) schedule();
-        });
+        send().then(rearm, rearm);
       }, 10000);
     }
-    Pet.api.getScanHistory(100).then(onHistory);
+    send();
     schedule();
   }
   function stopFallbackPolling() {
@@ -2628,8 +2634,12 @@
     // PET-111: fetch the authoritative armed bit once per obs ENTRY (guarded by
     // _armedSeeded — reset in mount/unmount/switchTab→obs) — never on every
     // SSE/poll re-render. Skip while a write is in flight so it can't clobber an
-    // optimistic value; paintBanner re-queries the live node.
-    if (!_armedSeeded && !_armedBusy) {
+    // optimistic value; paintBanner re-queries the live node. The !scopeError arm:
+    // a profile 422 resets the latch below (the bit was never read for that scope)
+    // and paints scopeError BEFORE its re-render, so this gate is what keeps the
+    // error re-render from re-fetching in a loop; the re-seed runs once a 200 on
+    // any scoped surface clears the error.
+    if (!_armedSeeded && !_armedBusy && !Pet.state.scopeError) {
       _armedSeeded = true;
       var _armedGen = _scopeGen; // PET-166 D17: captured at send time
       Pet.api.getArmed().then(function (d) {
@@ -2637,7 +2647,11 @@
         if (_armedGen !== _scopeGen) { _armedSeeded = false; return; } // superseded scope: leave un-seeded for the new scope's render
         if (Pet.isProfile422(d)) {
           // PET-166 D7: the coherent error state; never leave the prior bit painted
-          // as this profile's (the guard below would silently drop the 422).
+          // as this profile's (the guard below would silently drop the 422). The
+          // latch resets so the bit is re-read once the 422 clears — without this
+          // the banner keeps the previous scope's enforcement state for the rest
+          // of the scope (only mount/unmount/_invalidateScopeState reset it).
+          _armedSeeded = false;
           var _e0 = d.detail.filter(function (x) { return x && x.field === "profile"; })[0];
           Pet.state.scopeError = { surface: "armed", message: (_e0 && _e0.message) || "profile not found" };
           if (Pet.state.tab === "obs" && _container) Pet.renderDashboard(_container);
@@ -2708,7 +2722,7 @@
     // SSE-driven re-renders don't restart the fetch; it is reset only in
     // mount/unmount (never switchTab), so an obs→other→obs round-trip reuses
     // the SSE-maintained buffer rather than re-seeding.
-    if (!_historySeeded) {
+    if (!_historySeeded && !Pet.state.scopeError) { // !scopeError: same anti-loop arm as the armed seed above
       _historySeeded = true;
       // PET-148: every (re-)seed starts at the live head — drop any paged-back state from a
       // prior mount/profile (a `before` cursor is only meaningful within its own profile).
@@ -2718,7 +2732,7 @@
       Pet.api.getScanHistory(500).then(function (d) {
         if (Pet.auth.on401(d)) return; // PET-129 D3/§1: first statement, before the shape-guarded seed-merge
         if (_seedGen !== _scopeGen) { _historySeeded = false; return; } // PET-166: superseded scope
-        if (_scopeGuardHistory(d)) return; // PET-166 D7
+        if (_scopeGuardHistory(d)) { _historySeeded = false; return; } // PET-166 D7; un-latch so the seed re-runs once the 422 clears
         // startFallbackPolling response-shape guard, NOT the bare !d.error check:
         // _req never rejects on HTTP error (it resolves an error envelope), and a
         // 200 {} body lacking .entries would make the merge throw on .scan_id.

--- a/tests/js/profile-scoped-reads.test.mjs
+++ b/tests/js/profile-scoped-reads.test.mjs
@@ -1,0 +1,575 @@
+// PET-166: client-side read-scope behavior (petasos.js).
+//
+// Most cases drive a PURE SEAM, never renderDashboard: no tests/js module drives it
+// (two stub it outright, the rest never reach it), which is exactly why D12 puts the
+// empty-state ladder and the scoped subtitle behind Pet.historyEmptyState /
+// Pet.scopedHistorySubtitle rather than inline at the render site.
+//
+// Mints its own node:vm realm and its own resetState(), following the shipped
+// per-module pattern. Assert via Object.keys().length, never deepEqual on Pet.state
+// objects (cross-realm prototypes).
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped petasos.js.
+// Run with: node --test tests/js/profile-scoped-reads.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    attrs: {},
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute(k, v) { this.attrs[k] = v; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+// AbortController / TextDecoder / fetch are runtime APIs petasos.js already relies
+// on (the SSE pump); the shim provides them so _openStream can be driven headlessly.
+const sandbox = {
+  window: {}, document, console,
+  setTimeout, clearTimeout, setInterval, clearInterval,
+  AbortController, TextDecoder,
+  fetch: function () { return new Promise(function () {}); },
+};
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function resetState() {
+  Pet.state.readScope = null;
+  Pet.state.historyReadScope = null;
+  Pet.state.historyHasOlder = false;
+  Pet.state.spoolTruncated = false;
+  Pet.state.scopeError = null;
+  Pet.state.scopeNotice = false;
+  Pet.state.scanHistory = [];
+  Pet.state.bypassBySession = {};
+  Pet.state.historyStack = [];
+  Pet.state.historyAtHead = true;
+  Pet.state.historyFilter = "all";
+  Pet.state.selectedHermesProfile = null;
+  Pet.state.authRequired = false;
+  Pet.hostProfile.source = "none";
+  Pet.hostProfile.profile = "";
+  Pet.hostProfile.current = "";
+  Pet.sse._scopeLive = true;
+  Pet.sse._scopeRefusal = null;
+  Pet.sse._usingFallback = false;
+}
+
+function embedded(profile) {
+  Pet.hostProfile.source = "sdk";
+  Pet.hostProfile.profile = profile;
+  Pet.state.selectedHermesProfile = profile;
+}
+
+function scope(state, selected, equipped, tier) {
+  return {
+    selected: selected === undefined ? "beta" : selected,
+    equipped: equipped === undefined ? "alpha" : equipped,
+    equipped_tier: tier || "profile",
+    live: state === "equipped",
+    state,
+  };
+}
+
+// ── 1: scoped URLs asserted by PARSING, not substring ────────────────────────
+
+test("js/scoped-urls: every read carries the profile, parsed not matched", async () => {
+  resetState();
+  embedded("beta");
+  const seen = [];
+  const origReq = Pet.api._req;
+  Pet.api._req = function (path, opts) { seen.push({ path, opts }); return Promise.resolve({}); };
+  try {
+    await Pet.api.getScanHistory(100, "beta|1.0~s-a");
+    await Pet.api.getHealth();
+    await Pet.api.getArmed();
+    await Pet.api.setArmed(false);
+    await Pet.api.postScan("hi", "inbound", null);
+  } finally {
+    Pet.api._req = origReq;
+  }
+  const url = (i) => new URL("http://x" + seen[i].path);
+  // getScanHistory already carries "?limit=", so the separator must be "&" — a naive
+  // "?profile=" append parses as part of the `before` value with NO profile at all.
+  assert.equal(url(0).searchParams.get("profile"), "beta");
+  assert.equal(url(0).searchParams.get("before"), "beta|1.0~s-a");
+  assert.equal(url(1).searchParams.get("profile"), "beta");
+  assert.equal(url(2).searchParams.get("profile"), "beta");
+  // The write carries the scope in the BODY (a query-borne selector is a 422).
+  assert.equal(url(3).searchParams.get("profile"), null);
+  assert.equal(JSON.parse(seen[3].opts.body).profile, "beta");
+  // postScan carries it nowhere: a playground scan is a write against the equipped binding.
+  assert.equal(url(4).searchParams.get("profile"), null);
+  assert.equal(JSON.parse(seen[4].opts.body).profile, undefined);
+});
+
+test("js/standalone-renders-equipped-form: no scope emitted, every affordance equipped", async () => {
+  resetState(); // source "none", readScope null
+  const seen = [];
+  const origReq = Pet.api._req;
+  Pet.api._req = function (path) { seen.push(path); return Promise.resolve({}); };
+  try {
+    await Pet.api.getScanHistory(100);
+    await Pet.api.getHealth();
+    await Pet.api.getArmed();
+    await Pet.api.setArmed(true);
+  } finally {
+    Pet.api._req = origReq;
+  }
+  for (const p of seen) assert.ok(p.indexOf("profile=") === -1, "no scope on " + p);
+  // And every scoped affordance renders its equipped form off a null scope — a bare
+  // readScope.state dereference would throw here instead.
+  assert.equal(Pet.isForeignScope(), false);
+  assert.equal(Pet.playgroundScopeNote(Pet.state.readScope), null);
+  assert.equal(Pet.selfmodTileLabel(Pet.isForeignScope()).label, "self-tamper");
+  assert.equal(Pet.scanHistorySubtitle(12, 4413), "showing last 12 of 4413"); // "of N" present
+  assert.equal(Pet.historyEmptyState([], [], null, "all", false, ""), null); // equipped fall-through
+  assert.equal(Pet._scopePollState().running, false);
+});
+
+// ── D19: the absent-scope predicate ──────────────────────────────────────────
+
+test("js/is-foreign-scope: null is the equipped form, one implementation", () => {
+  resetState();
+  assert.equal(Pet.isForeignScope(null), false);
+  assert.equal(Pet.isForeignScope(undefined), false);
+  assert.equal(Pet.isForeignScope(scope("equipped", "alpha")), false);
+  assert.equal(Pet.isForeignScope(scope("not_equipped")), true);
+  assert.equal(Pet.isForeignScope(scope("unknown")), true);
+  Pet.state.readScope = scope("not_equipped");
+  assert.equal(Pet.isForeignScope(), true); // zero-arg reads Pet.state.readScope
+});
+
+// ── D12: subtitle composition ────────────────────────────────────────────────
+
+test("js/scoped-subtitle-composition: four clauses, one appender, shipped seam untouched", () => {
+  assert.equal(
+    Pet.scopedHistorySubtitle("showing last 12", "beta", "newest 09:14 (6d ago)", true, true),
+    "showing last 12 for beta · newest 09:14 (6d ago) · stale · self-tamper only"
+  );
+  // The paged-under-foreign form keeps the identity on the view that reaches furthest
+  // into another profile's data; age and stale are head-only.
+  assert.equal(
+    Pet.scopedHistorySubtitle("showing older history", "beta", null, false, false),
+    "showing older history for beta"
+  );
+  // The clause is emitted by the seam, so the render site must not append it again.
+  const s = Pet.scopedHistorySubtitle("showing last 3", "beta", null, false, true);
+  assert.equal(s.split("self-tamper only").length - 1, 1);
+  // The shipped seam's two-argument signature is unchanged.
+  assert.equal(Pet.scanHistorySubtitle.length, 2);
+  assert.equal(Pet.scanHistorySubtitle(12, 4413), "showing last 12 of 4413");
+});
+
+test("js/equipped-paging-unchanged: scans_total still drives subtitle and gate", () => {
+  // The fence that keeps D12's narrowing off the equipped path.
+  assert.equal(Pet.scanHistorySubtitle(12, 4413), "showing last 12 of 4413");
+  assert.equal(Pet.scanHistoryHasOlder(12, 4413), true);
+  assert.equal(Pet.scanHistoryHasOlder(0, 4413), false);   // the b > 0 term survives
+  assert.equal(Pet.scanHistoryHasOlder(12, 12), false);
+  // PET-165's equipped filtered-empty copy renders verbatim.
+  const arm = Pet.historyEmptyState([{}], [], null, "selfmod", false, "");
+  assert.equal(arm.text, "No self-tamper events in the buffered window.");
+});
+
+test("js/scoped-history-has-older: server boolean, buffer term kept", () => {
+  // Neither case below is reachable from scans_total alone, which is the point.
+  assert.equal(Pet.scopedHistoryHasOlder(12, true), true);   // small scans_total, older exist
+  assert.equal(Pet.scopedHistoryHasOlder(12, false), false); // large scans_total, none older
+  // b > 0 survives: a click over a transiently-empty buffer would re-mint from the
+  // Nth-newest row and silently omit the head band (PET-152 E-2/E-4).
+  assert.equal(Pet.scopedHistoryHasOlder(0, true), false);
+});
+
+// ── D12: the empty-state ladder ──────────────────────────────────────────────
+
+test("js/history-empty-state-ladder: arm order preserved, copy scope-aware", () => {
+  const paged = { entries: [], olderTruncated: false };
+  // Arm 1 (paged-empty) is positional and deliberately exempt from the naming rule.
+  assert.equal(Pet.historyEmptyState([], [], paged, "all", true, "beta").arm, 1);
+  assert.equal(Pet.historyEmptyState([], [], paged, "all", true, "beta").text, "no older history");
+
+  // Arm 2, equipped: PET-165's copy verbatim (the reversal this ladder must not make).
+  assert.equal(
+    Pet.historyEmptyState([{}], [], null, "selfmod", false, "").text,
+    "No self-tamper events in the buffered window."
+  );
+  // Arm 2, foreign: names both the filter and the profile.
+  assert.equal(
+    Pet.historyEmptyState([{}], [], null, "selfmod", true, "beta").text,
+    "no self-tamper events among the rows retained for beta"
+  );
+  // Arm 2's empty-buffer exception returns arm 3, so token and copy never disagree.
+  const exc = Pet.historyEmptyState([], [], null, "selfmod", true, "beta");
+  assert.equal(exc.arm, 3);
+  assert.equal(exc.text, "no scans retained for beta");
+
+  // Arm 3, foreign only; the EQUIPPED branch falls through to scanHistoryRows (null),
+  // which is what keeps the "no scans yet" literal owned by that seam.
+  assert.equal(Pet.historyEmptyState([], [], null, "all", true, "beta").arm, 3);
+  assert.equal(Pet.historyEmptyState([], [], null, "all", false, ""), null);
+
+  // Arm 4: rows present -> null (render them).
+  assert.equal(Pet.historyEmptyState([{}], [{}], null, "all", true, "beta"), null);
+
+  // The !histPaged guard: while paged, an emptying live buffer must NOT replace the
+  // fetched page with an empty-state sentence (PET-148's invariant).
+  const withRows = { entries: [{}], olderTruncated: false };
+  assert.equal(Pet.historyEmptyState([], [{}], withRows, "all", true, "beta"), null);
+});
+
+// ── D12: staleness ───────────────────────────────────────────────────────────
+
+test("js/scan-history-age: fresh, stale, empty, degenerate, future", () => {
+  const now = Date.now() / 1000;
+  assert.equal(Pet.scanHistoryAge([]), null);
+  assert.equal(Pet.scanHistoryAge(null), null);
+  assert.equal(Pet.scanHistoryAge([{}]), null);                       // absent timestamp
+  assert.equal(Pet.scanHistoryAge([{ timestamp: "nope" }]), null);    // non-numeric
+  const fresh = Pet.scanHistoryAge([{ timestamp: now - 240 }]);
+  assert.equal(fresh.stale, false);
+  assert.ok(/^newest \d\d:\d\d \(4m ago\)$/.test(fresh.label));
+  const stale = Pet.scanHistoryAge([{ timestamp: now - 7200 }]);
+  assert.equal(stale.stale, true);
+  assert.ok(stale.label.indexOf("2h ago") !== -1);
+  // A future timestamp clamps rather than producing a negative age that would read
+  // as the freshest row.
+  const future = Pet.scanHistoryAge([{ timestamp: now + 600 }]);
+  assert.equal(future.stale, false);
+  assert.ok(future.label.indexOf("just now") !== -1);
+});
+
+// ── D8: the self-tamper tile relabel ─────────────────────────────────────────
+
+test("js/selfmod-tile-scope-relabel: value kept, label and help scoped", () => {
+  const equipped = Pet.selfmodTileLabel(false);
+  const foreign = Pet.selfmodTileLabel(true);
+  assert.equal(equipped.label, "self-tamper");
+  assert.equal(foreign.label, "self-tamper (this dashboard's binding)");
+  assert.ok(foreign.help.indexOf("bound to") !== -1);
+  // The amended help no longer claims "the scan history below" counts the same thing.
+  assert.ok(equipped.help.indexOf("age out of the scan history below") !== -1);
+  assert.ok(foreign.help.indexOf("age out of the scan history below") === -1);
+  // House style: no em dashes in either string.
+  assert.ok(equipped.help.indexOf("\u2014") === -1);
+  assert.ok(foreign.help.indexOf("\u2014") === -1);
+  assert.ok(foreign.label.indexOf("\u2014") === -1);
+});
+
+// ── D9: the connection chip ──────────────────────────────────────────────────
+
+test("js/conn-chip-scoped-class: className not just label, three distinct titles", () => {
+  resetState();
+  Pet.state.selectedHermesProfile = "beta";
+  const live = Pet.connChipView(false, true, null);
+  assert.equal(live.className, "live");
+  assert.equal(live.label, "LIVE");
+
+  const scoped = Pet.connChipView(false, false, null);
+  assert.ok(scoped.className.indexOf("scoped") !== -1); // the CLASS, not merely the label
+  assert.equal(scoped.label, "SCOPED");
+  assert.ok(scoped.title.indexOf("beta") !== -1);       // names the selected profile
+
+  // The two refusal titles are distinct and neither names the refused profile.
+  const refused = Pet.connChipView(false, false, "profile");
+  const atCap = Pet.connChipView(false, false, "capacity");
+  assert.ok(refused.className.indexOf("scoped") !== -1);
+  assert.ok(refused.title.indexOf("profile not found") !== -1);
+  assert.ok(refused.title.indexOf("beta") === -1);
+  assert.ok(atCap.title.indexOf("capacity") !== -1);
+  assert.notEqual(refused.title, atCap.title);
+  assert.notEqual(scoped.title, refused.title);
+
+  // POLLING outranks SCOPED: a dead connection is the more urgent fact.
+  const polling = Pet.connChipView(true, false, "capacity");
+  assert.equal(polling.label, "POLLING");
+  assert.ok(polling.className.indexOf("polling") !== -1);
+});
+
+// ── D10: the playground note ─────────────────────────────────────────────────
+
+test("js/playground-scope-note: present when foreign, null when live or absent", () => {
+  assert.equal(Pet.playgroundScopeNote(null), null);
+  assert.equal(Pet.playgroundScopeNote(scope("equipped", "alpha")), null);
+  const note = Pet.playgroundScopeNote(scope("not_equipped"));
+  assert.ok(note.indexOf("equipped binding") !== -1);
+  assert.ok(note.indexOf("\u2014") === -1); // house style
+});
+
+// ── D7: the shared 422 test ──────────────────────────────────────────────────
+
+test("js/is-profile-422: status-keyed, not error-keyed", () => {
+  // A 422 body carries no `error`, so the readers' `!d.error` gates would treat it
+  // as an empty success and wipe healthy panels.
+  assert.equal(Pet.isProfile422({ _status: 422, detail: [{ field: "profile", message: "x" }] }), true);
+  assert.equal(Pet.isProfile422({ _status: 422, detail: [{ field: "before", message: "x" }] }), false);
+  assert.equal(Pet.isProfile422({ detail: [{ field: "profile" }] }), false);
+  assert.equal(Pet.isProfile422({ error: "boom" }), false);
+  assert.equal(Pet.isProfile422(null), false);
+});
+
+// ── D17: the armed write under a scope change ────────────────────────────────
+
+test("js/armed-write-scope-change: drop-and-re-read, never reconcile the stale bit", () => {
+  // A switch landing mid-POST: the decision must be drop-and-re-read, must leave the
+  // control re-armable (armedSeeded false), and must banner nothing about the prior scope.
+  const moved = Pet.armedWriteView({ scopeMoved: true, response: { armed: true }, next: true });
+  assert.equal(moved.action, "drop");
+  assert.equal(moved.armedSeeded, false);
+  assert.equal(moved.banner, null);
+  assert.equal(moved.reread, true);
+  assert.equal(moved.armed, undefined); // the stale optimistic bit is NOT reconciled
+
+  // A 409 surfaces detail[0].message and leaves the switch in server-truth position
+  // (it would otherwise snap back silently and read as a broken button).
+  const refused = Pet.armedWriteView({
+    scopeMoved: false, next: false,
+    response: { _status: 409, detail: [{ field: "profile", message: "not the equipped profile" }] },
+  });
+  assert.equal(refused.action, "refused");
+  assert.equal(refused.banner, "not the equipped profile");
+  assert.equal(refused.armed, true); // reverted from the optimistic false
+  assert.equal(refused.reread, true);
+
+  // A 422 is handled distinctly from the 409 and from a success.
+  const rejected = Pet.armedWriteView({
+    scopeMoved: false, next: false,
+    response: { _status: 422, detail: [{ field: "profile", message: "gone" }] },
+  });
+  assert.equal(rejected.action, "rejected");
+  assert.equal(rejected.banner, "gone");
+
+  // The ordinary path still reconciles to the authoritative value.
+  const ok = Pet.armedWriteView({ scopeMoved: false, response: { armed: false }, next: false });
+  assert.equal(ok.action, "reconcile");
+  assert.equal(ok.armedSeeded, true);
+  assert.equal(ok.armed, false);
+});
+
+test("js/armed-test-state: the read-only latch seam exists", () => {
+  const st = Pet._armedTestState();
+  assert.equal(Object.keys(st).length, 3);
+  assert.equal(typeof st.busy, "boolean");
+  assert.equal(typeof st.seeded, "boolean");
+  assert.equal(typeof st.confirmPending, "boolean");
+});
+
+// ── D17/D19: invalidation and the payload-derived-state rule ─────────────────
+
+test("js/read-scope-invalidation: a rebind clears every payload-derived fact", async () => {
+  resetState();
+  embedded("beta");
+  Pet.state.readScope = scope("not_equipped");
+  Pet.state.historyReadScope = scope("not_equipped");
+  Pet.state.historyHasOlder = true;
+  Pet.state.spoolTruncated = true;
+  Pet.state.scanHistory = [{ scan_id: "s-beta" }];
+  Pet.state.bypassBySession = { s1: 972 };
+  Pet.state.historyFilter = "selfmod";
+
+  // Drive the real rebind (SDK axis) with a fresh selection.
+  const origConnect = Pet.sse.connect;
+  Pet.sse.connect = function () {};
+  sandbox.window.__HERMES_PLUGIN_SDK__ = {
+    fetchJSON: function () { return Promise.resolve({}); },
+    profileScope: { profile: "gamma", currentProfile: "alpha", profiles: [], subscribe: function () { return function () {}; } },
+  };
+  try {
+    Pet.hostProfile._rebind();
+  } finally {
+    Pet.sse.connect = origConnect;
+    delete sandbox.window.__HERMES_PLUGIN_SDK__;
+  }
+
+  // null is defined as the equipped form, so the transient window degrades toward
+  // the safe direction rather than toward the previous profile's name.
+  assert.equal(Pet.state.readScope, null);
+  assert.equal(Pet.state.historyReadScope, null);
+  assert.equal(Pet.state.historyHasOlder, false);
+  assert.equal(Pet.state.spoolTruncated, false);
+  assert.equal(Pet.state.scanHistory.length, 0);
+  assert.equal(Object.keys(Pet.state.bypassBySession).length, 0); // D17: the headline number
+  assert.equal(Pet.state.historyAtHead, true);
+  assert.equal(Pet.state.historyStack.length, 0);
+  // The arm control is NOT left disabled by the invalidation (a null scope is equipped).
+  assert.equal(Pet.isForeignScope(), false);
+});
+
+test("js/history-filter-survives-scope-change", async () => {
+  resetState();
+  embedded("beta");
+  Pet.state.historyFilter = "selfmod";
+  const origConnect = Pet.sse.connect;
+  Pet.sse.connect = function () {};
+  sandbox.window.__HERMES_PLUGIN_SDK__ = {
+    fetchJSON: function () { return Promise.resolve({}); },
+    profileScope: { profile: "gamma", currentProfile: "alpha", profiles: [], subscribe: function () { return function () {}; } },
+  };
+  try {
+    Pet.hostProfile._rebind();
+  } finally {
+    Pet.sse.connect = origConnect;
+    delete sandbox.window.__HERMES_PLUGIN_SDK__;
+  }
+  // A view preference, not profile data: clearing it would silently discard an
+  // explicit operator selection.
+  assert.equal(Pet.state.historyFilter, "selfmod");
+  // And the resulting empty panel names both the filter and the profile.
+  assert.equal(
+    Pet.historyEmptyState([{}], [], null, "selfmod", true, "gamma").text,
+    "no self-tamper events among the rows retained for gamma"
+  );
+});
+
+test("js/bypass-cleared-on-scope-change: the tile reflects only the new profile", () => {
+  resetState();
+  Pet.accrueBypass([{ event_type: "bypassed_disarmed", session_id: "a1", bypassed_count: 972 }]);
+  assert.equal(Pet.bypassTotal(), 972);
+  // Object.keys().length, never deepEqual (cross-realm prototypes).
+  assert.equal(Object.keys(Pet.state.bypassBySession).length, 1);
+  Pet.state.bypassBySession = {};
+  Pet.accrueBypass([{ event_type: "bypassed_disarmed", session_id: "b1", bypassed_count: 4 }]);
+  assert.equal(Pet.bypassTotal(), 4);
+  assert.equal(Object.keys(Pet.state.bypassBySession).length, 1);
+});
+
+// ── D9: SSE transitions ──────────────────────────────────────────────────────
+
+test("js/read-scope-frame: live false downgrades to SCOPED, zero reconnects", () => {
+  resetState();
+  let reconnects = 0;
+  const origSched = Pet.sse._scheduleReconnect;
+  Pet.sse._scheduleReconnect = function () { reconnects += 1; };
+  try {
+    Pet.sse._dispatch("read_scope", JSON.stringify(scope("not_equipped")));
+  } finally {
+    Pet.sse._scheduleReconnect = origSched;
+  }
+  assert.equal(reconnects, 0);                 // an idle stream is not an outage
+  assert.equal(Pet.sse._usingFallback, false); // and never concedes to polling
+  assert.equal(Pet.sse._scopeLive, false);
+  assert.equal(Pet.connChipView(false, Pet.sse._scopeLive, Pet.sse._scopeRefusal).label, "SCOPED");
+  assert.equal(Pet.state.readScope.state, "not_equipped");
+});
+
+test("js/scope-live-resets-on-reconnect-not-only-connect", () => {
+  // _scheduleReconnect calls _openStream DIRECTLY, so a connect()-only reset would
+  // leave the chip reading SCOPED over a genuinely live stream.
+  resetState();
+  Pet.sse._scopeLive = false;
+  Pet.sse._scopeRefusal = "capacity";
+  Pet.sse._openStream(); // the sandbox fetch never settles, so only the reset runs
+  assert.equal(Pet.sse._scopeLive, true);   // reset lives in _openStream
+  assert.equal(Pet.sse._scopeRefusal, null);
+  assert.equal(Pet.connChipView(false, Pet.sse._scopeLive, Pet.sse._scopeRefusal).label, "LIVE");
+});
+
+// ── D3: the scoped poll ──────────────────────────────────────────────────────
+
+test("js/scope-poll-is-singleton: one timer across switches, cleared on teardown", () => {
+  resetState();
+  embedded("beta");
+  const origConnect = Pet.sse.connect;
+  Pet.sse.connect = function () {};
+  sandbox.window.__HERMES_PLUGIN_SDK__ = {
+    fetchJSON: function () { return Promise.resolve({}); },
+    profileScope: { profile: "", currentProfile: "alpha", profiles: [], subscribe: function () { return function () {}; } },
+  };
+  try {
+    // Three switches: A -> B -> C -> A, each through the real rebind path.
+    for (const name of ["gamma", "delta", "beta"]) {
+      sandbox.window.__HERMES_PLUGIN_SDK__.profileScope.profile = name;
+      Pet.state.readScope = scope("not_equipped", name);
+      Pet.sse._scopeLive = false;
+      Pet.hostProfile._rebind();
+    }
+    assert.equal(Pet._scopePollState().running, true); // exactly one, not four
+    // The gate goes false when a live equipped stream replaces the idle one.
+    Pet.state.readScope = scope("equipped", "beta", "beta");
+    Pet.sse._scopeLive = true;
+    Pet.sse._dispatch("read_scope", JSON.stringify(scope("equipped", "beta", "beta")));
+    Pet.hostProfile._rebind();
+  } finally {
+    Pet.sse.connect = origConnect;
+    delete sandbox.window.__HERMES_PLUGIN_SDK__;
+  }
+  Pet.unmount();
+  assert.equal(Pet._scopePollState().running, false); // cleared on teardown
+});
+
+test("js/scope-poll-survives-equipped-flip-until-a-live-stream-lands", () => {
+  // Keyed on the stream's own liveness as well as the scope: on the SDK-fallback
+  // equipped-flip path there is no rebind and no reconnect, so a scope-only gate
+  // would freeze both the chip and the panel with no path back.
+  resetState();
+  embedded("beta");
+  Pet.state.readScope = scope("not_equipped");
+  Pet.sse._scopeLive = false;
+  Pet.sse._dispatch("read_scope", JSON.stringify(scope("not_equipped")));
+  assert.equal(Pet._scopePollState().running, true);
+
+  // The selection becomes equipped while the stream is STILL the idle one.
+  Pet.state.readScope = scope("equipped", "beta", "beta");
+  Pet.sse._dispatch("read_scope", JSON.stringify(scope("equipped", "beta", "beta")));
+  assert.equal(Pet._scopePollState().running, true); // still polling: the stream is idle
+
+  Pet.unmount();
+  assert.equal(Pet._scopePollState().running, false);
+});
+
+// ── D15: the foreign provenance branch ───────────────────────────────────────
+
+test("js/foreign-provenance-row: not-verifiable copy, never tamper copy", () => {
+  resetState();
+  const panelFor = (prov) => collectText(Pet.scanDetailPanel({
+    scan_id: "e-1", source: "enforcement", event_type: "block", provenance: prov,
+    timestamp: 1, safe: false, tool: "web_request", session_id: "s1", armed: true,
+  })).join(" ");
+
+  const foreign = panelFor("foreign");
+  assert.ok(foreign.indexOf("another profile's key") !== -1, foreign);
+  assert.ok(foreign.indexOf("not verifiable from here") !== -1);
+  // Never the tamper copy: a foreign row is not a forgery claim.
+  assert.ok(foreign.indexOf("may not be a genuine") === -1);
+  // House style, asserted on the added string itself (the panel carries shipped copy too).
+  const added = "Signed by another profile's key; not verifiable from here.";
+  assert.ok(foreign.indexOf(added) !== -1);
+  assert.ok(added.indexOf("—") === -1);
+
+  // The shipped verdicts are untouched, and an unknown value still collapses to
+  // unattested rather than to the new branch.
+  assert.ok(panelFor("unverifiable").indexOf("may not be a genuine") !== -1);
+  assert.ok(panelFor("genuine").indexOf("signature checks out") !== -1);
+  assert.ok(panelFor("weird-value").indexOf("Integrity not configured") !== -1);
+});
+
+function collectText(node, out) {
+  out = out || [];
+  if (!node) return out;
+  if (node.nodeValue != null) out.push(node.nodeValue);
+  const kids = node.childNodes || [];
+  for (let i = 0; i < kids.length; i++) collectText(kids[i], out);
+  return out;
+}

--- a/tests/js/profile-scoped-reads.test.mjs
+++ b/tests/js/profile-scoped-reads.test.mjs
@@ -417,6 +417,39 @@ test("js/read-scope-invalidation: a rebind clears every payload-derived fact", a
   assert.equal(Pet.isForeignScope(), false);
 });
 
+test("js/fallback-poll-drops-superseded-scope: an in-flight resolve across a rebind never lands", async () => {
+  // D17 uniformity: the fallback history poll captures _scopeGen at send time like
+  // the other four scoped readers. Hold its request open across a real rebind, then
+  // settle it with the PREVIOUS profile's rows — nothing may land.
+  resetState();
+  embedded("beta");
+  let resolveHistory;
+  const origGet = Pet.api.getScanHistory;
+  Pet.api.getScanHistory = function () {
+    return new Promise(function (res) { resolveHistory = res; });
+  };
+  const origConnect = Pet.sse.connect;
+  Pet.sse.connect = function () {};
+  sandbox.window.__HERMES_PLUGIN_SDK__ = {
+    fetchJSON: function () { return Promise.resolve({}); },
+    profileScope: { profile: "gamma", currentProfile: "alpha", profiles: [], subscribe: function () { return function () {}; } },
+  };
+  try {
+    Pet._poll.startFallback();   // issues the initial read, held open above
+    Pet.hostProfile._rebind();   // bumps the scope generation mid-flight
+    resolveHistory({ entries: [{ scan_id: "s-beta-stale" }], read_scope: scope("not_equipped", "beta") });
+    await flush();
+    assert.equal(Pet.state.scanHistory.length, 0, "stale rows dropped");
+    assert.equal(Pet.state.historyReadScope, null, "stale scope label dropped");
+    assert.equal(Object.keys(Pet.state.bypassBySession).length, 0, "no bypass accrual off a dropped page");
+  } finally {
+    Pet.api.getScanHistory = origGet;
+    Pet.sse.connect = origConnect;
+    delete sandbox.window.__HERMES_PLUGIN_SDK__;
+    Pet.unmount(); // clears the fallback timer so later tests see a quiet slate
+  }
+});
+
 test("js/history-filter-survives-scope-change", async () => {
   resetState();
   embedded("beta");

--- a/tests/test_console_armed.py
+++ b/tests/test_console_armed.py
@@ -221,7 +221,7 @@ def client(request: pytest.FixtureRequest) -> Iterator[tuple[Any, str]]:
 
 
 def test_get_armed_reflects_read(client: tuple[Any, str], monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(armed_mod, "read_armed", lambda: False)
+    monkeypatch.setattr(armed_mod, "read_armed", lambda res=None: False)
     tc, path = client
     r = tc.get(path)
     assert r.status_code == 200

--- a/tests/test_console_auth.py
+++ b/tests/test_console_auth.py
@@ -45,7 +45,7 @@ def armed_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[dict[str, bool]]:
     """
     state = {"armed": True}
 
-    def _read() -> bool:
+    def _read(res: object = None) -> bool:
         return state["armed"]
 
     def _write(value: bool) -> bool:

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -547,7 +547,7 @@ async def test_get_armed_reflects_read(
 ) -> None:
     import petasos.console._armed as armed_mod
 
-    monkeypatch.setattr(armed_mod, "read_armed", lambda: False)
+    monkeypatch.setattr(armed_mod, "read_armed", lambda res=None: False)
     assert await handlers.get_armed() == {"armed": False}
 
 

--- a/tests/test_console_profile_scoped_reads.py
+++ b/tests/test_console_profile_scoped_reads.py
@@ -1,0 +1,819 @@
+"""PET-166: profile-scoped console read surfaces.
+
+Two-profile isolation, the 422/409 validation contracts, the non-destructive
+bounded non-equipped read, sink/spool merge and dedup, the `foreign` attestation
+domain, cursor scope-binding, and the binding-state matrix.
+
+The module installs its own fixture that CLEARS the two autouse path overrides
+from ``tests/conftest.py``. Both win unconditionally by design (so existing
+single-binding tests are unaffected), which means a scoped read here would never
+touch a real profile home: the isolation tests would fail confusingly and the
+non-destructive / branch-parity tests would pass vacuously against the shared
+override file. It also clears ``HERMES_HOME``, because
+``resolve_hermes_config_path()`` checks that variable FIRST and an inherited
+machine-scope pin (exactly what the field report found) would put the binding
+outside the temp root and invert every isolation test's premise.
+"""
+
+import json
+import math
+import os
+import platform
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import petasos.console._armed as armed_mod  # noqa: E402
+import petasos.console._events as events_mod  # noqa: E402
+import petasos.console._history as history_mod  # noqa: E402
+import petasos.console._paths as paths_mod  # noqa: E402
+import petasos.console.server as server_mod  # noqa: E402
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console.server import (  # noqa: E402
+    ConsoleHandlers,
+    CursorScopeMismatchError,
+    ProfileNotEquippedError,
+    ProfileNotFoundError,
+)
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+_SCOPED_ROUTES = ("scan-history", "armed-get", "armed-post", "health", "events")
+
+
+def _sign(rec: dict[str, Any], key: bytes) -> str:
+    """Stamp the same HMAC the spool writer does (mirrors _events.verify_event)."""
+    import hashlib
+    import hmac
+
+    rest = {k: v for k, v in rec.items() if k != "sig"}
+    preimage = json.dumps(rest, sort_keys=True, separators=(",", ":"), default=str)
+    return hmac.new(key, preimage.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _make_handlers(secret: bytes | None = None) -> ConsoleHandlers:
+    return ConsoleHandlers(
+        Pipeline(
+            scanners=[MinimalScanner()],
+            config=PetasosConfig(fail_mode="degraded", session_secret=secret),
+            host_id="test-host",
+        )
+    )
+
+
+def _sink_row(scan_id: str, ts: float, **extra: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {"scan_id": scan_id, "timestamp": ts, "safe": True, "source": "scan"}
+    row.update(extra)
+    return row
+
+
+def _spool_event(scan_id: str, ts: float, **extra: Any) -> dict[str, Any]:
+    ev: dict[str, Any] = {
+        "scan_id": scan_id,
+        "timestamp": ts,
+        "event_type": "block",
+        "session_id": "s1",
+        "tool": "write_file",
+    }
+    ev.update(extra)
+    return ev
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+class _Home:
+    """One profile home plus writers for its four read segments."""
+
+    def __init__(self, root: Path, name: str) -> None:
+        self.name = name
+        self.dir = root / "profiles" / name
+        self.dir.mkdir(parents=True, exist_ok=True)
+        (self.dir / "config.yaml").write_text("petasos:\n  enabled: true\n", encoding="utf-8")
+
+    @property
+    def sink(self) -> Path:
+        return self.dir / "petasos-scan-history.jsonl"
+
+    @property
+    def spool(self) -> Path:
+        return self.dir / "petasos-enforcement.jsonl"
+
+    def set_armed(self, armed: bool) -> None:
+        (self.dir / "config.yaml").write_text(
+            f"petasos:\n  enabled: {str(armed).lower()}\n", encoding="utf-8"
+        )
+        armed_mod._reset_armed_cache()
+
+    def seed(
+        self,
+        sink: list[dict[str, Any]] | None = None,
+        sink_rot: list[dict[str, Any]] | None = None,
+        spool: list[dict[str, Any]] | None = None,
+        spool_rot: list[dict[str, Any]] | None = None,
+    ) -> None:
+        if sink:
+            _write_jsonl(self.sink, sink)
+        if sink_rot:
+            _write_jsonl(Path(str(self.sink) + ".rot"), sink_rot)
+        if spool:
+            _write_jsonl(self.spool, spool)
+        if spool_rot:
+            _write_jsonl(Path(str(self.spool) + ".rot"), spool_rot)
+
+
+class _Env:
+    def __init__(self, root: Path, alpha: _Home, beta: _Home) -> None:
+        self.root = root
+        self.alpha = alpha
+        self.beta = beta
+
+    def activate(self, name: str) -> None:
+        (self.root / "active_profile").write_text(name, encoding="utf-8")
+        armed_mod._reset_armed_cache()
+
+
+@pytest.fixture()
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[_Env]:
+    # Clear both autouse overrides so a scoped read reaches a real profile home,
+    # restoring them on teardown (they are module globals the conftest fixtures
+    # also restore, so ordering is safe either way).
+    saved_spool = paths_mod._SPOOL_PATH_OVERRIDE
+    saved_hist = history_mod._HISTORY_PATH_OVERRIDE
+    saved_cap = server_mod._FOREIGN_SPOOL_READ_CAP
+    paths_mod._SPOOL_PATH_OVERRIDE = None
+    history_mod._HISTORY_PATH_OVERRIDE = None
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    root = paths_mod.hermes_root()
+    (root / "profiles").mkdir(parents=True, exist_ok=True)
+    e = _Env(root, _Home(root, "alpha"), _Home(root, "beta"))
+    e.activate("alpha")
+    armed_mod._reset_armed_cache()
+    try:
+        yield e
+    finally:
+        paths_mod._SPOOL_PATH_OVERRIDE = saved_spool
+        history_mod._HISTORY_PATH_OVERRIDE = saved_hist
+        server_mod._FOREIGN_SPOOL_READ_CAP = saved_cap
+        armed_mod._reset_armed_cache()
+
+
+def _assert_under(path: str, home: _Home) -> None:
+    """Every isolation assertion also pins the resolved path under the intended
+    home, so a re-armed override can never make one vacuous."""
+    assert os.path.normcase(str(home.dir)) in os.path.normcase(path)
+
+
+# ── Isolation, merge, and bounds ──────────────────────────────────────────
+
+
+async def test_scan_history_serves_selected_profile(env: _Env) -> None:
+    env.alpha.seed(sink=[_sink_row("s-alpha", 100.0)])
+    env.beta.seed(sink=[_sink_row("s-beta", 200.0)])
+    h = _make_handlers()
+    beta_res = paths_mod.resolve_profile_config_path("beta")
+    _assert_under(history_mod._history_path(beta_res), env.beta)
+
+    out = await h.get_scan_history(profile="beta")
+    ids = [r["scan_id"] for r in out["entries"]]
+    assert ids == ["s-beta"]
+    assert out["read_scope"]["state"] == "not_equipped"
+    assert out["read_scope"]["selected"] == "beta"
+    assert out["read_scope"]["equipped"] == "alpha"
+    assert out["read_scope"]["live"] is False
+
+
+async def test_scan_history_absent_profile_is_unchanged(env: _Env) -> None:
+    # D2, the byte-identity fence: no parameter -> the equipped ring window with the
+    # pre-change keys, an UNPREFIXED next_before, and none of the new keys.
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-ring", "timestamp": 500.0, "safe": True})
+    out = await h.get_scan_history()
+    assert set(out) == {"entries", "next_before", "older_truncated"}
+    assert [r["scan_id"] for r in out["entries"]] == ["s-ring"]
+    assert out["next_before"] is not None and "|" not in out["next_before"]
+
+
+async def test_non_equipped_read_is_non_destructive(env: _Env) -> None:
+    env.beta.seed(spool=[_spool_event("e-b1", 10.0)], spool_rot=[_spool_event("e-b2", 5.0)])
+    rot = Path(str(env.beta.spool) + ".rot")
+    before_live = env.beta.spool.read_bytes()
+    before_rot = rot.read_bytes()
+    h = _make_handlers()
+    off_before = h._enforcement_offset
+
+    await h.get_scan_history(profile="beta")
+
+    assert env.beta.spool.read_bytes() == before_live
+    assert rot.exists() and rot.read_bytes() == before_rot
+    assert h._enforcement_offset == off_before
+    assert not env.beta.sink.exists()  # nothing appended to beta
+
+
+async def test_non_equipped_read_includes_rotated_spool(env: _Env) -> None:
+    env.beta.seed(spool_rot=[_spool_event("e-rot", 7.0)])
+    rot = Path(str(env.beta.spool) + ".rot")
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert [r["scan_id"] for r in out["entries"]] == ["e-rot"]
+    assert rot.exists()
+
+
+async def test_equipped_drain_still_runs_under_a_scoped_read(env: _Env) -> None:
+    # D3: the drain is hoisted above the branch — we always drain our own binding.
+    env.alpha.seed(spool=[_spool_event("e-alpha", 42.0)])
+    env.beta.seed(sink=[_sink_row("s-beta", 1.0)])
+    h = _make_handlers()
+    broadcast: list[str] = []
+
+    async def _spy(event_type: str, data: dict[str, Any]) -> None:
+        broadcast.append(event_type)
+
+    h.sse.broadcast = _spy  # type: ignore[method-assign]
+    await h.get_scan_history(profile="beta")
+
+    assert h._enforcement_offset > 0  # alpha's offset advanced
+    assert "scan_result" in broadcast  # and its event was surfaced
+    assert h._scans_total == 1
+
+
+async def test_sink_and_spool_merge_dedups_by_scan_id(env: _Env) -> None:
+    env.beta.seed(
+        sink=[_sink_row("e-dup", 10.0, source="enforcement", detail_marker="sink")],
+        spool=[_spool_event("e-dup", 10.0)],
+    )
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert len(out["entries"]) == 1
+    assert out["entries"][0].get("detail_marker") == "sink"  # sink wins (determinism)
+
+
+async def test_duplicate_across_sink_segments_dedups(env: _Env) -> None:
+    env.beta.seed(sink=[_sink_row("s-x", 3.0)], sink_rot=[_sink_row("s-x", 3.0)])
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert [r["scan_id"] for r in out["entries"]] == ["s-x"]
+
+
+async def test_unorderable_rows_are_dropped(env: _Env) -> None:
+    env.beta.seed(
+        spool=[
+            {"timestamp": 1.0},  # no scan_id
+            _spool_event("e-str", "nope"),  # type: ignore[arg-type]
+            {"scan_id": "e-nots"},  # no timestamp
+            _spool_event("e-bool", True),
+            _spool_event("e-ok", 9.0),
+        ]
+    )
+    with open(env.beta.spool, "a", encoding="utf-8") as f:
+        f.write("[1, 2, 3]\n")  # a non-dict line
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert [r["scan_id"] for r in out["entries"]] == ["e-ok"]
+
+
+async def test_out_of_range_timestamp_is_dropped_not_raised(env: _Env) -> None:
+    # The crash lives INSIDE read_history_page's own key computation, which sits
+    # outside every try in that function, so it fires before the merge filter runs.
+    env.beta.seed(sink=[_sink_row("s-huge", 0.0), _sink_row("s-ok", 4.0)])
+    with open(env.beta.sink, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"scan_id": "s-big", "timestamp": 10**400}) + "\n")
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    ids = [r["scan_id"] for r in out["entries"]]
+    assert "s-big" not in ids
+    assert set(ids) == {"s-huge", "s-ok"}
+
+
+def test_read_history_page_drops_unfloatable_timestamp(tmp_path: Path) -> None:
+    p = tmp_path / "sink.jsonl"
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(json.dumps({"scan_id": "a", "timestamp": 10**400}) + "\n")
+        f.write('{"scan_id": "b", "timestamp": Infinity}\n')
+        f.write('{"scan_id": "c", "timestamp": NaN}\n')
+        f.write(json.dumps({"scan_id": "d", "timestamp": 1.0}) + "\n")
+    rows, _ = history_mod.read_history_page(str(p), before=None, limit=10)
+    assert [r["scan_id"] for r in rows] == ["d"]
+    assert all(math.isfinite(float(r["timestamp"])) for r in rows)
+
+
+async def test_equipped_scoped_read_reports_spool_truncated_false(env: _Env) -> None:
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="alpha")
+    assert out["read_scope"]["state"] == "equipped"
+    assert out["spool_truncated"] is False  # present, not absent
+    assert "has_older" not in out  # non-equipped branch only (D12)
+
+
+async def test_merged_page_orders_by_timestamp_scan_id(env: _Env) -> None:
+    env.beta.seed(
+        sink=[_sink_row("s-a", 1.0), _sink_row("s-c", 3.0)],
+        spool=[_spool_event("e-b", 2.0), _spool_event("e-d", 3.0)],
+    )
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert [r["scan_id"] for r in out["entries"]] == ["s-c", "e-d", "e-b", "s-a"]
+
+
+async def test_older_truncated_uses_merged_oldest(env: _Env) -> None:
+    # The spool holds the oldest row, so forwarding read_history_page's own flag
+    # would report a true bottom above it.
+    env.beta.seed(sink=[_sink_row("s-new", 100.0)], spool=[_spool_event("e-old", 1.0)])
+    h = _make_handlers()
+    head = await h.get_scan_history(limit=1, profile="beta")
+    assert [r["scan_id"] for r in head["entries"]] == ["s-new"]
+    page = await h.get_scan_history(limit=1, before=head["next_before"], profile="beta")
+    assert [r["scan_id"] for r in page["entries"]] == ["e-old"]
+    assert page["older_truncated"] is False
+    bottom = await h.get_scan_history(limit=1, before=page["next_before"], profile="beta")
+    assert bottom["entries"] == []
+    # The merged bottom is a true bottom, not a rotation loss: the cursor is not
+    # older than the merged global oldest, so older_truncated stays False.
+    assert bottom["older_truncated"] is False
+
+
+async def test_branches_agree_when_spool_empty(env: _Env) -> None:
+    rows = [_sink_row(f"s-{i}", float(i)) for i in range(5)]
+    env.beta.seed(sink=rows)
+    h = _make_handlers()
+    merged = await h.get_scan_history(profile="beta")
+    direct, _ = history_mod.read_history_page(str(env.beta.sink), before=None, limit=100)
+    assert [r["scan_id"] for r in merged["entries"]] == [r["scan_id"] for r in direct]
+
+
+async def test_oversized_foreign_spool_is_bounded(env: _Env) -> None:
+    server_mod._FOREIGN_SPOOL_READ_CAP = 400
+    env.beta.seed(spool=[_spool_event(f"e-{i}", float(i), pad="x" * 60) for i in range(20)])
+    assert os.path.getsize(env.beta.spool) > 400
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["spool_truncated"] is True
+    assert out["entries"]  # the tail was read
+    assert len(out["entries"]) < 20  # and the head was clipped
+    # No leading partial line survived: every row parsed with a real scan_id.
+    assert all(str(r["scan_id"]).startswith("e-") for r in out["entries"])
+
+
+def test_spool_window_without_newline_yields_no_events(env: _Env) -> None:
+    server_mod._FOREIGN_SPOOL_READ_CAP = 20
+    env.beta.spool.write_text("x" * 500, encoding="utf-8")
+    events, truncated = server_mod.read_spool_tail(str(env.beta.spool))
+    assert events == []
+    assert truncated is True
+
+
+def test_subcap_spool_without_newline_is_not_truncated(env: _Env) -> None:
+    # A sub-cap file holding one in-flight partial line: no events, and NOT
+    # truncated — the retention notice must not render over benign torn bytes.
+    server_mod._FOREIGN_SPOOL_READ_CAP = 2_000_000
+    env.beta.spool.write_text("x" * 500, encoding="utf-8")
+    events, truncated = server_mod.read_spool_tail(str(env.beta.spool))
+    assert events == []
+    assert truncated is False
+
+
+# ── Validation contracts ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("route", _SCOPED_ROUTES)
+async def test_unknown_profile_422_on_every_scoped_route(env: _Env, route: str) -> None:
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        if route == "scan-history":
+            await h.get_scan_history(profile="ghost")
+        elif route == "armed-get":
+            await h.get_armed(profile="ghost")
+        elif route == "armed-post":
+            await h.set_armed(False, profile="ghost")
+        elif route == "health":
+            await h.get_health(profile="ghost")
+        else:
+            h.resolve_events_scope("ghost")
+
+
+@pytest.mark.parametrize("name", ["nfd", "nfc"])
+async def test_unknown_profile_422_unicode_normalization(env: _Env, name: str) -> None:
+    # D7: matching is byte-exact; NFD and NFC forms of one name are distinct, so a
+    # macOS-decomposed leaf name is a known non-member. Pinned, not incidental.
+    _Home(env.root, "café")  # NFC on disk
+    h = _make_handlers()
+    probe = "café" if name == "nfc" else "café"
+    if name == "nfc":
+        out = await h.get_scan_history(profile=probe)
+        assert out["read_scope"]["selected"] == probe
+    else:
+        with pytest.raises(ProfileNotFoundError):
+            await h.get_scan_history(profile=probe)
+
+
+@pytest.mark.parametrize("blank", ["", " "])
+async def test_blank_profile_422(env: _Env, blank: str) -> None:
+    # A blank value reaches the membership gate and 422s; it never serves equipped.
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_scan_history(profile=blank)
+
+
+async def test_deleted_profile_422(env: _Env) -> None:
+    h = _make_handlers()
+    await h.get_scan_history(profile="beta")  # resolves while it exists
+    (env.beta.dir / "config.yaml").unlink()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_scan_history(profile="beta")
+
+
+async def test_case_variant_profile_422(env: _Env) -> None:
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_scan_history(profile="BETA")
+
+
+async def test_profile_without_config_yaml_422(env: _Env) -> None:
+    (env.root / "profiles" / "fresh").mkdir(parents=True, exist_ok=True)
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_scan_history(profile="fresh")
+
+
+@pytest.mark.parametrize("name", ["../beta", "..", "/etc", "beta/../alpha"])
+async def test_traversal_name_rejected(env: _Env, name: str) -> None:
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_scan_history(profile=name)
+
+
+async def test_foreign_cursor_rejected(env: _Env) -> None:
+    # alpha is equipped, so its scoped head read serves the ring; either way the
+    # token it mints is scope-bound to alpha and must not page beta.
+    env.beta.seed(sink=[_sink_row("s-b", 2.0)])
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-a", "timestamp": 1.0, "safe": True})
+    alpha_page = await h.get_scan_history(profile="alpha")
+    assert alpha_page["next_before"] is not None
+    with pytest.raises(CursorScopeMismatchError):
+        await h.get_scan_history(before=alpha_page["next_before"], profile="beta")
+
+
+async def test_unscoped_cursor_replayed_under_no_scope_is_422(env: _Env) -> None:
+    # D2's one named body-level exception: a prefixed token with NO parameter is a
+    # 422, where today any unparseable token is a 200 empty page.
+    env.beta.seed(sink=[_sink_row("s-b", 2.0)])
+    h = _make_handlers()
+    page = await h.get_scan_history(profile="beta")
+    with pytest.raises(CursorScopeMismatchError):
+        await h.get_scan_history(before=page["next_before"])
+
+
+async def test_unprefixed_cursor_under_a_scope_is_422(env: _Env) -> None:
+    # The other direction: an unprefixed token WITH a profile must not fall
+    # through to the shipped two-segment parse and return a plausible page.
+    env.beta.seed(sink=[_sink_row("s-b", 2.0)])
+    h = _make_handlers()
+    with pytest.raises(CursorScopeMismatchError):
+        await h.get_scan_history(before="2.0~s-b", profile="beta")
+
+
+async def test_unscoped_cursor_format_unchanged(env: _Env) -> None:
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-ring", "timestamp": 7.0, "safe": True})
+    out = await h.get_scan_history()
+    assert out["next_before"] == "7.0~s-ring"
+
+
+async def test_equipped_named_cursor_round_trips(env: _Env) -> None:
+    # An INTEGER timestamp survives the float() coercion in the mint, so the token
+    # round-trips against the parser.
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-1", "timestamp": 5, "safe": True})
+    h._record_scan({"scan_id": "s-2", "timestamp": 6, "safe": True})
+    page = await h.get_scan_history(limit=1, before=None, profile="alpha")
+    tok = page["next_before"]
+    assert tok is not None and tok.startswith("alpha|")
+    cursor, status = server_mod._parse_history_cursor(tok, "alpha")
+    assert status == "ok"
+    assert cursor is not None and cursor[0] == 6.0
+
+
+@pytest.mark.parametrize("sid", ["e-a|b", "e-a~b", "e-a~b|c", "e-a%b"])
+def test_delimiter_bearing_scan_id_round_trips(sid: str) -> None:
+    tok = server_mod._history_cursor_token({"timestamp": 1.5, "scan_id": sid}, "beta")
+    assert tok is not None
+    # Exactly one structural delimiter of each kind survives the escape.
+    assert tok.count("|") == 1
+    assert tok.count("~") == 1
+    cursor, status = server_mod._parse_history_cursor(tok, "beta")
+    assert status == "ok"
+    assert cursor == (1.5, sid)
+
+
+def test_cursor_scope_name_is_escaped() -> None:
+    tok = server_mod._history_cursor_token({"timestamp": 1.0, "scan_id": "s-a"}, "we|ird~name")
+    assert tok is not None and tok.count("|") == 1 and tok.count("~") == 1
+    assert server_mod._parse_history_cursor(tok, "we|ird~name")[1] == "ok"
+
+
+# ── Armed ─────────────────────────────────────────────────────────────────
+
+
+async def test_armed_reads_selected_profile(env: _Env) -> None:
+    env.alpha.set_armed(True)
+    env.beta.set_armed(False)
+    h = _make_handlers()
+    assert (await h.get_armed(profile="alpha"))["armed"] is True
+    assert (await h.get_armed(profile="beta"))["armed"] is False
+    assert (await h.get_armed())["armed"] is True  # unscoped -> the equipped binding
+
+
+async def test_armed_cache_not_confused_by_identical_stat_key(env: _Env) -> None:
+    # Two configs with equal size and forced-equal mtime: the pre-PET-166 stat-only
+    # key would serve one profile's bit for the other.
+    env.alpha.set_armed(True)
+    env.beta.set_armed(False)
+    a_cfg, b_cfg = env.alpha.dir / "config.yaml", env.beta.dir / "config.yaml"
+    # Equal SIZE with both values still real booleans: pad the shorter one with a
+    # comment so a bool-vs-garbage difference cannot be what the test observes.
+    a_cfg.write_text("petasos:\n  enabled: true  #pad\n", encoding="utf-8")
+    b_cfg.write_text("petasos:\n  enabled: false #pad\n", encoding="utf-8")
+    st = a_cfg.stat()
+    os.utime(b_cfg, ns=(st.st_atime_ns, st.st_mtime_ns))
+    assert b_cfg.stat().st_size == a_cfg.stat().st_size
+    assert b_cfg.stat().st_mtime_ns == a_cfg.stat().st_mtime_ns
+    armed_mod._reset_armed_cache()
+
+    h = _make_handlers()
+    assert (await h.get_armed(profile="alpha"))["armed"] is True
+    assert (await h.get_armed(profile="beta"))["armed"] is False
+    assert (await h.get_armed(profile="alpha"))["armed"] is True
+
+
+def test_armed_cache_bounded(env: _Env) -> None:
+    armed_mod._reset_armed_cache()
+    now = time.monotonic()
+    for i in range(armed_mod._ARMED_CACHE_MAX + 4):
+        armed_mod._cache_store((f"p{i}", i, i), True, now)
+    assert len(armed_mod._ARMED_CACHE) == armed_mod._ARMED_CACHE_MAX
+    assert ("p0", 0, 0) not in armed_mod._ARMED_CACHE  # oldest evicted
+    assert ("p11", 11, 11) in armed_mod._ARMED_CACHE  # newest retained
+
+
+async def test_set_armed_non_equipped_is_409(env: _Env) -> None:
+    before = (env.beta.dir / "config.yaml").read_bytes()
+    h = _make_handlers()
+    with pytest.raises(ProfileNotEquippedError) as exc:
+        await h.set_armed(False, profile="beta")
+    assert "alpha" in str(exc.value)  # names the equipped profile
+    assert "persist" not in str(exc.value).lower()  # not the 503 persistence body
+    assert (env.beta.dir / "config.yaml").read_bytes() == before
+
+
+async def test_set_armed_equipped_unchanged(env: _Env) -> None:
+    h = _make_handlers()
+    result, ok = await h.set_armed(False, profile="alpha")
+    assert ok is True
+    assert result["armed"] is False and result["persisted"] is True
+    assert result["read_scope"]["state"] == "equipped"
+    assert armed_mod.read_armed(paths_mod.resolve_profile_config_path("alpha")) is False
+
+
+async def test_set_armed_unscoped_shape_is_unchanged(env: _Env) -> None:
+    h = _make_handlers()
+    result, ok = await h.set_armed(False)
+    assert ok is True
+    assert result == {"armed": False, "persisted": True}  # D2: no new keys
+
+
+# ── Attestation domain (D15) ──────────────────────────────────────────────
+
+
+async def test_spool_rows_verified_with_spool_key(env: _Env) -> None:
+    # Regression fence on the EQUIPPED branch: a correctly signed spool row is
+    # `genuine`, never `unverifiable`. Pins shipped PET-139 behavior.
+    h = _make_handlers(secret=b"secret-value-for-testing-0123456")
+    key = events_mod._derive_spool_key(b"secret-value-for-testing-0123456")
+    ev = _spool_event("e-signed", 12.0)
+    ev["sig"] = _sign(ev, key)
+    _write_jsonl(env.alpha.spool, [ev])
+    out = await h.get_scan_history()
+    assert [r["provenance"] for r in out["entries"]] == ["genuine"]
+
+
+async def test_non_equipped_rows_are_foreign(env: _Env) -> None:
+    h = _make_handlers(secret=b"secret-value-for-testing-0123456")
+    other = events_mod._derive_spool_key(b"another-profiles-secret-value-00")
+    ev = _spool_event("e-beta", 3.0)
+    ev["sig"] = _sign(ev, other)
+    env.beta.seed(sink=[_sink_row("s-beta", 4.0, sig="deadbeef")], spool=[ev])
+
+    out = await h.get_scan_history(profile="beta")
+    assert {r["provenance"] for r in out["entries"]} == {"foreign"}
+    assert all("sig" not in r for r in out["entries"])  # the sink row's sig is stripped
+
+
+async def test_non_equipped_read_does_not_touch_integrity_state(env: _Env) -> None:
+    h = _make_handlers(secret=b"secret-value-for-testing-0123456")
+    env.beta.seed(
+        spool=[
+            _spool_event("e-unsigned", 3.0),
+            _spool_event("e-selfmod", 4.0, event_type="selfmod_attempt"),
+        ]
+    )
+    await h.get_scan_history(profile="beta")
+    assert list(h._integrity_recent) == []
+    assert h._selfmod_total == 0
+    assert h._block_tally == {}
+    assert h._integrity_preflight_emitted is False
+    assert (await h.get_health())["integrity"]["window_size"] == 0
+
+
+# ── Scope reporting and binding states ────────────────────────────────────
+
+
+async def test_read_scope_shape_identical_across_surfaces(env: _Env) -> None:
+    h = _make_handlers()
+    hist = await h.get_scan_history(profile="beta")
+    armed = await h.get_armed(profile="beta")
+    health = await h.get_health(profile="beta")
+    idle = server_mod._read_scope_payload(h.resolve_events_scope("beta"))
+    keys = {"selected", "equipped", "equipped_tier", "live", "state"}
+    for payload in (hist["read_scope"], armed["read_scope"], health["read_scope"], idle):
+        assert set(payload) == keys
+    assert hist["read_scope"] == armed["read_scope"] == health["read_scope"] == idle
+
+
+async def test_read_scope_absent_when_unscoped(env: _Env) -> None:
+    h = _make_handlers()
+    assert "read_scope" not in await h.get_scan_history()
+    assert "spool_truncated" not in await h.get_scan_history()
+    assert "read_scope" not in await h.get_armed()
+    assert "read_scope" not in await h.get_health()
+
+
+async def test_has_older_reflects_the_merged_clamp(env: _Env) -> None:
+    limit = 5
+    env.beta.seed(sink=[_sink_row(f"s-{i:02d}", float(i)) for i in range(limit + 3)])
+    h = _make_handlers()
+    out = await h.get_scan_history(limit=limit, profile="beta")
+    assert out["has_older"] is True
+
+    env2_rows = [_sink_row(f"t-{i:02d}", float(i)) for i in range(limit - 1)]
+    _write_jsonl(env.alpha.dir.parent / "gamma" / "petasos-scan-history.jsonl", env2_rows)
+    _Home(env.root, "gamma")
+    _write_jsonl(env.root / "profiles" / "gamma" / "petasos-scan-history.jsonl", [])
+    small = await h.get_scan_history(limit=limit, profile="gamma")
+    assert small["has_older"] is False
+    assert small["next_before"] is not None  # the two are not the same signal
+    # And absent on the equipped and unscoped payloads (D2/D12).
+    assert "has_older" not in await h.get_scan_history(profile="alpha")
+    assert "has_older" not in await h.get_scan_history()
+
+
+async def test_health_reports_scope_and_does_not_fabricate(env: _Env) -> None:
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-1", "timestamp": 1.0, "safe": True})
+    scoped = await h.get_health(profile="beta")
+    unscoped = await h.get_health()
+    assert scoped["read_scope"]["state"] == "not_equipped"
+    # Every process fact is reported identically: health is NOT per-profile.
+    assert scoped["pipeline"] == unscoped["pipeline"]
+    assert scoped["scanners"] == unscoped["scanners"]
+
+
+async def test_hermes_home_inside_profiles_is_equipped(
+    env: _Env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # D16: HERMES_HOME pointed inside profiles/ resolves to tier hermes_home with a
+    # path byte-equal to the profile's, so PATH equality (not tier) decides.
+    monkeypatch.setenv("HERMES_HOME", str(env.beta.dir))
+    armed_mod._reset_armed_cache()
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["read_scope"]["state"] == "equipped"
+    assert out["read_scope"]["equipped"] == "beta"
+    assert out["read_scope"]["equipped_tier"] == "profile"
+    assert out["read_scope"]["live"] is True
+
+
+async def test_hermes_home_outside_profiles_has_no_equipped_name(
+    env: _Env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "config.yaml").write_text("petasos:\n  enabled: true\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(outside))
+    armed_mod._reset_armed_cache()
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["read_scope"]["equipped"] is None
+    assert out["read_scope"]["equipped_tier"] == "hermes_home"
+    # An UNSCOPED post still arms (the only arming target that exists).
+    _, ok = await h.set_armed(False)
+    assert ok is True
+
+
+async def test_root_tier_scope_reports_tier(env: _Env) -> None:
+    (env.root / "active_profile").unlink()
+    (env.root / "config.yaml").write_text("petasos:\n  enabled: true\n", encoding="utf-8")
+    armed_mod._reset_armed_cache()
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["read_scope"]["equipped"] is None
+    assert out["read_scope"]["equipped_tier"] == "root"
+
+
+async def test_unresolvable_equipped_path_is_unknown_and_still_allows_unscoped_arm(
+    env: _Env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real = paths_mod._resolved_normcase
+    equipped_cfg = env.alpha.dir / "config.yaml"
+
+    def _fake(path: Path) -> str | None:
+        if os.path.normcase(str(path)) == os.path.normcase(str(equipped_cfg)):
+            return None  # the EQUIPPED side fails to resolve
+        return real(path)
+
+    monkeypatch.setattr(server_mod, "_resolved_normcase", _fake)
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["read_scope"]["state"] == "unknown"
+    assert out["read_scope"]["live"] is False  # reads take the non-equipped branch
+    _, ok = await h.set_armed(False)  # arming remains available, unscoped
+    assert ok is True
+
+
+async def test_both_paths_unresolvable_is_not_equipped(
+    env: _Env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # D10 step 4 ordering: a flat comparison would read None == None as equipped and
+    # let a scoped disarm through the D6 guard into the running agent's config.
+    monkeypatch.setattr(server_mod, "_resolved_normcase", lambda _p: None)
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["read_scope"]["state"] != "equipped"
+    with pytest.raises(ProfileNotEquippedError):
+        await h.set_armed(False, profile="beta")
+
+
+async def test_ring_cleared_on_binding_change(env: _Env) -> None:
+    h = _make_handlers()
+    await h.get_scan_history()  # first drain adopts alpha's spool
+    h._record_scan({"scan_id": "s-alpha-ring", "timestamp": 9.0, "safe": True})
+    total_before = h._scans_total
+
+    env.activate("beta")  # the binding moves
+    out = await h.get_scan_history(profile="beta")
+    assert [r["scan_id"] for r in out["entries"]] == []
+    assert h._scans_total == total_before  # lifetime counters survive
+
+
+async def test_first_drain_does_not_clear_the_ring(env: _Env) -> None:
+    # Embedded Hermes runs no preflight drain, so the FIRST drain of every process
+    # takes the binding-change branch by construction. An unguarded clear would wipe
+    # a pre-drain playground row here (and pass under standalone's preflight).
+    h = _make_handlers()
+    h._record_scan({"scan_id": "s-playground", "timestamp": 3.0, "safe": True})
+    out = await h.get_scan_history()
+    assert [r["scan_id"] for r in out["entries"]] == ["s-playground"]
+
+
+async def test_unscoped_read_logs_scope_tripwire_once_embedded_only(
+    env: _Env, caplog: pytest.LogCaptureFixture
+) -> None:
+    h = _make_handlers()
+    with caplog.at_level("INFO", logger="petasos.console.server"):
+        await h.get_scan_history()  # standalone: no flag, no line
+        assert "PETASOS_SCOPE_UNSCOPED_READ" not in caplog.text
+        h._embedded = True
+        await h.get_scan_history()
+        await h.get_armed()
+        await h.get_health()
+    assert caplog.text.count("PETASOS_SCOPE_UNSCOPED_READ") == 1
+
+
+async def test_scope_tripwire_silent_without_an_active_profile(
+    env: _Env, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Two profiles, none active: D16's legitimate equipped_name-is-null configuration,
+    # where the client correctly omits the selector. Not a stale bundle.
+    (env.root / "active_profile").unlink()
+    armed_mod._reset_armed_cache()
+    h = _make_handlers()
+    h._embedded = True
+    with caplog.at_level("INFO", logger="petasos.console.server"):
+        await h.get_scan_history()
+    assert "PETASOS_SCOPE_UNSCOPED_READ" not in caplog.text

--- a/tests/test_console_profile_scoped_reads.py
+++ b/tests/test_console_profile_scoped_reads.py
@@ -20,6 +20,7 @@ import math
 import os
 import platform
 import time
+import unicodedata
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -370,6 +371,35 @@ async def test_oversized_foreign_spool_is_bounded(env: _Env) -> None:
     assert all(str(r["scan_id"]).startswith("e-") for r in out["entries"])
 
 
+@pytest.mark.parametrize("segment", ["live", "rot"])
+async def test_oversized_foreign_sink_is_skipped_and_reported(env: _Env, segment: str) -> None:
+    # The sink read carries the same per-segment size gate as the spool reads: an
+    # over-cap segment (either live or .rot) skips the whole sink rather than load
+    # an attacker-grown file, and the loss surfaces through spool_truncated. Spool
+    # rows still serve — the gate bounds memory, it does not blank the page.
+    server_mod._FOREIGN_SPOOL_READ_CAP = 400
+    big = [_sink_row(f"s-{i}", float(i), pad="x" * 60) for i in range(20)]
+    env.beta.seed(
+        sink=big if segment == "live" else None,
+        sink_rot=big if segment == "rot" else None,
+        spool=[_spool_event("e-1", 1.0)],
+    )
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["spool_truncated"] is True
+    assert [r["scan_id"] for r in out["entries"]] == ["e-1"]  # sink skipped, spool served
+
+
+async def test_subcap_foreign_sink_still_reads_whole(env: _Env) -> None:
+    # The gate is per-segment size, not row count: a sub-cap sink reads in full and
+    # reports no truncation.
+    env.beta.seed(sink=[_sink_row(f"s-{i}", float(i)) for i in range(5)])
+    h = _make_handlers()
+    out = await h.get_scan_history(profile="beta")
+    assert out["spool_truncated"] is False
+    assert len(out["entries"]) == 5
+
+
 def test_spool_window_without_newline_yields_no_events(env: _Env) -> None:
     server_mod._FOREIGN_SPOOL_READ_CAP = 20
     env.beta.spool.write_text("x" * 500, encoding="utf-8")
@@ -410,10 +440,16 @@ async def test_unknown_profile_422_on_every_scoped_route(env: _Env, route: str) 
 @pytest.mark.parametrize("name", ["nfd", "nfc"])
 async def test_unknown_profile_422_unicode_normalization(env: _Env, name: str) -> None:
     # D7: matching is byte-exact; NFD and NFC forms of one name are distinct, so a
-    # macOS-decomposed leaf name is a known non-member. Pinned, not incidental.
-    _Home(env.root, "café")  # NFC on disk
+    # macOS-decomposed leaf name is a known non-member. Derived, not literal: two
+    # visually identical source literals survive neither an editor nor a formatter
+    # round-trip reliably, and a silent re-normalization would flip the nfd arm
+    # into probing a real member with no visible cause.
+    nfc = unicodedata.normalize("NFC", "café")
+    nfd = unicodedata.normalize("NFD", nfc)
+    assert nfc != nfd  # the premise: the two forms are distinct byte sequences
+    _Home(env.root, nfc)  # NFC on disk
     h = _make_handlers()
-    probe = "café" if name == "nfc" else "café"
+    probe = nfc if name == "nfc" else nfd
     if name == "nfc":
         out = await h.get_scan_history(profile=probe)
         assert out["read_scope"]["selected"] == probe

--- a/tests/test_console_scoped_routes.py
+++ b/tests/test_console_scoped_routes.py
@@ -1,0 +1,305 @@
+"""PET-166: the scoped ROUTE contracts on both console surfaces.
+
+The handler-level semantics live in ``test_console_profile_scoped_reads.py``;
+this module pins what only a route can show: the 422/409 status mapping, the
+query-borne-selector rejection on the write, the SSE idle arm (its terminal
+``scope_refusal`` marker, its slot accounting, and the never-iterated-response
+leak), and the D13 requirement that the embedded bridge moves in lockstep with
+the standalone routes rather than one of them being ported later.
+"""
+
+import json
+import platform
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import petasos.console._armed as armed_mod  # noqa: E402
+import petasos.console._history as history_mod  # noqa: E402
+import petasos.console._paths as paths_mod  # noqa: E402
+import petasos.console.hermes.plugin_api as plugin_mod  # noqa: E402
+import petasos.console.server as server_mod  # noqa: E402
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+
+def _make_pipeline() -> Pipeline:
+    return Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+
+
+@pytest.fixture()
+def profiles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Two real profile homes with alpha equipped (see the sibling module's fixture
+    docstring for why the autouse overrides and HERMES_HOME must be cleared)."""
+    saved_spool = paths_mod._SPOOL_PATH_OVERRIDE
+    saved_hist = history_mod._HISTORY_PATH_OVERRIDE
+    paths_mod._SPOOL_PATH_OVERRIDE = None
+    history_mod._HISTORY_PATH_OVERRIDE = None
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    root = paths_mod.hermes_root()
+    for name in ("alpha", "beta"):
+        d = root / "profiles" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.yaml").write_text("petasos:\n  enabled: true\n", encoding="utf-8")
+    (root / "active_profile").write_text("alpha", encoding="utf-8")
+    armed_mod._reset_armed_cache()
+    try:
+        yield root
+    finally:
+        paths_mod._SPOOL_PATH_OVERRIDE = saved_spool
+        history_mod._HISTORY_PATH_OVERRIDE = saved_hist
+        armed_mod._reset_armed_cache()
+
+
+@pytest.fixture(params=["standalone", "plugin"])
+def client(request: pytest.FixtureRequest) -> Iterator[tuple[Any, str]]:
+    """Both route surfaces, so D13's lockstep requirement is a test fact.
+
+    Every contract below runs twice; a bridge that dropped the parameter, the 409,
+    the 503 mapping, or the idle-arm slot accounting fails on the plugin pass only.
+    """
+    from fastapi.testclient import TestClient
+
+    plugin_mod._handlers = None
+    if request.param == "standalone":
+        from petasos.console.server import build_app
+
+        with TestClient(build_app(_make_pipeline())) as tc:
+            yield tc, "/api"
+    else:
+        from fastapi import FastAPI
+
+        from petasos.console.hermes.plugin_api import init_handlers, router
+
+        init_handlers(_make_pipeline())
+        app = FastAPI()
+        app.include_router(router)
+        with TestClient(app) as tc:
+            yield tc, ""
+    plugin_mod._handlers = None
+
+
+def _handlers(client: tuple[Any, str]) -> Any:
+    tc, base = client
+    if base == "":
+        return plugin_mod._handlers
+    # build_app closes over its handlers; reach them through the live route closure.
+    for route in tc.app.routes:
+        closure = getattr(getattr(route, "endpoint", None), "__closure__", None) or ()
+        for cell in closure:
+            if isinstance(cell.cell_contents, server_mod.ConsoleHandlers):
+                return cell.cell_contents
+    raise AssertionError("handlers not reachable")
+
+
+# ── 422 / 409 status mapping ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", ["/scan-history", "/armed", "/health", "/events"])
+def test_unknown_profile_is_422_on_every_scoped_route(
+    client: tuple[Any, str], profiles: Path, path: str
+) -> None:
+    tc, base = client
+    r = tc.get(base + path, params={"profile": "ghost"})
+    assert r.status_code == 422
+    assert r.json()["detail"][0]["field"] == "profile"
+    # For /events the failure is an ordinary JSON body, NOT a frame inside a stream.
+    assert "text/event-stream" not in r.headers.get("content-type", "")
+
+
+def test_set_armed_non_equipped_is_409(client: tuple[Any, str], profiles: Path) -> None:
+    tc, base = client
+    r = tc.post(base + "/armed", json={"armed": False, "profile": "beta"})
+    assert r.status_code == 409
+    body = r.json()["detail"][0]
+    assert body["field"] == "profile"
+    assert "alpha" in body["message"]
+    assert "persist" not in body["message"].lower()  # never the 503 persistence body
+    # beta's config is untouched.
+    beta_cfg = profiles / "profiles" / "beta" / "config.yaml"
+    assert "enabled: true" in beta_cfg.read_text(encoding="utf-8")
+
+
+def test_set_armed_query_profile_is_422(client: tuple[Any, str], profiles: Path) -> None:
+    # Without this the selector arrives None, the scope resolves to equipped, the
+    # 409 never fires, and the running agent is disarmed while the UI names another
+    # profile.
+    tc, base = client
+    r = tc.post(base + "/armed", params={"profile": "beta"}, json={"armed": False})
+    assert r.status_code == 422
+    assert "body" in r.json()["detail"][0]["message"]
+
+
+def test_set_armed_non_string_profile_422(client: tuple[Any, str], profiles: Path) -> None:
+    tc, base = client
+    r = tc.post(base + "/armed", json={"armed": False, "profile": 7})
+    assert r.status_code == 422
+    assert r.json()["detail"][0]["field"] == "profile"
+
+
+def test_set_armed_equipped_still_arms(client: tuple[Any, str], profiles: Path) -> None:
+    tc, base = client
+    r = tc.post(base + "/armed", json={"armed": False, "profile": "alpha"})
+    assert r.status_code == 200
+    assert r.json()["armed"] is False
+    assert r.json()["read_scope"]["state"] == "equipped"
+
+
+def test_unscoped_requests_are_unchanged(client: tuple[Any, str], profiles: Path) -> None:
+    # D2's fence at the route layer: no parameter -> no new key on any surface.
+    tc, base = client
+    assert "read_scope" not in tc.get(base + "/armed").json()
+    assert "read_scope" not in tc.get(base + "/health").json()
+    hist = tc.get(base + "/scan-history").json()
+    assert set(hist) == {"entries", "next_before", "older_truncated"}
+
+
+def test_foreign_cursor_is_422_on_before(client: tuple[Any, str], profiles: Path) -> None:
+    tc, base = client
+    r = tc.get(base + "/scan-history", params={"profile": "beta", "before": "alpha|1.0~s-x"})
+    assert r.status_code == 422
+    assert r.json()["detail"][0]["field"] == "before"
+
+
+# ── SSE: the idle arm, its marker, and its slot accounting ────────────────
+
+
+async def _first_frame(h: Any, profile: str) -> str:
+    """Drive the idle generator directly and pull its first frame.
+
+    Deliberately NOT through TestClient streaming: the idle stream never
+    completes by design (D9), so a client-side read loop would block the suite.
+    """
+    scope = h.resolve_events_scope(profile)
+    gen = h.idle_scope_stream(scope)
+    try:
+        frame = await gen.__anext__()
+    finally:
+        await gen.aclose()
+    assert frame.startswith("event: read_scope")
+    return str(frame.split("data: ", 1)[1].strip())
+
+
+async def test_events_non_equipped_emits_scope_frame_and_stays_open(
+    client: tuple[Any, str], profiles: Path
+) -> None:
+    h = _handlers(client)
+    subscribed: list[int] = []
+    real_subscribe = h.sse.subscribe
+
+    def _counting_subscribe() -> Any:
+        subscribed.append(1)
+        return real_subscribe()
+
+    h.sse.subscribe = _counting_subscribe
+
+    scope = h.resolve_events_scope("beta")
+    gen = h.idle_scope_stream(scope)
+    frame = await gen.__anext__()
+    payload = json.loads(frame.split("data: ", 1)[1].strip())
+    assert payload["state"] == "not_equipped"
+    assert payload["live"] is False
+    assert payload["selected"] == "beta"
+    assert subscribed == []  # consumes no live subscriber slot
+    assert h._idle_stream_count == 1  # holds an idle slot while open
+    await gen.aclose()
+    assert h._idle_stream_count == 0  # and releases it in the finally
+
+
+def test_events_equipped_unchanged(client: tuple[Any, str], profiles: Path) -> None:
+    # The equipped arm takes the shipped subscribe/stream path and never touches
+    # the idle counter. Asserted through the route's own decision (the scope
+    # resolution) rather than by opening a live stream against a test client.
+    h = _handlers(client)
+    assert h.resolve_events_scope("alpha").state == "equipped"
+    assert h.resolve_events_scope(None).state == "equipped"
+    assert h._idle_stream_count == 0
+
+
+def test_events_subscriber_limit_is_503_unmarked(client: tuple[Any, str], profiles: Path) -> None:
+    # A full LIVE pool is a 503 (it 500s today) and stays UNMARKED, so the shipped
+    # client keeps its retry-then-fallback path on the equipped arm.
+    tc, base = client
+    h = _handlers(client)
+
+    def _boom() -> Any:
+        raise RuntimeError("Too many SSE subscribers")
+
+    h.sse.subscribe = _boom
+    r = tc.get(base + "/events")
+    assert r.status_code == 503
+    assert "scope_refusal" not in r.json()
+
+
+async def test_idle_stream_limit_is_503_and_slot_is_released(
+    client: tuple[Any, str], profiles: Path
+) -> None:
+    tc, base = client
+    h = _handlers(client)
+    h._idle_stream_count = h.sse.max_subscribers
+    r = tc.get(base + "/events", params={"profile": "beta"})
+    assert r.status_code == 503
+    assert r.json()["scope_refusal"] == "capacity"  # the D9 terminal marker
+
+    h._idle_stream_count = 0
+    # Closing an idle stream frees its slot (the generator's finally), so the next
+    # one is admitted rather than inheriting a leaked count.
+    await _first_frame(h, "beta")
+    assert h._idle_stream_count == 0
+
+
+def test_abandoned_idle_response_holds_no_slot(client: tuple[Any, str], profiles: Path) -> None:
+    # Build the generator and NEVER iterate it: a never-started generator's finally
+    # never runs, so an increment placed in the ROUTE would leak permanently, once
+    # per aborted open. This is the only way that leak is observable.
+    h = _handlers(client)
+    scope = h.resolve_events_scope("beta")
+    for _ in range(h.sse.max_subscribers + 2):
+        h.idle_scope_stream(scope)  # constructed, never awaited
+    assert h._idle_stream_count == 0
+
+
+async def test_idle_stream_limit_tracks_broadcaster_bound(profiles: Path) -> None:
+    # Constructing the broadcaster with a non-default bound moves BOTH arms, so the
+    # two limits are pinned to one source rather than a shared literal.
+    from petasos.console._sse import SSEBroadcaster
+
+    h = server_mod.ConsoleHandlers(_make_pipeline())
+    h.sse = SSEBroadcaster(max_subscribers=3)
+    assert h.sse.max_subscribers == 3
+    h._idle_stream_count = 3
+    assert h._idle_stream_count >= h.sse.max_subscribers  # the idle arm refuses here
+
+
+async def test_bridge_and_standalone_agree_on_every_scoped_contract(
+    client: tuple[Any, str], profiles: Path
+) -> None:
+    # D13: the five handlers all forward the selector. A bridge that dropped it
+    # would return the equipped view under beta's name (state "equipped").
+    tc, base = client
+    assert (
+        tc.get(base + "/scan-history", params={"profile": "beta"}).json()["read_scope"]["state"]
+        == "not_equipped"
+    )
+    assert (
+        tc.get(base + "/armed", params={"profile": "beta"}).json()["read_scope"]["state"]
+        == "not_equipped"
+    )
+    assert (
+        tc.get(base + "/health", params={"profile": "beta"}).json()["read_scope"]["state"]
+        == "not_equipped"
+    )
+    frame = json.loads(await _first_frame(_handlers(client), "beta"))
+    assert frame["state"] == "not_equipped"
+    assert tc.post(base + "/armed", json={"armed": False, "profile": "beta"}).status_code == 409

--- a/tests/test_profile_rebind.py
+++ b/tests/test_profile_rebind.py
@@ -25,6 +25,7 @@ import importlib.util
 import logging
 import sys
 import threading
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -212,9 +213,12 @@ def test_rebind_survives_mtime_size_collision(
     monkeypatch.setattr(ref, "_session_resolution", _make_resolution(w_home / "config.yaml"))
 
     st = (x_home / "config.yaml").stat()
-    x_key = (st.st_mtime_ns, st.st_size)
-    # Seed the armed cache as if W's armed bit were cached under X's exact key (collision).
-    armed_mod._ARMED_CACHE = (x_key, True, time.monotonic())
+    # PET-166 D5 re-keyed the cache by (normcase(path), mtime_ns, size), so a bare
+    # (mtime, size) collision from another profile can no longer serve a stale bit.
+    # The PET-132 premise this test pins is re-expressed under the new key: a stale
+    # armed=True cached under X's OWN full key must still lose to the re-bind reset.
+    x_key = (os.path.normcase(str(x_res.path)), st.st_mtime_ns, st.st_size)
+    armed_mod._ARMED_CACHE[x_key] = (True, time.monotonic())
     # Control: with the stale entry present, a read at X's key HITS and returns True.
     assert armed_mod.read_armed(x_res) is True
 

--- a/tests/test_profile_rebind.py
+++ b/tests/test_profile_rebind.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import logging
+import os
 import sys
 import threading
-import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -37,6 +37,10 @@ async def test_full_queue_silently_dropped() -> None:
 
 async def test_subscriber_limit() -> None:
     sse = SSEBroadcaster(max_subscribers=2)
+    # PET-166 D9: the read-only property reports the constructed bound, so the idle
+    # stream counter reads the live pool bound rather than a drifting literal
+    # (relied on by test_idle_stream_limit_tracks_broadcaster_bound).
+    assert sse.max_subscribers == 2
     sse.subscribe()
     sse.subscribe()
     with pytest.raises(RuntimeError, match="Too many"):


### PR DESCRIPTION
## Summary

- Scan history, the armed indicator, health, and the live event stream now take the host-selected profile as an explicit, validated `profile` read scope, so selecting profile X in the Hermes switcher shows X's enforcement data instead of the process binding's under X's name.
- A selection that is not the equipped profile is rendered honestly rather than silently misattributed: read-only rows from that profile's own files marked `foreign`, an idle labelled event stream, a 30s history refresh, arming refused with a 409, and a subtitle that names the profile and its data's age.
- Enforcement binding does not move. Every write keeps resolving the process binding, and any request that sends no `profile` is byte-identical to before, so standalone consoles and existing embedders see no change.

## Two-check interaction

The read scope and the write binding are deliberately independent, and two decisions keep them from collapsing into each other:

**Equipped-ness is decided by ordered path checks, never a flat comparison.** `_resolved_normcase` returns `None` on `OSError`, and one inaccessible reparse point under `%LOCALAPPDATA%\hermes` fails *both* resolutions at once. A flat equality test would evaluate `None == None` as `True`, report `"equipped"`, and let `set_armed(profile="beta")` through the refusal guard into a `write_armed` that disarms the running agent. The ordered form reports `"unknown"` there, which keeps reads on the safe non-equipped branch while leaving unscoped arming available.

**The write selector rides in the body, and a query-borne one is rejected.** Without that rejection a client that put the selector in the query string sends a request the route cannot see: `profile` arrives `None`, the scope resolves to equipped, the 409 never fires, and the agent is disarmed while the UI names another profile — the same failure reached through mis-location rather than omission.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/server.py` | Adds `_ReadScope` / `_resolve_read_scope`, `ProfileNotEquippedError`, `CursorScopeMismatchError`, the bounded `read_spool_tail`, scope-bound cursor mint/parse with both segments escaped, the merged non-equipped read, the guarded ring clear on binding change, and the `_embedded`-gated unscoped-read tripwire |
| `petasos/console/_history.py` | `_history_path` takes an optional resolution; `read_history_page`'s key computation gains an OverflowError / isfinite guard |
| `petasos/console/_paths.py` | `spool_path` and `spool_rot_path` take an optional resolution |
| `petasos/console/_armed.py` | `_ARMED_CACHE` becomes a path-keyed bounded dict at both write sites; the module precondition is rewritten and names its `_reload.py` sibling |
| `petasos/console/_sse.py` | Names `DEFAULT_MAX_SUBSCRIBERS` and exposes a read-only `max_subscribers`, so the idle-stream limit reads the live pool bound instead of a literal |
| `petasos/console/hermes/plugin_api.py` | Forwards the scope on all five bridge handlers and adds the 422 / 409 / 503 mappings; sets `_embedded` at registration |
| `petasos/console/static/petasos.js` | Scope emission, invalidation with per-request generation guards, the SCOPED connection state, the singleton scoped poll, and the new pure seams (`isForeignScope`, `scopedHistorySubtitle`, `historyEmptyState`, `scanHistoryAge`, `scopedHistoryHasOlder`, `selfmodTileLabel`, `connChipView`, `playgroundScopeNote`, `armedWriteView`) |
| `petasos/console/static/petasos.css` | New `.live.scoped` and `.sd-prov-foreign` states, so neither inherits a tone that overstates what it means |
| `docs/deployment/profile-resolution-model.md` | New read-scope-vs-write-binding section naming `PETASOS_SCOPE_UNSCOPED_READ`, its trigger, its excluded case, and its remediation |
| `docs/deployment/hardening.md` | § 3.1 gains the `foreign` verdict beside the labels it already uses |
| `docs/usage/hermes-agent-profiles.md` | The binding read-out is documented as "resolved via:", matching the client relabel |
| `CHANGELOG.md` | `[Unreleased]` entry |
| `tests/test_console_profile_scoped_reads.py` | New: 65 cases covering isolation, merge/dedup, bounds, validation, the attestation domain, and the binding-state matrix |
| `tests/test_console_scoped_routes.py` | New: 33 cases pinning the route-level contracts on **both** surfaces |
| `tests/js/profile-scoped-reads.test.mjs` | New: 22 cases over the pure client seams |

## Test plan

- [x] `C:/python310/python.exe -m pytest tests/ -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` — 2723 passed, 48 skipped, 1 xfailed (full output: `docs/specs/TODO/PET-166.test-output.txt`)
- [x] `node --test tests/js/*.test.mjs` — 290/290 pass
- [x] `ruff check .` — clean; `ruff format --check petasos tests` — 169 files already formatted
- [x] `mypy --strict .` — no issues in 172 source files
- [x] The single deselect is the pre-existing master failure (Unicode 13 vs 14 on the local 3.10 interpreter), not a regression from this change
- [ ] Post-merge: re-sync the hand-synced Hermes plugin bundle, since the client half only takes effect there once the bundle carries it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHvkhKpB8cjFPPGbNFzSML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile-scoped console views for health, history, live events, and armed status.
  * Added read-only handling and provenance labels for profiles not equipped on the dashboard.
  * Added scoped history navigation, status indicators, empty states, and retention notices.
  * Added clearer connection states and bounded live-event subscriptions.
* **Bug Fixes**
  * Prevented arming non-equipped profiles and corrected profile-specific state handling.
  * Added validation and structured error responses for invalid profiles and unsupported actions.
* **Documentation**
  * Documented profile read scope, write behavior, foreign-profile data, and configuration resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->