### PR TITLE
fix(pet-185): source the armed bit from the write binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   (uvicorn 0.48.0), whose own h11 `send` returns early rather than raising when the
   client is gone, so the leak is not reachable from a bare uvicorn client abort; it is
   reachable through any host, ASGI middleware, or transport whose `send` raises there.
+- **The arming banner now describes the binding its toggle writes (PET-185).**
+  A regression shipped with 0.3.0's profile-scoped console reads (PET-166): a
+  scoped `GET /api/armed` served the selected profile's `petasos.enabled` while
+  the unscoped arm toggle wrote the process binding's config, so on a
+  `HERMES_HOME`-pinned dashboard with a named profile selected, an Unequip
+  landed in one file and the banner kept repainting from the other. Worse, the
+  banner could read EQUIPPED while the binding the toggle governs was disarmed.
+  The armed bit is now always sourced from the write binding, in every scope
+  state, and the caption under the control names the binding the banner
+  describes. Operator-visible consequence: the console no longer reports a
+  non-equipped profile's own arming bit anywhere; that per-profile read is
+  withdrawn (it remains readable on disk at `profiles/<name>/config.yaml`).
+  Plugin/bundle sync requirement: the console bundle must travel with the
+  backend on hand-synced deployments; copy `petasos/console/static/petasos.js`
+  together with the library upgrade, or the caption will assert the new
+  semantics against a backend still serving the old ones.
 
 ## [0.3.0] - 2026-08-11
 

--- a/docs/deployment/profile-resolution-model.md
+++ b/docs/deployment/profile-resolution-model.md
@@ -103,14 +103,15 @@ vector open. Treat the whole `profiles/` tree as security-bearing.
 
 ## Read scope vs write binding (PET-166)
 
-The console's read surfaces (scan history, armed indicator, health, the event
-stream) take an optional `profile` read scope: the client sends the
-host-selected profile and the server serves that profile's on-disk state,
-validated through the same membership gate the Config Editor uses. The scope
-selects only what the operator is shown. Every write keeps resolving the
-process binding: the enforcement pipeline, the drain, spool rotation, and the
-armed write never move with the selector, and arming a non-equipped profile is
-refused with a 409. A non-equipped read is served read-only from that profile's
+The console's read surfaces (scan history, health, the event stream) take an
+optional `profile` read scope: the client sends the host-selected profile and
+the server serves that profile's on-disk state, validated through the same
+membership gate the Config Editor uses. The scope selects only what the
+operator is shown. Every write keeps resolving the process binding: the
+enforcement pipeline, the drain, spool rotation, and the armed write never
+move with the selector, and arming a non-equipped profile is refused with a
+409. The armed bit is the one read that follows the write binding in every
+scope state, because the control under it can only write there (PET-185). A non-equipped read is served read-only from that profile's
 files, marked `foreign` in the drill-down, and its live event stream stays
 idle (this process holds no other profile's events).
 

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -1879,15 +1879,23 @@ class ConsoleHandlers:
 
     async def get_armed(self, profile: str | None = None) -> dict[str, Any]:
         # PET-111: the Equipped/Unequipped master bit. File-backed (petasos.enabled)
-        # via the shared _paths resolver — the dashboard reads what the gateway reads.
-        # PET-166 (D1): a scoped read serves the SELECTED profile's bit from its own
-        # config.yaml; the write binding never moves.
+        # via the shared _paths resolver - the dashboard reads what the gateway reads.
+        # PET-166 D1 NARROWED BY PET-185: every other scoped read serves the SELECTED
+        # profile's own config.yaml, but this one does not. The armed bit follows the
+        # WRITE binding, because the control it renders can only write there.
         from petasos.console._armed import read_armed
 
         scope = _resolve_read_scope(profile)
         self._note_unscoped_read(scope)
-        payload: dict[str, Any] = {"armed": read_armed(scope.resolution)}
-        if profile is not None:  # D2/D19: scope-gated
+        # PET-185: the bit ALWAYS describes the binding `set_armed` writes, in every scope
+        # state. `write_armed` takes no resolution and re-resolves ambient, so passing None
+        # here puts the read on the same resolver call with no path copied between the two
+        # sides. Agreement holds per resolution epoch: a binding that moves mid-request
+        # (active_profile rewritten, HERMES_HOME mutated in-process) can still skew this
+        # payload's `armed` against its own `read_scope`, exactly as it can skew a GET
+        # against a following POST. That window is not new and is not closed here.
+        payload: dict[str, Any] = {"armed": read_armed(None)}
+        if profile is not None:  # D2/D19: scope-gated, unchanged
             payload["read_scope"] = _read_scope_payload(scope)
         return payload
 

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -2145,6 +2145,47 @@
     };
   };
 
