### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [0.3.0] - 2026-08-11
 
-Headline release since 0.2.0: the ingestion path is now guarded end to end
-(tool results scanned and annotated, with a session backstop that actually
-gates), the console's read surfaces follow the Hermes profile switcher with an
-honest foreign-data model, a new self-tamper detection family watches Petasos's
-own files, and two enforcement-reaching bugs are fixed (scanner config that
-never reached the enforcing pipeline; a failed init that used to disable
+Headline release since 0.2.0: the ingestion path gains bounded scanning and
+session gating. Read-only tool results are scanned inbound over an
+8,000-character window taken head and tail and annotated, never withheld, and
+repeated flagged reads now move the session ladder and stop later tool
+dispatch. The window is the bound, not a whole-payload guarantee: the middle
+of a larger result reaches the model unscanned and unannotated. Also: the
+console's read surfaces follow the Hermes profile switcher with an honest
+foreign-data model, a new self-tamper detection family watches Petasos's own
+control surfaces, and two enforcement-reaching bugs are fixed (scanner config
+that never reached the enforcing pipeline; a failed init that used to disable
 enforcement entirely).
 
 ### Changed
@@ -161,7 +165,12 @@ enforcement entirely).
   401. Detection-only by design: the findings are unsuppressible by
   construction (profile suppression cannot drop them), never block on their
   own, and render as a distinct amber `self-tamper` badge so red stays reserved
-  for actual blocks. `READ_ONLY_TOOLS` is promoted to a public export of
+  for actual blocks. The family lives in the tool guard's evaluate path, so it
+  runs only while `tool_guard_enabled` is on: disabling the guard bypasses
+  self-tamper classification along with tool-call tier evaluation. Profile
+  suppression still cannot drop the findings when they are raised, and the
+  content-scan escalation floor is a separate mechanism, unaffected by the
+  guard toggle. `READ_ONLY_TOOLS` is promoted to a public export of
   `petasos.session.guard`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-11
+
+Headline release since 0.2.0: the ingestion path is now guarded end to end
+(tool results scanned and annotated, with a session backstop that actually
+gates), the console's read surfaces follow the Hermes profile switcher with an
+honest foreign-data model, a new self-tamper detection family watches Petasos's
+own files, and two enforcement-reaching bugs are fixed (scanner config that
+never reached the enforcing pipeline; a failed init that used to disable
+enforcement entirely).
+
 ### Changed
 
 - **Config-surface honesty audit (PET-169).** Every one of the 64 `PetasosConfig`
@@ -129,6 +139,30 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   never logs, so a caller keeps its own wording and levels, and it never raises
   for an optional-backend failure. Embedders who construct their own `Pipeline`
   can call it instead of hand-wiring each scanner's config.
+- **Bounded init wait and durable cold-start visibility (PET-167).** A cold
+  process's first tool calls previously queued on the init lock for the full
+  scanner startup (about 12 seconds with ML extras), which meant the degraded
+  fallback written for that window was structurally unreachable. They now wait
+  up to a process-wide deadline (new `PetasosConfig.init_wait_timeout_seconds`),
+  and on expiry the branch is governed by `fail_mode` and runs the
+  zero-dependency syntactic scanner. Two enforcement-spool markers,
+  `cold_start_degraded` and `init_failed`, make the window durable: the console
+  renders both with an amber badge and an honest provenance line, so a session
+  that ran before scanners came up is distinguishable after the fact.
+- **Console self-tamper surfacing (PET-165).** The Observability tab gains an
+  eviction-proof self-tamper tile (survives the 500-entry ring), a history
+  filter narrowing to self-tamper rows with scope-aware empty states, and
+  severity-differentiated badges (critical renders red, high amber) with live
+  SSE increments.
+- **Self-tamper detection family `petasos.selfmod.*` (PET-164).** Tool-call
+  argument classification (not a content scan) that raises a finding when a
+  tool call targets Petasos's own control surfaces: the resolved `config.yaml`
+  set across all profile homes, the enforcement spool, and the console API on a
+  401. Detection-only by design: the findings are unsuppressible by
+  construction (profile suppression cannot drop them), never block on their
+  own, and render as a distinct amber `self-tamper` badge so red stays reserved
+  for actual blocks. `READ_ONLY_TOOLS` is promoted to a public export of
+  `petasos.session.guard`.
 
 ### Fixed
 
@@ -352,7 +386,9 @@ First public release. Every feature ships free and keyless: no license key, no t
 - **Tool-name canonicalization parity**: enforcement and classification share one canonical primitive, closing case / homoglyph / namespace / CamelCase / `_tool`-suffix variant-named egress bypasses
 - **PII-egress hardening**: egress-scoped guard blocking, corrected ordinal severity ranking (a lone CRITICAL now blocks), and a parse-time PII-entity vocabulary guard
 
-[Unreleased]: https://github.com/Vigil-Harbor/Petasos/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/Vigil-Harbor/Petasos/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Vigil-Harbor/Petasos/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/Vigil-Harbor/Petasos/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/Vigil-Harbor/Petasos/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Vigil-Harbor/Petasos/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Vigil-Harbor/Petasos/releases/tag/v0.1.0

--- a/petasos/__init__.py
+++ b/petasos/__init__.py
@@ -71,4 +71,4 @@ __all__ = [
     "validate_license",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Cut 0.3.0. Everything merged since v0.2.0 ships in this release: PET-164 (self-tamper detection family), PET-165 (console self-tamper surfacing), PET-167 (bounded init wait + cold-start visibility), PET-174 (shared scanner bootstrap fix), PET-169 (config-surface honesty audit), PET-170 (ingestion-result scan + annotate), PET-171 (failed-init syntactic fallback fix), PET-176 (ingestion session backstop), PET-166 (profile-scoped console read surfaces).

Changes in this PR:
- CHANGELOG: [Unreleased] promoted to [0.3.0] - 2026-08-11 with a headline paragraph; entries for PET-164/165/167 authored (they were missing from Unreleased); the stale footer compare links fixed (the Unreleased link still pointed at v0.1.2 and 0.2.0 had no link).
- `__version__` bumped to 0.3.0 in `petasos/__init__.py` (single authority per PET-141; `tests/test_version_sourcing.py` green).

After merge: tag `v0.3.0`, publish the GitHub release (trusted publishing to PyPI fires on release-published), verify on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHvkhKpB8cjFPPGbNFzSML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile-scoped console reads for more targeted information access.
  - Improved ingestion scanning and session fallback handling.
  - Added scanner construction and bounded initialization.
  - Introduced self-tamper detection.
- **Bug Fixes**
  - Addressed related scanning, initialization, and session-handling issues.
- **Release**
  - Published version 0.3.0 with updated release comparison links and package version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->