### PR TITLE
fix(pet-191): bind SSE slot release to response teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ## [Unreleased]
 
+### Fixed
+
+- **SSE subscriber slots no longer leak on an aborted open (PET-191, PET-184 finding
+  PETRT-003).** A `/api/events` request whose stream generator never took its first
+  step used to hold one of the ten live subscriber slots for the life of the process,
+  because the slot was reserved in the route and released only when the generator
+  finished; ten such opens denied the event stream to every later client with a 503.
+  Slots are now released when the response's ASGI call tears down, which runs whether
+  or not the generator started. The idle (non-equipped) arm moves onto the same
+  reservation, retiring the check-then-act over-admit PET-166 D9 had accepted as
+  transient, and its capacity refusal now logs like the live arm's. Both console
+  surfaces share one route builder. The cap is still ten; the 503 bodies are unchanged.
+  What `tests/test_console_sse_route.py` demonstrates, stated exactly: a `send` that
+  fails at `http.response.start` stranded a never-started generator and leaked a slot
+  on both console surfaces and on both starlette 1.1.0 response branches, including
+  the one uvicorn 0.48.0 selects. A plain early client disconnect did **not** leak on
+  that stack, and uvicorn's own h11 `send` returns early rather than raising when the
+  client is gone, so the leak is not reachable from a bare uvicorn client abort; it is
+  reachable through any host, ASGI middleware, or transport whose `send` raises there.
+
 ## [0.3.0] - 2026-08-11
 
 Headline release since 0.2.0: the ingestion path gains bounded scanning and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   surfaces share one route builder. The cap is still ten; the 503 bodies are unchanged.
   What `tests/test_console_sse_route.py` demonstrates, stated exactly: a `send` that
   fails at `http.response.start` stranded a never-started generator and leaked a slot
-  on both console surfaces and on both starlette 1.1.0 response branches, including
-  the one uvicorn 0.48.0 selects. A plain early client disconnect did **not** leak on
-  that stack, and uvicorn's own h11 `send` returns early rather than raising when the
+  on both console surfaces and on both of Starlette's streaming-response branches
+  (ASGI `spec_version` 2.3 and 2.4), the 2.3 branch being the one the tested host
+  advertises. A plain early client disconnect did **not** leak on the tested stack
+  (uvicorn 0.48.0), whose own h11 `send` returns early rather than raising when the
   client is gone, so the leak is not reachable from a bare uvicorn client abort; it is
   reachable through any host, ASGI middleware, or transport whose `send` raises there.
 

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -335,6 +335,9 @@ Operational notes:
 - **Forward-looking invariant:** the dependency gates by the `/api/` path prefix,
   so every sensitive route must live under `/api/`. A future non-asset route
   added outside `/api/` would be served unauthenticated.
+- The event stream pool is small and fixed. A slot is released when its response
+  tears down, so a client that opens `/api/events` and disconnects before the first
+  frame cannot pin one (PET-191).
 
 ### The floor that survives a hostile config
 