+  // PET-185: the ONE derivation of the arm control's scope state and the caption that
+  // names which binding the banner above it describes. Pure (readScope in, plain object
+  // out) so the node:vm harness can assert the labelling directly. PET-166 D16's three
+  // states are preserved exactly; only the caption text gains the binding name.
+  Pet.armScopeView = function (readScope) {
+    var s = readScope || null;
+    if (!s) return { disabled: false, unscoped: false, notice: null };
+    var st = s.state;
+    var selected = String(s.selected || "the selected profile");
+    var disabled = st === "not_equipped" && s.equipped != null;
+    var unscoped = st === "unknown" || s.equipped == null;
+    // The binding's parenthetical is emitted ONLY for a tier that names something an
+    // operator can act on. `equipped_tier` falls back to the raw resolution tier when no
+    // member is active (server.py:613), so "profile" IS reachable here (an active_profile
+    // pointing at a directory with no config.yaml: _paths.py:104 admits the dir, and
+    // list_hermes_profiles skips it at _paths.py:184). "(this profile)" would name nothing
+    // and read as a contradiction, so that tier and an absent tier get no parenthetical.
+    var where = st === "unknown" ? ""
+      : (s.equipped_tier === "hermes_home" ? " (HERMES_HOME)"
+        : (s.equipped_tier === "root" ? " (the root Hermes home)" : ""));
+    if (disabled) {
+      return { disabled: true, unscoped: false,
+        notice: "arming is disabled here: " + selected + " is not the equipped profile ("
+          + String(s.equipped) + " is). The banner above shows " + String(s.equipped)
+          + "'s state, not " + selected + "'s." };
+    }
+    if (unscoped) {
+      // The two branches deliberately say DIFFERENT things. In the unknown row the
+      // binding is unreachable, so read_armed returns its fail-secure True and a write
+      // 503s (Decision 1): claiming the banner "describes" that binding would be the
+      // same false confidence this ticket is removing.
+      return { disabled: false, unscoped: true,
+        notice: (st === "unknown"
+          ? "could not verify this dashboard's binding. The banner shows the fail-secure state, and arming may not persist. It does not describe "
+            + selected + "."
+          : "the banner and the toggle both describe this dashboard's binding" + where
+            + ", not " + selected + ". Arming here does not change " + selected + "'s enforcement.") };
+    }
+    return { disabled: false, unscoped: false, notice: null };
+  };
+
   // PET-129 D2: the authenticate panel rendered (instead of the dashboard tiles) while
   // Pet.state.authRequired is set. Shows the honest banner (bannerView authRequired ->
   // AUTHENTICATE, never EQUIPPED), a token field + Unlock submit, and an explicit
@@ -2258,17 +2299,13 @@
       var mark = b.querySelector(".equip-mark");
       if (mark) mark.src = Pet.asset(view.on ? "img/petasos-equipped.png" : "img/petasos-unequipped.png");
     };
-    // PET-166 (D16): the arm control is the ONE consumer that reads scope state
-    // directly (it discriminates three states, not two), through a null guard so the
-    // absent case (all of standalone) takes the ordinary equipped affordance.
-    var _armScope = Pet.state.readScope || {};
-    var _armSt = _armScope.state;
-    var _armDisabled = _armSt === "not_equipped" && _armScope.equipped != null;
-    // equipped_name null (a HERMES_HOME/root binding outside profiles/) or an
-    // unresolvable equipped path: keep the toggle ENABLED but send NO scope — an
-    // unscoped arm targets the process binding, the only arming target that exists.
-    var _armUnscoped = (Pet.state.readScope != null)
-      && (_armSt === "unknown" || _armScope.equipped == null);
+    // PET-166 (D16) via PET-185: the arm control is the ONE consumer that reads scope
+    // state directly (it discriminates three states, not two). The derivation lives in
+    // the pure Pet.armScopeView seam; both booleans are bit-identical to the old inline
+    // form for every input, including the null-readScope standalone path.
+    var _armView = Pet.armScopeView(Pet.state.readScope);
+    var _armDisabled = _armView.disabled;
+    var _armUnscoped = _armView.unscoped;
     var doToggle = function () {
       if (Pet.state.authRequired) return; // PET-129 D3: no toggling (or EQUIPPED repaint) while unauthenticated
       if (_armedBusy) return;  // ignore rapid re-clicks while a write is in flight
@@ -2345,17 +2382,12 @@
       Pet.HelpTip("<b>Equipped</b>: master switch. <b>Unequipped</b> disables <b>all</b> Petasos enforcement (scan, guard, audit) for this and running sessions, applied by the next tool call. Backed by <code>petasos.enabled</code>."),
       armedSwitch
     ));