--- a/petasos/console/_sse_route.py
+++ b/petasos/console/_sse_route.py
@@ -1,0 +1,127 @@
+"""The /api/events route builder shared by both console surfaces (PET-166 D13, PET-191).
+
+One decision path for the standalone app and the Hermes bridge: scope resolution,
+the two capacity refusals, and the stream response whose teardown releases the
+slot it reserved. Top-level fastapi import is fine here: this module is only
+imported from inside a route body or ``build_app``, after fastapi is known present
+(the same shape as ``hermes/plugin_api.py``).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import TYPE_CHECKING, Any
+
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from starlette.types import Receive, Scope, Send
+
+    from petasos.console.server import ConsoleHandlers
+
+_logger = logging.getLogger(__name__)
+
+_STREAM_HEADERS = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+
+
+class LeasedStreamingResponse(StreamingResponse):
+    """A StreamingResponse that releases a reserved slot when its ASGI call tears down.
+
+    FastAPI's route wrapper awaits ``response(scope, receive, send)`` for every
+    response an endpoint returns (see PET-191 spec, Decision 1), so this
+    ``finally`` runs whether the body generator started or not. That is the
+    property the route needs: a client that disconnects before the first body
+    pull leaves the generator never started and its ``finally`` never runs, which
+    is how the slot used to leak.
+
+    ``release`` must be synchronous and must not raise; it is invoked exactly once
+    per response call and need not be idempotent (the live arm's ``unsubscribe``
+    happens to be, which is why a started generator's own ``finally`` is harmless;
+    the idle arm's ``release_idle_slot`` is a counting operation and is not). It
+    must close over the object it reserved from (the broadcaster instance, the
+    handlers instance), never over a path through a mutable attribute.
+    """
+
+    def __init__(
+        self,
+        content: AsyncIterator[str],
+        release: Callable[[], None],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(content, **kwargs)
+        self._release = release
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # The base class's websocket branch drains the body iterator with no
+        # disconnect listener and would never return for an endless stream, so this
+        # `finally` would never be reached on it. Unreachable here: both events routes
+        # are HTTP GET only, and a websocket scope with no matching route is denied by
+        # the router before any endpoint runs.
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            try:
+                self._release()
+            except Exception:  # a broken release must never eat a CancelledError
+                _logger.exception(
+                    "PETASOS_STREAM_RELEASE_FAILED release=%r; a stream slot is now leaked "
+                    "for the life of the process",
+                    self._release,
+                )
+
+
+def events_response(handlers: ConsoleHandlers, profile: str | None) -> Response:
+    """Build the /api/events response for BOTH surfaces (PET-166 D13, PET-191).
+
+    Plain ``def`` with no suspension point: on each arm the capacity check and the
+    reservation run back to back under the event loop, so no concurrent request
+    can interleave (Decision 2; pinned by test). Every refusal is a JSON response
+    built before any stream object exists (PET-166 D7/D9): the 422 for a
+    non-member profile, the idle-arm 503 carrying ``scope_refusal: capacity`` (the
+    D9 terminal marker), and the equipped-arm 503 left unmarked so the client's
+    shipped retry-then-fallback path fires.
+    """
+    from petasos.console.server import ProfileNotFoundError
+
+    try:
+        scope = handlers.resolve_events_scope(profile)
+    except ProfileNotFoundError as exc:
+        # Both arguments by keyword, matching every shipped 422 site.
+        return JSONResponse(
+            status_code=422,
+            content={"detail": [{"field": "profile", "message": str(exc)}]},
+        )
+    if scope.state != "equipped":
+        if not handlers.reserve_idle_slot():
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": [{"field": "profile", "message": "idle scope streams at capacity"}],
+                    "scope_refusal": "capacity",
+                },
+            )
+        return LeasedStreamingResponse(
+            handlers.idle_scope_stream(scope),
+            handlers.release_idle_slot,
+            media_type="text/event-stream",
+            headers=_STREAM_HEADERS,
+        )
+    sse = handlers.sse  # captured now: the release must target the pool it reserved from
+    try:
+        q = sse.subscribe()
+    except RuntimeError:
+        # PET-166: a full subscriber pool used to 500 out of this route; it is an
+        # honest 503 (unmarked -- the client's shipped retry path is correct here).
+        return JSONResponse(
+            status_code=503,
+            content={"detail": [{"field": "profile", "message": "event stream at capacity"}]},
+        )
+    return LeasedStreamingResponse(
+        sse.stream(q),
+        functools.partial(sse.unsubscribe, q),
+        media_type="text/event-stream",
+        headers=_STREAM_HEADERS,
+    )

--- a/petasos/console/hermes/plugin_api.py
+++ b/petasos/console/hermes/plugin_api.py
@@ -235,50 +235,16 @@ async def get_profiles() -> Any:
 
 @router.get("/events")
 async def events(profile: str | None = None) -> Any:
-    # PET-166 (D9/D13): both route surfaces move in lockstep — the 422, the idle arm
-    # (with its slot check against the SHARED handlers counter), and the RuntimeError
-    # -> 503 mapping (both routes 500 on a full pool today) are all present here, not
-    # only on the standalone route. A bridge that checked without incrementing would
-    # admit unbounded idle generators; the increment lives inside the shared
-    # idle_scope_stream generator, so both routes feed one counter.
-    from fastapi.responses import JSONResponse, StreamingResponse
+    # PET-166 D13 / PET-191: both surfaces are one line into the shared builder, so the
+    # 422, the two capacity refusals, and the slot lease cannot drift between them.
+    #
+    # Limit worth stating: the lease releases on response teardown, which FastAPI's
+    # route wrapper always runs (PET-191 Decision 1) as long as no function-scoped
+    # `yield` dependency sits on the route. A host that mounts this router with one of
+    # its own would reopen the leak, and that composition is outside what this repo pins.
+    from petasos.console._sse_route import events_response
 
-    from petasos.console.server import ProfileNotFoundError
-
-    h = _require_handlers()
-    try:
-        scope = h.resolve_events_scope(profile)
-    except ProfileNotFoundError as exc:
-        return JSONResponse(
-            status_code=422,
-            content={"detail": [{"field": "profile", "message": str(exc)}]},
-        )
-    if scope.state != "equipped":
-        if h._idle_stream_count >= h.sse.max_subscribers:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "detail": [{"field": "profile", "message": "idle scope streams at capacity"}],
-                    "scope_refusal": "capacity",
-                },
-            )
-        return StreamingResponse(
-            h.idle_scope_stream(scope),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
-    try:
-        q = h.sse.subscribe()
-    except RuntimeError:
-        return JSONResponse(
-            status_code=503,
-            content={"detail": [{"field": "profile", "message": "event stream at capacity"}]},
-        )
-    return StreamingResponse(
-        h.sse.stream(q),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+    return events_response(_require_handlers(), profile)
 
 
 @router.get("/about")

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -1203,27 +1203,44 @@ class ConsoleHandlers:
         self._note_unscoped_read(scope)
         return scope
 
+    def reserve_idle_slot(self) -> bool:
+        """Reserve an idle-stream slot; False when the idle pool is at its bound.
+
+        Shared by BOTH ``/api/events`` routes through the builder (PET-166 D13).
+        Synchronous check-and-increment: the caller holds the event loop for both, so
+        two concurrent opens cannot both observe a count below the bound (PET-191
+        retires the PET-166 D9 over-admit). Released by the response teardown, never
+        by the generator.
+        """
+        bound = self.sse.max_subscribers
+        if self._idle_stream_count >= bound:
+            _logger.warning("idle scope stream limit reached (%d), rejecting", bound)
+            return False
+        self._idle_stream_count += 1
+        return True
+
+    def release_idle_slot(self) -> None:
+        """Release one idle-stream slot (PET-191); paired with ``reserve_idle_slot``."""
+        # A counting release, NOT idempotent: LeasedStreamingResponse calls it exactly
+        # once per reserved response, and nothing else may. The clamp keeps the check
+        # above honest; it is not machinery for a reachable state (PET-171).
+        self._idle_stream_count = max(0, self._idle_stream_count - 1)
+
     async def idle_scope_stream(self, scope: "_ReadScope") -> "AsyncIterator[str]":
         """The non-equipped SSE stream (PET-166 D9): one ``read_scope`` frame, then a bare
         keepalive loop that never completes and never touches the live subscriber pool.
 
-        The slot is acquired in the generator's preamble and released in ``finally`` —
-        never in the route — because in the installed starlette a client disconnect
-        between ``http.response.start`` and the first body pull raises out of ``send``
-        with the generator never started: its ``finally`` would never run, and a slot
-        acquired at the route would leak permanently, once per aborted open. A
-        never-started generator never acquired, so the counter is self-healing; the
-        cost is a transient over-admit bounded by concurrent opens.
+        The generator owns no accounting (PET-191). Its slot is reserved by
+        ``reserve_idle_slot`` in the shared route builder, atomically with the capacity
+        check, and released by the response's ASGI teardown, which runs whether or not
+        this generator ever took its first step. That is the property a ``finally`` here
+        could not give: a never-started generator never runs one.
         """
-        self._idle_stream_count += 1
-        try:
-            frame = json.dumps(_read_scope_payload(scope))
-            yield f"event: read_scope\ndata: {frame}\n\n"
-            while True:
-                await asyncio.sleep(15.0)
-                yield ":keepalive\n\n"
-        finally:
-            self._idle_stream_count -= 1
+        frame = json.dumps(_read_scope_payload(scope))
+        yield f"event: read_scope\ndata: {frame}\n\n"
+        while True:
+            await asyncio.sleep(15.0)
+            yield ":keepalive\n\n"
 
     async def get_config(self, profile: str | None = None) -> dict[str, Any]:
         # PET-146 D1: the active binding identity + its (possibly dangling-pointer)
@@ -1963,10 +1980,11 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
 
     from fastapi import Depends, Header, HTTPException, Request
     from fastapi import FastAPI as _FastAPI
-    from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+    from fastapi.responses import HTMLResponse, JSONResponse
     from fastapi.staticfiles import StaticFiles
 
     import petasos
+    from petasos.console._sse_route import events_response
 
     # PET-141: bind the package version once so both FastAPI constructions (and the
     # package) can never drift — D3 single source for the OpenAPI version field.
@@ -2174,52 +2192,10 @@ def build_app(pipeline: "Pipeline", *, auth_token: str | None = None) -> "FastAP
 
     @app.get("/api/events")
     async def api_events(profile: str | None = None) -> Any:
-        # PET-166 (D7/D9): validation happens BEFORE any stream object is built, so a
-        # failure is an ordinary JSON response, never an error frame inside a
-        # text/event-stream.
-        try:
-            scope = handlers.resolve_events_scope(profile)
-        except ProfileNotFoundError as exc:
-            # Both arguments by keyword, matching every shipped 422 site.
-            return JSONResponse(
-                status_code=422,
-                content={"detail": [{"field": "profile", "message": str(exc)}]},
-            )
-        if scope.state != "equipped":
-            # D9: check here (so the refusal is a JSON 503, not a frame in a stream),
-            # but the slot is acquired INSIDE the generator — a never-started generator
-            # must not hold a slot. scope_refusal is the terminal marker; the
-            # equipped-arm 503 below stays unmarked so the shipped client
-            # retry-then-fallback path is preserved there.
-            if handlers._idle_stream_count >= handlers.sse.max_subscribers:
-                return JSONResponse(
-                    status_code=503,
-                    content={
-                        "detail": [
-                            {"field": "profile", "message": "idle scope streams at capacity"}
-                        ],
-                        "scope_refusal": "capacity",
-                    },
-                )
-            return StreamingResponse(
-                handlers.idle_scope_stream(scope),
-                media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-            )
-        try:
-            q = handlers.sse.subscribe()
-        except RuntimeError:
-            # PET-166: today a full subscriber pool 500s out of this route; map it to
-            # an honest 503 (unmarked — the client's shipped retry path is correct here).
-            return JSONResponse(
-                status_code=503,
-                content={"detail": [{"field": "profile", "message": "event stream at capacity"}]},
-            )
-        return StreamingResponse(
-            handlers.sse.stream(q),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-        )
+        # PET-191: one builder for both surfaces. It owns the PET-166 D7/D9 reasoning
+        # (validation before any stream object; the two refusal bodies) and the slot
+        # lease whose release is bound to the response teardown.
+        return events_response(handlers, profile)
 
     @app.get("/api/about")
     async def api_get_about() -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,11 +123,21 @@ module = [
     "petasos.console.*",
     "fastapi",
     "fastapi.*",
+    # PET-191: _sse_route's TYPE_CHECKING import of starlette.types must resolve to
+    # Any in the CI typecheck lane, which installs only .[dev] (no fastapi/starlette).
+    "starlette",
+    "starlette.*",
     "uvicorn",
     "uvicorn.*",
 ]
 ignore_missing_imports = true
 disallow_untyped_decorators = false
+
+# PET-191: LeasedStreamingResponse subclasses StreamingResponse, which is Any in
+# the CI typecheck lane (no fastapi installed). Scoped to the one module that needs it.
+[[tool.mypy.overrides]]
+module = "petasos.console._sse_route"
+disallow_subclassing_any = false
 
 [[tool.mypy.overrides]]
 module = ["reference_plugin", "reference_plugin.*"]

--- a/tests/test_console_scoped_routes.py
+++ b/tests/test_console_scoped_routes.py
@@ -3,9 +3,11 @@
 The handler-level semantics live in ``test_console_profile_scoped_reads.py``;
 this module pins what only a route can show: the 422/409 status mapping, the
 query-borne-selector rejection on the write, the SSE idle arm (its terminal
-``scope_refusal`` marker, its slot accounting, and the never-iterated-response
-leak), and the D13 requirement that the embedded bridge moves in lockstep with
-the standalone routes rather than one of them being ported later.
+``scope_refusal`` marker), and the D13 requirement that the embedded bridge moves
+in lockstep with the standalone routes rather than one of them being ported later.
+
+Slot accounting and the never-started-generator leak moved to
+``test_console_sse_route.py`` with PET-191, where the reservation now lives.
 """
 
 import json
@@ -212,9 +214,10 @@ async def test_events_non_equipped_emits_scope_frame_and_stays_open(
     assert payload["live"] is False
     assert payload["selected"] == "beta"
     assert subscribed == []  # consumes no live subscriber slot
-    assert h._idle_stream_count == 1  # holds an idle slot while open
+    # PET-191: the generator owns no accounting any more (the slot is reserved and
+    # released by the response lease), so there is nothing to assert around it here.
+    # tests/test_console_sse_route.py T-3/T-4/T-8 carry that meaning.
     await gen.aclose()
-    assert h._idle_stream_count == 0  # and releases it in the finally
 
 
 def test_events_equipped_unchanged(client: tuple[Any, str], profiles: Path) -> None:
@@ -242,32 +245,19 @@ def test_events_subscriber_limit_is_503_unmarked(client: tuple[Any, str], profil
     assert "scope_refusal" not in r.json()
 
 
-async def test_idle_stream_limit_is_503_and_slot_is_released(
-    client: tuple[Any, str], profiles: Path
-) -> None:
+def test_idle_stream_limit_is_503_marked(client: tuple[Any, str], profiles: Path) -> None:
+    # A full IDLE pool is a 503 carrying the D9 terminal marker, on both surfaces.
+    # PET-191 moved the release half of this test to test_console_sse_route.py, where
+    # the reservation now lives; the refusal contract is what a route can still show.
     tc, base = client
     h = _handlers(client)
     h._idle_stream_count = h.sse.max_subscribers
-    r = tc.get(base + "/events", params={"profile": "beta"})
-    assert r.status_code == 503
-    assert r.json()["scope_refusal"] == "capacity"  # the D9 terminal marker
-
-    h._idle_stream_count = 0
-    # Closing an idle stream frees its slot (the generator's finally), so the next
-    # one is admitted rather than inheriting a leaked count.
-    await _first_frame(h, "beta")
-    assert h._idle_stream_count == 0
-
-
-def test_abandoned_idle_response_holds_no_slot(client: tuple[Any, str], profiles: Path) -> None:
-    # Build the generator and NEVER iterate it: a never-started generator's finally
-    # never runs, so an increment placed in the ROUTE would leak permanently, once
-    # per aborted open. This is the only way that leak is observable.
-    h = _handlers(client)
-    scope = h.resolve_events_scope("beta")
-    for _ in range(h.sse.max_subscribers + 2):
-        h.idle_scope_stream(scope)  # constructed, never awaited
-    assert h._idle_stream_count == 0
+    try:
+        r = tc.get(base + "/events", params={"profile": "beta"})
+        assert r.status_code == 503
+        assert r.json()["scope_refusal"] == "capacity"
+    finally:
+        h._idle_stream_count = 0
 
 
 async def test_idle_stream_limit_tracks_broadcaster_bound(profiles: Path) -> None:
@@ -278,8 +268,14 @@ async def test_idle_stream_limit_tracks_broadcaster_bound(profiles: Path) -> Non
     h = server_mod.ConsoleHandlers(_make_pipeline())
     h.sse = SSEBroadcaster(max_subscribers=3)
     assert h.sse.max_subscribers == 3
-    h._idle_stream_count = 3
-    assert h._idle_stream_count >= h.sse.max_subscribers  # the idle arm refuses here
+    # PET-191: drive the real owner of the check rather than comparing two values the
+    # test itself wrote. Three reservations fit, the fourth is refused, and three
+    # releases hand the capacity back.
+    assert [h.reserve_idle_slot() for _ in range(3)] == [True, True, True]
+    assert h.reserve_idle_slot() is False
+    for _ in range(3):
+        h.release_idle_slot()
+    assert h._idle_stream_count == 0
 
 
 async def test_bridge_and_standalone_agree_on_every_scoped_contract(

--- a/tests/test_console_sse_route.py
+++ b/tests/test_console_sse_route.py
@@ -1,0 +1,436 @@
+"""PET-191: the ``/api/events`` slot lease, on both console surfaces.
+
+A slot reserved by the route used to be released only by the stream generator's
+``finally``, which never runs when the generator is never started. This module
+pins the replacement: the reservation is bound to the response's ASGI call, whose
+``finally`` runs whether the generator started or not, and the idle arm's counter
+moves onto the same primitive (retiring the PET-166 D9 check-then-act over-admit).
+
+Discipline for this file, because every non-refusal call now reserves a real slot:
+
+1. Every ``LeasedStreamingResponse`` a test builds is driven to teardown (or its
+   counters reset) before the next assertion.
+2. Tests that call ``__call__`` directly build the app or handlers OUTSIDE any
+   ``TestClient`` context, on the test's own loop: ``asyncio.Queue`` is loop-bound
+   and ``TestClient`` runs the app on a portal thread's loop. Startup (including
+   the standalone ``_enforcement_tailer`` task) then does not run, which is what
+   you want during a pool-count assertion.
+3. No ``TestClient`` streaming of a live SSE route anywhere: the routes never
+   complete by design, so a client-side read loop hangs the suite.
+4. The ASGI scope handed to a direct ``__call__`` is explicit about
+   ``asgi.spec_version`` (it selects the ``StreamingResponse.__call__`` branch),
+   and every direct ``__call__`` gets an async ``send``: ``Response.__call__``
+   sends two messages unconditionally even though it never reads ``receive``.
+"""
+
+import ast
+import asyncio
+import inspect
+import json
+import logging
+import platform
+import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+import petasos.console._armed as armed_mod  # noqa: E402
+import petasos.console._history as history_mod  # noqa: E402
+import petasos.console._paths as paths_mod  # noqa: E402
+import petasos.console.hermes.plugin_api as plugin_mod  # noqa: E402
+import petasos.console.server as server_mod  # noqa: E402
+from petasos.config import PetasosConfig  # noqa: E402
+from petasos.pipeline import Pipeline  # noqa: E402
+from petasos.scanners.minimal import MinimalScanner  # noqa: E402
+
+
+def _make_pipeline() -> Pipeline:
+    return Pipeline(scanners=[MinimalScanner()], config=PetasosConfig(fail_mode="degraded"))
+
+
+@pytest.fixture()
+def profiles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Two real profile homes with alpha equipped (the sibling module's fixture shape)."""
+    saved_spool = paths_mod._SPOOL_PATH_OVERRIDE
+    saved_hist = history_mod._HISTORY_PATH_OVERRIDE
+    paths_mod._SPOOL_PATH_OVERRIDE = None
+    history_mod._HISTORY_PATH_OVERRIDE = None
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if platform.system() == "Windows":
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    else:
+        monkeypatch.setenv("HOME", str(tmp_path))
+    root = paths_mod.hermes_root()
+    for name in ("alpha", "beta"):
+        d = root / "profiles" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.yaml").write_text("petasos:\n  enabled: true\n", encoding="utf-8")
+    (root / "active_profile").write_text("alpha", encoding="utf-8")
+    armed_mod._reset_armed_cache()
+    try:
+        yield root
+    finally:
+        paths_mod._SPOOL_PATH_OVERRIDE = saved_spool
+        history_mod._HISTORY_PATH_OVERRIDE = saved_hist
+        armed_mod._reset_armed_cache()
+
+
+def _handlers_of(app: Any) -> Any:
+    """Reach build_app's handlers through a live route closure (the sibling idiom)."""
+    for route in app.routes:
+        closure = getattr(getattr(route, "endpoint", None), "__closure__", None) or ()
+        for cell in closure:
+            if isinstance(cell.cell_contents, server_mod.ConsoleHandlers):
+                return cell.cell_contents
+    raise AssertionError("handlers not reachable")
+
+
+def _asgi_app(surface: str) -> tuple[Any, Any, str]:
+    """(app, handlers, path) for a surface, built OUTSIDE TestClient (discipline 2)."""
+    if surface == "standalone":
+        app = server_mod.build_app(_make_pipeline())
+        return app, _handlers_of(app), "/api/events"
+    from fastapi import FastAPI
+
+    plugin_mod.init_handlers(_make_pipeline())
+    app = FastAPI()
+    app.include_router(plugin_mod.router)
+    return app, plugin_mod._handlers, "/events"
+
+
+def _http_scope(path: str, spec_version: str, query: bytes = b"") -> dict[str, Any]:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": spec_version},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query,
+        "root_path": "",
+        "headers": [(b"host", b"testserver")],
+        "client": ("127.0.0.1", 51234),
+        "server": ("testserver", 80),
+    }
+
+
+async def _disconnect_receive() -> dict[str, Any]:
+    """A ``receive`` that reports the client is already gone, without suspending.
+
+    This is uvicorn 0.48.0's own behaviour once ``RequestResponseCycle.disconnected``
+    is set: the ``message_event.wait()`` is skipped and ``http.disconnect`` returns
+    immediately (``h11_impl.py``). It is what an early client abort looks like to the app.
+    """
+    return {"type": "http.disconnect"}
+
+
+async def _noop_send(message: dict[str, Any]) -> None:
+    return None
+
+
+# ── T-5 / T-6: ASGI-level reachability (Decision 7) ────────────────────────
+#
+# These two drive the REAL route, not the builder, so they are the only tests in
+# this module that can run against the pre-fix tree; their pre-fix outcome is
+# recorded in docs/specs/TODO/PET-191.test-output.txt.
+#
+# Measured pre-fix at c5ef6d9, and it revises the spec's Decision 7 hypothesis:
+#
+#   spec_version 2.3, working send  -> generator STARTS, pool 0   (no leak)
+#   spec_version 2.3, send raises   -> generator never starts, pool 1  (LEAK)
+#   spec_version 2.4, working send  -> generator starts, pool 0
+#   spec_version 2.4, send raises   -> generator never starts, pool 1  (LEAK)
+#
+# So an immediate disconnect on the shipped host does NOT strand a generator:
+# starlette's task group lets the ``start_soon``'d ``stream_response`` reach its
+# first ``send`` before the cancel lands. The never-started generator comes from a
+# ``send`` that fails at ``http.response.start``, and that leaks on BOTH branches,
+# the shipped 2.3 one included. uvicorn 0.48.0's own h11 ``send`` returns early
+# when ``disconnected`` is set rather than raising, so this is not reachable from
+# a bare uvicorn client abort; it is reachable through any host, ASGI middleware,
+# or transport whose ``send`` raises there. T-5 stays as the regression pin for
+# the disconnect path.
+
+
+@pytest.mark.parametrize("surface", ["standalone", "plugin"])
+async def test_early_disconnect_leaves_no_leaked_slot(profiles: Path, surface: str) -> None:
+    """T-5: an immediate client disconnect on the shipped host (uvicorn 0.48.0 h11
+    advertises spec_version "2.3", so starlette takes the anyio task-group branch).
+
+    Measured green pre-fix: ``stream_response`` reaches ``send`` and the body
+    generator starts, so its own ``finally`` unsubscribes. Kept as the pin that the
+    lease does not regress the path that already worked."""
+    plugin_mod._handlers = None
+    try:
+        app, handlers, path = _asgi_app(surface)
+        await app(_http_scope(path, "2.3"), _disconnect_receive, _noop_send)
+        assert len(handlers.sse._subscribers) == 0
+    finally:
+        plugin_mod._handlers = None
+
+
+@pytest.mark.parametrize("surface", ["standalone", "plugin"])
+@pytest.mark.parametrize("spec_version", ["2.3", "2.4"])
+async def test_failing_response_start_leaves_no_leaked_slot(
+    profiles: Path, surface: str, spec_version: str
+) -> None:
+    """T-6: ``send`` raising at ``http.response.start``. This is the trigger that
+    actually strands a never-started generator, and it does so on both starlette
+    branches: on 2.4 the ``OSError`` becomes ``ClientDisconnect`` before ``async
+    for`` begins, on 2.3 it escapes the task group from the same point. Pre-fix both
+    leaked one slot on both surfaces.
+
+    The load-bearing assertion is the post-call pool count, not the exception type."""
+    from starlette.requests import ClientDisconnect
+
+    plugin_mod._handlers = None
+    try:
+        app, handlers, path = _asgi_app(surface)
+
+        async def _broken_send(message: dict[str, Any]) -> None:
+            if message["type"] == "http.response.start":
+                raise OSError("client gone")
+
+        with pytest.raises((ClientDisconnect, OSError)):
+            await app(_http_scope(path, spec_version), _disconnect_receive, _broken_send)
+        assert len(handlers.sse._subscribers) == 0
+    finally:
+        plugin_mod._handlers = None
+
+
+# ── Builder-level behaviour ────────────────────────────────────────────────
+
+
+def _handlers_only() -> Any:
+    """Bare handlers on the test's own loop (no app, no TestClient)."""
+    return server_mod.ConsoleHandlers(_make_pipeline())
+
+
+async def _tear_down(response: Any, spec_version: str = "2.3") -> None:
+    """Drive a built response through one ASGI call so its lease releases."""
+    await response(_http_scope("/api/events", spec_version), _disconnect_receive, _noop_send)
+
+
+async def test_equipped_responses_torn_down_leave_pool_empty(profiles: Path) -> None:
+    """T-2: max_subscribers + 2 equipped-arm responses. The first max_subscribers are
+    leases, the last two are the unmarked 503. Tearing all of them down empties the
+    live pool and the next subscribe() succeeds."""
+    from petasos.console._sse_route import LeasedStreamingResponse, events_response
+
+    h = _handlers_only()
+    bound = h.sse.max_subscribers
+    built = [events_response(h, None) for _ in range(bound + 2)]
+
+    assert all(isinstance(r, LeasedStreamingResponse) for r in built[:bound])
+    assert len(h.sse._subscribers) == bound
+    for overflow in built[bound:]:
+        assert overflow.status_code == 503
+        assert b"scope_refusal" not in overflow.body  # equipped arm stays unmarked
+
+    for response in built:
+        await _tear_down(response)
+
+    assert len(h.sse._subscribers) == 0
+    h.sse.unsubscribe(h.sse.subscribe())  # the pool admits again
+
+
+async def test_idle_responses_torn_down_leave_counter_at_zero(profiles: Path) -> None:
+    """T-3: the idle arm, same shape. Replaces the deleted
+    ``test_abandoned_idle_response_holds_no_slot``, whose meaning this carries."""
+    from petasos.console._sse_route import LeasedStreamingResponse, events_response
+
+    h = _handlers_only()
+    bound = h.sse.max_subscribers
+    built = [events_response(h, "beta") for _ in range(bound + 2)]
+
+    assert all(isinstance(r, LeasedStreamingResponse) for r in built[:bound])
+    assert h._idle_stream_count == bound
+    for overflow in built[bound:]:
+        assert overflow.status_code == 503
+        assert json.loads(overflow.body)["scope_refusal"] == "capacity"
+
+    for response in built:
+        await _tear_down(response)
+
+    assert h._idle_stream_count == 0
+    assert len(h.sse._subscribers) == 0  # the idle arm never touches the live pool
+
+
+@pytest.mark.parametrize("arm", ["idle", "equipped"])
+async def test_started_then_closed_releases_exactly_once(profiles: Path, arm: str) -> None:
+    """T-4: the normal path. Drive a lease to a first body frame, then disconnect, and
+    assert the pool is empty afterwards. On the idle arm the generator no longer touches
+    the counter at all, so the started and never-started paths land on a single
+    ``release_idle_slot()`` from the teardown; on the live arm the generator's own
+    ``unsubscribe`` is the harmless (idempotent) second call."""
+    from petasos.console._sse_route import events_response
+
+    h = _handlers_only()
+    response = events_response(h, "beta" if arm == "idle" else None)
+    if arm == "equipped":
+        assert len(h.sse._subscribers) == 1
+    else:
+        assert h._idle_stream_count == 1
+
+    gone = asyncio.Event()
+    frames: list[bytes] = []
+    polled = False
+
+    async def receive() -> dict[str, Any]:
+        # First call answers immediately so listen_for_disconnect keeps waiting; every
+        # later call SUSPENDS on `gone` (a receive that never suspends busy-loops the
+        # task group and the stream task never gets to run).
+        nonlocal polled
+        if not polled:
+            polled = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await gone.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] == "http.response.body" and message.get("body"):
+            frames.append(message["body"])
+            gone.set()
+
+    if arm == "equipped":
+        # The live arm only yields once something is broadcast to its queue.
+        async def feed() -> None:
+            await asyncio.sleep(0)
+            await h.sse.broadcast("ping", {"hello": "world"})
+
+        await asyncio.gather(response(_http_scope("/api/events", "2.3"), receive, send), feed())
+    else:
+        await response(_http_scope("/api/events", "2.3"), receive, send)
+
+    assert frames  # the generator really started
+    assert h._idle_stream_count == 0
+    assert len(h.sse._subscribers) == 0
+
+
+async def test_idle_over_admit_is_retired(profiles: Path) -> None:
+    """T-8: check and reserve are one step, so the second concurrent open is refused
+    rather than admitted. Pre-fix both would have been admitted."""
+    from petasos.console._sse_route import LeasedStreamingResponse, events_response
+
+    h = _handlers_only()
+    bound = h.sse.max_subscribers
+    h._idle_stream_count = bound - 1
+
+    first = events_response(h, "beta")
+    assert isinstance(first, LeasedStreamingResponse)
+    assert h._idle_stream_count == bound  # reserved by the builder, not the generator
+
+    second = events_response(h, "beta")
+    assert second.status_code == 503
+    assert json.loads(second.body)["scope_refusal"] == "capacity"
+
+    await _tear_down(first)
+    assert h._idle_stream_count == bound - 1
+
+
+async def test_idle_refusal_logs_a_warning(
+    profiles: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """T-11: a refused idle open leaves the same log evidence the live pool already
+    does (``SSEBroadcaster.subscribe``'s limit WARNING). It was silent before."""
+    from petasos.console._sse_route import events_response
+
+    h = _handlers_only()
+    h._idle_stream_count = h.sse.max_subscribers
+    with caplog.at_level(logging.WARNING):
+        refused = events_response(h, "beta")
+    assert refused.status_code == 503
+    assert any("idle scope stream limit reached" in r.getMessage() for r in caplog.records)
+
+
+# ── Structural pins ───────────────────────────────────────────────────────
+
+
+def _routes_under_test() -> list[tuple[str, Any]]:
+    """(label, route) for every /api/events route surface this repo defines."""
+
+    def events_route(app: Any, path: str) -> Any:
+        for route in app.routes:
+            if getattr(route, "path", None) == path:
+                return route
+        raise AssertionError(f"no route at {path}")
+
+    plugin_mod._handlers = None
+    try:
+        return [
+            ("standalone", events_route(server_mod.build_app(_make_pipeline()), "/api/events")),
+            (
+                "standalone-token",
+                events_route(
+                    server_mod.build_app(_make_pipeline(), auth_token="t"), "/api/events"
+                ),
+            ),
+            ("plugin", events_route(plugin_mod.router, "/events")),
+        ]
+    finally:
+        plugin_mod._handlers = None
+
+
+def test_check_and_reserve_have_no_suspension_point(profiles: Path) -> None:
+    """T-9: atomicity as an AST fact, not prose. A plain ``def`` whose body contains no
+    await/async-for/async-with cannot be interleaved between its check and its
+    reservation under a single event loop."""
+    from petasos.console._sse_route import events_response
+
+    for fn in (events_response, server_mod.ConsoleHandlers.reserve_idle_slot):
+        assert inspect.iscoroutinefunction(fn) is False, fn
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        offenders = [
+            type(n).__name__
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.Await, ast.AsyncFor, ast.AsyncWith))
+        ]
+        assert offenders == [], f"{fn.__qualname__} gained a suspension point: {offenders}"
+
+
+def test_both_routes_delegate_to_the_shared_builder(profiles: Path) -> None:
+    """T-10: with one builder, equal behaviour on both surfaces is structural. T-7 is
+    the behavioural half."""
+    for label, route in _routes_under_test():
+        tree = ast.parse(textwrap.dedent(inspect.getsource(route.endpoint)))
+        called = {
+            n.func.attr if isinstance(n.func, ast.Attribute) else getattr(n.func, "id", None)
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+        }
+        assert "events_response" in called, f"{label} does not delegate: {called}"
+        assert "subscribe" not in called, f"{label} kept the old inline shape"
+        assert "idle_scope_stream" not in called, f"{label} kept the old inline shape"
+
+
+def test_no_events_route_has_a_function_scoped_generator_dependency(profiles: Path) -> None:
+    """T-12: the Decision 1 precondition, pinned. FastAPI awaits a returned response
+    unconditionally only because the route's function-scoped exit stack is empty; a
+    ``Depends`` with ``yield`` and ``scope="function"`` would put a suspension point (and
+    a raise site) between the endpoint returning and ``await response(...)``.
+
+    Limit, stated plainly: this covers this repo's route definitions and the standalone
+    app's own composition. A host that mounts the bridge router with its own
+    function-scoped ``yield`` dependency would reopen the leak on both arms, and that
+    composition is outside what this repo can pin."""
+
+    def walk(dependant: Any) -> list[Any]:
+        found = [dependant]
+        for sub in dependant.dependencies:
+            found.extend(walk(sub))
+        return found
+
+    for label, route in _routes_under_test():
+        for dep in walk(route.dependant):
+            is_gen = getattr(dep, "is_gen_callable", False) or getattr(
+                dep, "is_async_gen_callable", False
+            )
+            assert not (is_gen and getattr(dep, "scope", None) == "function"), (
+                f"{label}: {dep.call!r} is a function-scoped generator dependency; "
+                "the PET-191 lease no longer releases unconditionally"
+            )


### PR DESCRIPTION
## Summary

- A `/api/events` request whose stream generator never took its first step held one of the ten live subscriber slots for the life of the process. The slot was reserved in the route but released only by the generator's own `finally`, which a never-started generator never runs; ten such opens denied the event stream to every later client with a 503. Release now hangs off the response's ASGI call, which FastAPI's route wrapper awaits whether or not the body iterator ever started.
- The idle (non-equipped) arm moves onto the same reservation. Check and reserve are one plain `def` with no suspension point, which retires the check-then-act over-admit PET-166 D9 accepted as transient. Its capacity refusal now logs like the live pool's already did.
- Both console surfaces collapse to a one-line call into a shared route builder, so the 422, the two 503 bodies, and the lease cannot drift between them. The cap is still ten and every refusal body is byte-for-byte unchanged.

Provenance: PET-184 finding PETRT-003 (adversarial cross-model review of the 0.3.0 surface).

## What is actually reachable, as measured rather than predicted

The ticket verified the hub-level mechanism and explicitly left remote reachability open. The two ASGI-level tests were written and run against `c5ef6d9` **before** the fix, and they revise the spec's own hypothesis:

| pre-fix probe (`c5ef6d9`) | result |
|---|---|
| immediate client disconnect, `spec_version` 2.3 (the branch uvicorn 0.48.0 selects) | **no leak** - the task group lets `stream_response` reach its first `send`, so the generator starts and its `finally` unsubscribes |
| `send` raising at `http.response.start`, `spec_version` 2.3 | **leaks 1 slot**, both surfaces |
| `send` raising at `http.response.start`, `spec_version` 2.4 | **leaks 1 slot**, both surfaces |

So the spec expected an early disconnect to strand the generator and expected the failing-`send` case to be forward-compat only. Neither held: the failing `send` is the real trigger and it reaches the *shipped* branch too. The honest limit, also carried in the CHANGELOG: uvicorn 0.48.0's own h11 `send` returns early rather than raising once the client is gone, so this is not reachable from a bare uvicorn client abort; it is reachable through any host, ASGI middleware, or transport whose `send` raises there. The fix removes the class of bug regardless of which host reaches it.

## Why teardown and not "reserve inside the generator"

Reserving inside the generator is correct for the leak, but it is exactly what gives the idle arm its over-admit: the route's capacity check and the generator's increment are separated by `http.response.start`. Moving the equipped arm onto that shape would import the over-admit onto the live pool. Response teardown keeps the route's synchronous check-and-reserve and still always releases.

That guarantee rests on one precondition - FastAPI's route wrapper awaits a returned `Response` unconditionally only while the route's function-scoped exit stack is empty. A `Depends(...)` with `yield` and `scope="function"` would put a suspension point and a raise site between the endpoint returning and `await response(...)`. That precondition is a test, not a comment: `test_no_events_route_has_a_function_scoped_generator_dependency` walks the dependant tree of all three route surfaces (including the token-on app, the only configuration whose tree carries `_require_console_token`). Its limit is stated in the test and in the bridge route's comment: a host that mounts the bridge router with its own function-scoped `yield` dependency would reopen the leak, and that composition is outside what this repo can pin.

## Files changed

| File | Change |
|------|--------|
| `petasos/console/_sse_route.py` | New. `LeasedStreamingResponse` (releases in its `__call__` finally, logging and swallowing a raising release so it can never replace an in-flight `CancelledError`) and `events_response()`, the builder both surfaces use. |
| `petasos/console/server.py` | Adds `reserve_idle_slot` / `release_idle_slot`; `idle_scope_stream` becomes a pure frame-plus-keepalive generator that owns no accounting; the `/api/events` route body becomes one line. |
| `petasos/console/hermes/plugin_api.py` | The bridge `/events` route body becomes the same one line, with the mount-time limit stated. |
| `pyproject.toml` | `starlette`, `starlette.*` join the console mypy override; a new single-module override lets `_sse_route` subclass a `StreamingResponse` that is `Any` in the fastapi-less CI lane. |
| `CHANGELOG.md` | `[Unreleased]` / `### Fixed`, wording what was demonstrated and what was not. |
| `docs/deployment/hardening.md` | One bullet in the console-token section's operational notes, no numeric literal (PET-128 doc-source-assert regime). |
| `tests/test_console_sse_route.py` | New. ASGI reachability on both surfaces and both branches, teardown of `max_subscribers + 2` responses on each arm, a started-then-closed control, the retired over-admit, the idle refusal warning, and three structural pins (AST atomicity, route delegation, dependency shape). |
| `tests/test_console_scoped_routes.py` | One test deleted (vacuous once the generator owns no counter), two trimmed, one re-pointed at `reserve_idle_slot` / `release_idle_slot` - its previous form compared two values the test itself wrote and never reached the refusing code. |

## Test plan

Spec artifacts live under `docs/specs/`, which is gitignored in this repo, so the numbers are inline rather than linked.

- [x] `python -m pytest tests/test_console_sse_route.py tests/test_sse.py tests/test_console_scoped_routes.py tests/test_plugin_api_sse.py tests/test_console_profile_scoped_reads.py tests/test_hardening_docs.py -q` - 136/136 pass
- [x] Full suite, `python -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` - **2739 passed, 48 skipped, 1 xfailed** (the deselect is the pre-existing Unicode 13-vs-14 failure on the local 3.10 gate, unrelated to this ticket)
- [x] `ruff check` / `ruff format --check` over the `git ls-files`-scoped tree plus both new files - clean, 175 files formatted
- [x] `mypy --strict` on the three changed modules - clean
- [x] **CI typecheck-lane mirror** - scratch venv with `.[dev]` only (no fastapi/starlette/uvicorn, as in `ci.yml`'s typecheck job): `mypy --strict .` clean over 175 files. Negative control with both new `pyproject.toml` overrides removed produces 3 errors, so neither override is decoration.
- [x] Pre-fix measurement captured before any `_sse_route` import existed in the test module, so the pre-fix run was a measurement and not a collection error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG1B5SMMp59ex4BN57zcaw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event-stream capacity slots remaining occupied after disconnected clients or failed response startup.
  * Ensured both console surfaces consistently enforce the ten-connection limit, return 503 responses when capacity is reached, and log refusals.
  * Improved cleanup for both idle and equipped event streams during connection teardown.

* **Documentation**
  * Documented event-stream capacity limits and automatic slot release when connections close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->