-    // PET-166 (D16): label the arm control with what it will act on. Three states:
-    // not_equipped with a named equipped profile -> disabled with a reason; equipped
-    // name null -> enabled, unscoped, labelled; binding unresolvable -> same.
-    if (_armDisabled) {
-      wrapper.appendChild(Pet.h("div", { className: "mono", role: "status", style: { fontSize: "11px", color: "var(--tx-faint)" } },
-        "arming is disabled here: " + String(_armScope.selected || "the selected profile") + " is not the equipped profile (" + String(_armScope.equipped) + " is)"));
-    } else if (_armUnscoped) {
-      wrapper.appendChild(Pet.h("div", { className: "mono", role: "status", style: { fontSize: "11px", color: "var(--tx-faint)" } },
-        _armSt === "unknown"
-          ? "could not verify this dashboard's binding; arming targets it directly"
-          : "arming targets this dashboard's binding, not the selected profile"));
+    // PET-166 (D16) via PET-185: label the arm control with the binding the banner
+    // describes. The caption text is armScopeView's; a role="status" readout must
+    // clear WCAG 1.4.3, hence --tx-mut rather than --tx-faint (petasos.css:179-183).
+    if (_armView.notice) {
+      wrapper.appendChild(Pet.h("div", { className: "mono", role: "status", style: { fontSize: "11px", color: "var(--tx-mut)" } },
+        _armView.notice));
     }
     // PET-166 (D20): the client-side scope notice — a 200 the client believes it
     // scoped came back without a confirmed scope, so what is shown below is the

--- a/tests/js/arm-scope-view.test.mjs
+++ b/tests/js/arm-scope-view.test.mjs
@@ -1,0 +1,171 @@
+// PET-185: Pet.armScopeView — the ONE derivation of the arm control's scope state
+// and the caption naming which binding the banner describes.
+//
+// Pure seam only (readScope in, plain object out); renderDashboard is never driven,
+// per the harness rule in profile-scoped-reads.test.mjs. Assert via field-by-field
+// comparison, never deepEqual on cross-realm objects.
+//
+// Zero npm deps: Node's built-in test runner + node:vm over the real shipped petasos.js.
+// Run with: node --test tests/js/arm-scope-view.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+function makeNode(nodeType) {
+  return {
+    nodeType,
+    childNodes: [],
+    style: {},
+    className: "",
+    attrs: {},
+    appendChild(child) { this.childNodes.push(child); return child; },
+    setAttribute(k, v) { this.attrs[k] = v; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+}
+const document = {
+  createDocumentFragment() { return makeNode(11); },
+  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
+  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
+const sandbox = {
+  window: {}, document, console,
+  setTimeout, clearTimeout, setInterval, clearInterval,
+  AbortController, TextDecoder,
+  fetch: function () { return new Promise(function () {}); },
+};
+vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+const Pet = sandbox.window.__PETASOS_CONSOLE__;
+
+function view(rs) { return Pet.armScopeView(rs); }
+
+test("null readScope: standalone path, all defaults", () => {
+  for (const rs of [null, undefined]) {
+    const v = view(rs);
+    assert.equal(v.disabled, false);
+    assert.equal(v.unscoped, false);
+    assert.equal(v.notice, null);
+  }
+});
+
+test("empty object: unscoped (the old equipped == null disjunct)", () => {
+  const v = view({});
+  assert.equal(v.disabled, false);
+  assert.equal(v.unscoped, true);
+  assert.notEqual(v.notice, null);
+});
+
+test("equipped with a named member: fully quiet", () => {
+  // Full fixture on purpose: a bare {state:"equipped"} has equipped === undefined,
+  // and undefined == null is true, so unscoped would fire. That combination is
+  // server-unreachable (state "equipped" forces a non-null is_active member).
+  const v = view({ state: "equipped", equipped: "alpha", selected: "alpha", equipped_tier: "profile" });
+  assert.equal(v.disabled, false);
+  assert.equal(v.unscoped, false);
+  assert.equal(v.notice, null);
+});
+
+test("equipped with equipped:null stays unscoped BY DESIGN (D16 disjunct)", () => {
+  // Pinned so nobody "repairs" a red bare-fixture test by short-circuiting on
+  // st === "equipped", which would silently drop the equipped == null disjunct.
+  const v = view({ state: "equipped", equipped: null });
+  assert.equal(v.unscoped, true);
+});
+
+test("not_equipped with a named equipped profile: disabled, names whose state shows", () => {
+  const v = view({ state: "not_equipped", equipped: "gibson", selected: "work" });
+  assert.equal(v.disabled, true);
+  assert.equal(v.unscoped, false);
+  assert.ok(v.notice.includes("gibson"));
+  assert.ok(v.notice.includes("work"));
+  assert.ok(v.notice.includes("The banner above shows gibson's state, not work's."));
+});
+
+test("the live-box row: HERMES_HOME binding, named selection", () => {
+  const v = view({ state: "not_equipped", equipped: null, equipped_tier: "hermes_home", selected: "gibson" });
+  assert.equal(v.disabled, false);
+  assert.equal(v.unscoped, true);
+  assert.ok(v.notice.includes("HERMES_HOME"));
+  assert.ok(v.notice.includes("gibson"));
+  assert.ok(v.notice.includes("does not change gibson's enforcement"));
+});
+
+test("root tier gets the root label", () => {
+  const v = view({ state: "not_equipped", equipped: null, equipped_tier: "root", selected: "gibson" });
+  assert.ok(v.notice.includes("the root Hermes home"));
+});
+
+test("profile tier with equipped:null: no parenthetical, no self-reference", () => {
+  // Reachable: an active_profile pointing at a directory with no config.yaml.
+  const v = view({ state: "not_equipped", equipped: null, equipped_tier: "profile", selected: "gibson" });
+  assert.equal(v.unscoped, true);
+  assert.ok(!v.notice.includes("("));
+  assert.ok(!v.notice.includes("this profile"));
+});
+
+test("equipped_tier absent entirely (stale or skewed backend): same shape", () => {
+  const v = view({ state: "not_equipped", equipped: null, selected: "gibson" });
+  assert.equal(v.unscoped, true);
+  assert.ok(!v.notice.includes("("));
+  assert.ok(!v.notice.includes("this profile"));
+});
+
+test("unknown wins over a non-null equipped name and refuses to vouch", () => {
+  const v = view({ state: "unknown", equipped: "gibson", selected: "work", equipped_tier: "profile" });
+  assert.equal(v.disabled, false);
+  assert.equal(v.unscoped, true);
+  assert.ok(v.notice.includes("fail-secure"));
+  assert.ok(v.notice.includes("arming may not persist"));
+  assert.ok(!v.notice.includes("both describe this dashboard's binding"));
+  assert.ok(!v.notice.includes("(")); // no binding parenthetical in the unknown row
+});
+
+test("selected:null falls back to the generic phrase, never the string 'null'", () => {
+  const v = view({ state: "not_equipped", equipped: null, equipped_tier: "hermes_home", selected: null });
+  assert.ok(v.notice.includes("the selected profile"));
+  assert.ok(!v.notice.includes("null"));
+});
+
+test("house style: no em dash in any caption string", () => {
+  const fixtures = [
+    { state: "not_equipped", equipped: "gibson", selected: "work" },
+    { state: "not_equipped", equipped: null, equipped_tier: "hermes_home", selected: "gibson" },
+    { state: "not_equipped", equipped: null, equipped_tier: "root", selected: "gibson" },
+    { state: "unknown", equipped: "gibson", selected: "work" },
+    {},
+  ];
+  for (const rs of fixtures) {
+    const v = view(rs);
+    if (v.notice != null) assert.ok(!v.notice.includes("—"), "em dash in: " + v.notice);
+  }
+});
+
+test("term-by-term equivalence to the old inline booleans", () => {
+  // Old: _armDisabled = st === "not_equipped" && equipped != null (over readScope || {});
+  //      _armUnscoped = (readScope != null) && (st === "unknown" || equipped == null).
+  const cases = [
+    [null, false, false],
+    [{}, false, true],
+    [{ state: "equipped", equipped: "a", selected: "a", equipped_tier: "profile" }, false, false],
+    [{ state: "equipped", equipped: null }, false, true],
+    [{ state: "not_equipped", equipped: "a" }, true, false],
+    [{ state: "not_equipped", equipped: null }, false, true],
+    [{ state: "unknown", equipped: "a" }, false, true],
+    [{ state: "unknown", equipped: null }, false, true],
+  ];
+  for (const [rs, disabled, unscoped] of cases) {
+    const v = view(rs);
+    assert.equal(v.disabled, disabled, "disabled for " + JSON.stringify(rs));
+    assert.equal(v.unscoped, unscoped, "unscoped for " + JSON.stringify(rs));
+  }
+});

--- a/tests/test_console_armed_write_binding.py
+++ b/tests/test_console_armed_write_binding.py
@@ -1,0 +1,287 @@
+"""PET-185: the armed bit always describes the binding the toggle writes.
+
+Regression for PET-185: PET-166 D1 served a scoped ``GET /api/armed`` from the
+SELECTED profile's config while the unscoped arm toggle wrote the process
+binding's config, so on a ``HERMES_HOME``-pinned dashboard with a named profile
+selected an Unequip landed in one file and the banner kept repainting from the
+other. ``get_armed`` now sources the bit from the write binding in every scope
+state (all five rows of the spec's Design table), keeps ``read_scope``
+scope-gated so the client's unscoped-arm predicate cannot oscillate, and leaves
+every refusal contract untouched.
+
+Modelled on ``tests/test_console_profile_scoped_reads.py``: same
+``HERMES_HOME`` / ``LOCALAPPDATA`` / ``HOME`` monkeypatching, same
+``_reset_armed_cache()`` discipline, same ``_assert_under`` path pinning so no
+assertion can go vacuous. Handlers are driven directly.
+"""
+
+import logging
+import os
+import platform
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytest.importorskip("fastapi")
+
+import petasos.console._armed as armed_mod  # noqa: E402
+import petasos.console._paths as paths_mod  # noqa: E402
+import petasos.console.server as server_mod  # noqa: E402
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.console.server import (  # noqa: E402
+    ConsoleHandlers,
+    ProfileNotEquippedError,
+    ProfileNotFoundError,
+)
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+pytestmark = pytest.mark.anyio
+
+
+def _make_handlers() -> ConsoleHandlers:
+    return ConsoleHandlers(
+        Pipeline(
+            scanners=[MinimalScanner()],
+            config=PetasosConfig(fail_mode="degraded"),
+            host_id="test-host",
+        )
+    )
+
+
+def _write_enabled(cfg: Path, enabled: bool) -> None:
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(f"petasos:\n  enabled: {str(enabled).lower()}\n", encoding="utf-8")
+    armed_mod._reset_armed_cache()
+
+
+class _Env:
+    """Hermes root plus two profile homes; ``pin_root`` reproduces the live-box leg."""
+
+    def __init__(self, root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.root = root
+        self._monkeypatch = monkeypatch
+        self.root_cfg = root / "config.yaml"
+        self.alpha_dir = root / "profiles" / "alpha"
+        self.beta_dir = root / "profiles" / "beta"
+        self.alpha_cfg = self.alpha_dir / "config.yaml"
+        self.beta_cfg = self.beta_dir / "config.yaml"
+        _write_enabled(self.alpha_cfg, True)
+        _write_enabled(self.beta_cfg, True)
+
+    def activate(self, name: str) -> None:
+        (self.root / "active_profile").write_text(name, encoding="utf-8")
+        armed_mod._reset_armed_cache()
+
+    def pin_root(self) -> None:
+        """Pin ``HERMES_HOME`` to the root home (the ``-p default`` dashboard launch).
+
+        Reproduces the live-box precondition: ``resolve_hermes_config_path()``
+        returns the root ``config.yaml`` at ``tier="hermes_home"`` while
+        ``list_hermes_profiles()`` reports ``is_active=False`` for every member.
+        """
+        self._monkeypatch.setenv("HERMES_HOME", str(self.root))
+        armed_mod._reset_armed_cache()
+
+
+@pytest.fixture()
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[_Env]:
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    root = paths_mod.hermes_root()
+    (root / "profiles").mkdir(parents=True, exist_ok=True)
+    e = _Env(root, monkeypatch)
+    e.activate("alpha")
+    armed_mod._reset_armed_cache()
+    try:
+        yield e
+    finally:
+        armed_mod._reset_armed_cache()
+
+
+def _assert_under(path: str, directory: Path) -> None:
+    """Pin a resolved path under the intended home so no assertion goes vacuous."""
+    assert os.path.normcase(str(directory)) in os.path.normcase(path)
+
+
+# ── T1: the live-box repro (the headline regression pin) ─────────────────
+
+
+async def test_unequip_sticks_on_root_pinned_dashboard(env: _Env) -> None:
+    # Regression for PET-185: Unequip on a HERMES_HOME-pinned dashboard with a
+    # named profile selected must be visible on the next read of the same route.
+    _write_enabled(env.root_cfg, True)
+    env.pin_root()
+    # The precondition the brief verified on the live box; if this fails the rest
+    # of the suite is testing a different configuration.
+    scope = server_mod._resolve_read_scope("alpha")
+    assert scope.equipped_name is None
+    assert scope.state == "not_equipped"
+    alpha_before = env.alpha_cfg.read_bytes()
+
+    h = _make_handlers()
+    _, ok = await h.set_armed(False)
+    assert ok is True
+    # The navigate-away-and-back sequence reduced to its two calls.
+    assert (await h.get_armed(profile="alpha"))["armed"] is False
+    loaded = yaml.safe_load(env.root_cfg.read_text(encoding="utf-8"))
+    assert loaded["petasos"]["enabled"] is False
+    assert env.alpha_cfg.read_bytes() == alpha_before
+
+
+# ── T2: read and write address the same file ──────────────────────────────
+
+
+async def test_read_and_write_resolve_the_same_file(
+    env: _Env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_enabled(env.root_cfg, True)
+    env.pin_root()
+    rec: list[paths_mod.HermesConfigResolution] = []
+    real = paths_mod.resolve_hermes_config_path
+
+    def _recording() -> paths_mod.HermesConfigResolution:
+        res = real()
+        rec.append(res)
+        return res
+
+    # Patch the symbol AS IMPORTED INTO _armed: that is what makes the test
+    # observe the real call each side makes, not a path the test computed itself.
+    monkeypatch.setattr(armed_mod, "resolve_hermes_config_path", _recording)
+
+    h = _make_handlers()
+    await h.get_armed(profile="alpha")
+    await h.set_armed(False)
+    # REQUIRED, and the reason the test is not vacuous: with the pre-PET-185
+    # read_armed(scope.resolution) in place the read leg short-circuits at
+    # _armed.py:73 and never reaches the resolver, leaving one recorded call.
+    assert len(rec) == 2
+    # Read-then-write by drive order; with the arity assertion this uniquely
+    # identifies both legs, so no per-call-site tagging wrapper is needed.
+    assert len({os.path.normcase(str(r.path)) for r in rec}) == 1
+    _assert_under(str(rec[0].path), env.root)
+
+
+# ── T3: equipped_name null (the D16 row) ──────────────────────────────────
+
+
+async def test_null_equipped_name_serves_root_bit_not_selected(env: _Env) -> None:
+    _write_enabled(env.root_cfg, True)
+    _write_enabled(env.alpha_cfg, False)  # opposed values: no coincidence can pass
+    env.pin_root()
+    h = _make_handlers()
+    assert (await h.get_armed(profile="alpha"))["armed"] is True  # root's bit
+    assert (await h.get_armed())["armed"] is True
+
+
+# ── T4: not_equipped with equipped_name non-null ──────────────────────────
+
+
+async def test_not_equipped_named_serves_equipped_bit(env: _Env) -> None:
+    env.activate("alpha")
+    _write_enabled(env.alpha_cfg, True)
+    _write_enabled(env.beta_cfg, False)
+    h = _make_handlers()
+    out = await h.get_armed(profile="beta")
+    assert out["armed"] is True  # alpha's bit (the write target), not beta's
+    assert out["read_scope"]["state"] == "not_equipped"
+    assert out["read_scope"]["equipped"] == "alpha"
+
+
+# ── T5: the equipped state is unaffected ──────────────────────────────────
+
+
+async def test_equipped_state_unaffected(env: _Env) -> None:
+    env.activate("alpha")
+    h = _make_handlers()
+    for bit in (True, False):
+        _write_enabled(env.alpha_cfg, bit)
+        out = await h.get_armed(profile="alpha")
+        assert out["armed"] is bit
+        assert out["read_scope"]["state"] == "equipped"
+
+
+# ── T6: the unknown state, non-vacuously ──────────────────────────────────
+
+
+async def test_unknown_state_serves_ambient_bit(
+    env: _Env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Force `unknown` the way the existing suite does: unresolvable EQUIPPED path
+    # only, both config files fully readable. A genuinely unresolvable path would
+    # make read_armed fail its stat() and return the fail-secure True, and the
+    # assertion could not distinguish "ambient bit" from "error default".
+    env.activate("alpha")
+    _write_enabled(env.alpha_cfg, False)  # ambient binding
+    _write_enabled(env.beta_cfg, True)  # selected profile, opposed
+    real = paths_mod._resolved_normcase
+    equipped_cfg = env.alpha_cfg
+
+    def _fake(path: Path) -> str | None:
+        if os.path.normcase(str(path)) == os.path.normcase(str(equipped_cfg)):
+            return None  # the EQUIPPED side fails to resolve
+        return real(path)
+
+    monkeypatch.setattr(server_mod, "_resolved_normcase", _fake)
+    h = _make_handlers()
+    out = await h.get_armed(profile="beta")
+    assert out["read_scope"]["state"] == "unknown"
+    # Reachable only by actually reading the ambient file, not the error default.
+    assert out["armed"] is False
+
+
+# ── T7: anti-oscillation pin ──────────────────────────────────────────────
+
+
+async def test_read_scope_rides_scoped_reads_and_only_scoped_reads(env: _Env) -> None:
+    env.activate("alpha")
+    h = _make_handlers()
+    scoped = await h.get_armed(profile="beta")
+    assert "read_scope" in scoped
+    unscoped = await h.get_armed()
+    assert set(unscoped) == {"armed"}
+    assert isinstance(unscoped["armed"], bool)
+    # Stable inputs for Pet.armScopeView across consecutive reads; the client-side
+    # fixed point itself is the JS suite's to pin.
+    again = await h.get_armed(profile="beta")
+    assert again["read_scope"] == scoped["read_scope"]
+
+
+# ── T8: unchanged refusals ────────────────────────────────────────────────
+
+
+async def test_refusal_contracts_unchanged(env: _Env) -> None:
+    # Deliberate duplication of existing coverage: these are the invariants most
+    # likely to be collaterally broken by a change in get_armed.
+    env.activate("alpha")
+    h = _make_handlers()
+    with pytest.raises(ProfileNotFoundError):
+        await h.get_armed(profile="ghost")
+    before = env.beta_cfg.read_bytes()
+    with pytest.raises(ProfileNotEquippedError):
+        await h.set_armed(False, profile="beta")
+    assert env.beta_cfg.read_bytes() == before
+
+
+# ── T9: the D20 tripwire still fires, exactly once ────────────────────────
+
+
+async def test_unscoped_read_tripwire_fires_once(
+    env: _Env, caplog: pytest.LogCaptureFixture
+) -> None:
+    env.activate("alpha")  # two profiles, one active, no selector
+    h = _make_handlers()
+    h._embedded = True
+    with caplog.at_level(logging.INFO, logger="petasos.console.server"):
+        # Twice on the same handler instance: the latch is per-instance, so a
+        # single call would satisfy "not twice" trivially and pin nothing.
+        await h.get_armed()
+        await h.get_armed()
+    hits = [r for r in caplog.records if "PETASOS_SCOPE_UNSCOPED_READ" in r.getMessage()]
+    assert len(hits) == 1
+    assert hits[0].levelno == logging.INFO

--- a/tests/test_console_profile_scoped_reads.py
+++ b/tests/test_console_profile_scoped_reads.py
@@ -567,18 +567,25 @@ def test_cursor_scope_name_is_escaped() -> None:
 # ── Armed ─────────────────────────────────────────────────────────────────
 
 
-async def test_armed_reads_selected_profile(env: _Env) -> None:
+async def test_armed_reads_write_binding_not_selected_profile(env: _Env) -> None:
+    # PET-185: the armed bit ALWAYS describes the binding the toggle writes (the
+    # equipped/ambient binding), never the selected profile's own config. The old
+    # PET-166 expectation (profile="beta" serves beta's bit) inverted here for the
+    # beta case: reading beta while alpha is equipped now reports alpha's bit.
     env.alpha.set_armed(True)
     env.beta.set_armed(False)
     h = _make_handlers()
     assert (await h.get_armed(profile="alpha"))["armed"] is True
-    assert (await h.get_armed(profile="beta"))["armed"] is False
+    assert (await h.get_armed(profile="beta"))["armed"] is True  # alpha's bit, not beta's
     assert (await h.get_armed())["armed"] is True  # unscoped -> the equipped binding
 
 
 async def test_armed_cache_not_confused_by_identical_stat_key(env: _Env) -> None:
     # Two configs with equal size and forced-equal mtime: the pre-PET-166 stat-only
-    # key would serve one profile's bit for the other.
+    # key would serve one profile's bit for the other. The property (path is part of
+    # the _armed.py cache key) lives in read_armed itself, so it is exercised there:
+    # after PET-185, get_armed reads one file for every selector and would make this
+    # test vacuous.
     env.alpha.set_armed(True)
     env.beta.set_armed(False)
     a_cfg, b_cfg = env.alpha.dir / "config.yaml", env.beta.dir / "config.yaml"
@@ -592,10 +599,17 @@ async def test_armed_cache_not_confused_by_identical_stat_key(env: _Env) -> None
     assert b_cfg.stat().st_mtime_ns == a_cfg.stat().st_mtime_ns
     armed_mod._reset_armed_cache()
 
-    h = _make_handlers()
-    assert (await h.get_armed(profile="alpha"))["armed"] is True
-    assert (await h.get_armed(profile="beta"))["armed"] is False
-    assert (await h.get_armed(profile="alpha"))["armed"] is True
+    # Bind and pin the resolutions FIRST: read_armed(None) silently re-resolves
+    # ambient, and alpha IS the ambient binding here, so a None from a membership
+    # regression would let both alpha assertions pass while testing nothing.
+    a_res = paths_mod.resolve_profile_config_path("alpha")
+    b_res = paths_mod.resolve_profile_config_path("beta")
+    assert a_res is not None and b_res is not None
+    _assert_under(str(a_res.path), env.alpha)
+    _assert_under(str(b_res.path), env.beta)
+    assert armed_mod.read_armed(a_res) is True
+    assert armed_mod.read_armed(b_res) is False
+    assert armed_mod.read_armed(a_res) is True
 
 
 def test_armed_cache_bounded(env: _Env) -> None:


### PR DESCRIPTION
## Summary
- `GET /api/armed` now sources the bit from the binding `POST /api/armed` writes, in every scope state. Under PET-166 a scoped read served the selected profile's `petasos.enabled` while the unscoped toggle wrote the process binding's config, so on a `HERMES_HOME`-pinned dashboard with a named profile selected an Unequip never stuck visually, and the banner could read EQUIPPED while the binding the toggle governs was disarmed (live gibson box, 2026-08-13).
- New pure client seam `Pet.armScopeView` derives the PET-166 D16 booleans bit-identically and captions the arm control with the binding the banner describes, naming the binding tier and stating plainly that arming does not change the selected profile's enforcement. Caption contrast moves from `--tx-faint` to `--tx-mut` per the `role="status"` WCAG 1.4.3 rule.
- Operator-visible consequence, stated rather than buried: the console no longer reports a non-equipped profile's own arming bit anywhere (it remains readable on disk). `read_scope` stays scope-gated on the response, so the client's unscoped-arm predicate cannot oscillate.

## Read/write agreement

The fix is one expression: `read_armed(scope.resolution)` becomes `read_armed(None)`, which re-resolves ambient through the same `resolve_hermes_config_path()` call `write_armed` makes, through the same module import - no path copied between the two sides, no new `_ReadScope` field. `_resolve_read_scope` still runs first, so the 422 contract, the D6 409 refusal, the D20 tripwire, and the scope-gated `read_scope` payload are all unchanged.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/server.py` | `get_armed` sources the bit from the write binding; stale PET-166 D1 header comment replaced |
| `petasos/console/static/petasos.js` | New pure `Pet.armScopeView`; `renderDashboard` consumes it; caption names the binding, contrast fix |
| `docs/deployment/profile-resolution-model.md` | Armed indicator dropped from the scoped-read enumeration; the one-read-follows-the-write-binding sentence added (PET-185) |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry incl. the bundle-sync requirement for hand-synced deployments |
| `tests/test_console_armed_write_binding.py` | New: T1 live-box repro, T2 same-file resolver pin (recording passthrough, arity-asserted), T3-T6 all scope-state rows, T7 anti-oscillation, T8 refusal contracts, T9 D20 tripwire |
| `tests/test_console_profile_scoped_reads.py` | Two PET-166 tests retargeted: the armed read now pins write-binding semantics; the stat-key cache property moved to `read_armed` where it lives |
| `tests/js/arm-scope-view.test.mjs` | New: 13 cases incl. the live-box row, the D16 `equipped:null` disjunct pin, term-by-term boolean equivalence, house-style pin |

## Test plan

- [x] `C:\python310\python.exe -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` - 2735 passed / 48 skipped / 1 xfailed (output captured locally at docs/specs/TODO/PET-185.test-output.txt; that tree is gitignored)
- [x] `node --test tests/js/*.test.mjs` - 304/304 pass
- [x] `ruff check .` + `ruff format --check .` - clean
- [x] `mypy --strict .` - clean, 173 files
- [ ] Post-merge: hand-sync the gibson bundle - `petasos.js` must travel with the backend (new console over an old backend inverts the caption's claim on exactly the box this fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arming status now consistently reflects the active write binding.
  * Arming banners and controls clearly indicate which binding they affect.
  * Profile-scoped views no longer display misleading armed-state information.
  * Unknown or unavailable binding states now fail safely.
  * Aborted or excess event streams are handled correctly, preventing capacity leaks and returning an appropriate service-unavailable response.

* **Documentation**
  * Updated deployment and profile-scope guidance to describe the corrected arming behavior.

* **Tests**
  * Added coverage for event-stream capacity and root, profile, equipped, unscoped, and unknown binding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->