### PR TITLE
fix(pet-189): report feature and arming state from the deployed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   fail-secure default armed it without a boolean ever being read. The `Config validation`
   row uses the same derivation and drops its drifted copy of the env overlay. The RESULT
   line now carries the warning count. Because the script now imports the sibling plugin
-  module, a library too old for the plugin's module-level imports fails those two rows with
-  the import error, closing the verify.py blind spot 0.3.0 disclosed. The bootstrap's
+  module, a library too old for the plugin's module-level imports fails the config
+  validation and feature activation rows with the import error, closing the verify.py blind
+  spot 0.3.0 disclosed. The arming state row does not import the plugin, so the armed bit
+  stays readable through that skew. The bootstrap's
   missing-section warning no longer claims defaults disable features; they enable all five.
   The script still reads the config file, not the running gateway.
 - **SSE subscriber slots no longer leak on an aborted open (PET-191, PET-184 finding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **The verify.py feature row now reports the deployed config (PET-189, PET-184 finding
+  PETRT-001).** The `Feature activation` row built its own `PetasosConfig` with every
+  session flag forced on and reported `PASS: All 5 session features available` over any
+  deployment, including one with `tool_guard_enabled: false`. It now reads the config the
+  plugin would boot from, built by the plugin's own `_build_config_from_section`, and lists
+  the features that config turns off, the file it read, and whether it read a validated
+  section or library defaults. A new `Arming state` row reports `petasos.enabled` via the
+  same reader the console uses, and warns rather than passing on the three shapes where the
+  fail-secure default armed it without a boolean ever being read. The `Config validation`
+  row uses the same derivation and drops its drifted copy of the env overlay. The RESULT
+  line now carries the warning count. Because the script now imports the sibling plugin
+  module, a library too old for the plugin's module-level imports fails those two rows with
+  the import error, closing the verify.py blind spot 0.3.0 disclosed. The bootstrap's
+  missing-section warning no longer claims defaults disable features; they enable all five.
+  The script still reads the config file, not the running gateway.
 - **SSE subscriber slots no longer leak on an aborted open (PET-191, PET-184 finding
   PETRT-003).** A `/api/events` request whose stream generator never took its first
   step used to hold one of the ten live subscriber slots for the life of the process,

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -414,9 +414,20 @@ checks all components, including split-brain detection:
 %LOCALAPPDATA%\hermes\hermes-agent\venv\Scripts\python.exe plugins/petasos/verify.py
 ```
 
-Expected output: checks for scanner imports, plugin files, config validation,
-env vars, injection detection, and config split-brain, all PASS. The header line
-shows which config file was resolved and the winning tier.
+Expected output: rows for scanner imports, plugin files, config validation,
+environment variables, license, feature activation, arming state, injection
+detection, and config split-brain. The header shows which config file was
+resolved, the winning tier, and which plugin copy the script imported. The
+config, feature activation, and arming state rows are all read from that config
+file, built by the plugin's own config builder, and each detail line names the
+file. A WARN on feature activation lists the session features that config turns
+off. A WARN on arming state means `petasos.enabled` is false (Unequipped in the
+console) and nothing is enforced, or that no boolean was there to read and the
+fail-secure default armed it. The script reads the config file and executes the
+plugin file it sits beside; it reports what those two files say, so compare its
+resolved path with the `loading config from ...` INFO line in the gateway log
+rather than treating either file as tamper-evident, and restart after a config
+edit before trusting either.
 
 ### Upgrading Hermes orphans plugins
 
@@ -458,10 +469,12 @@ minor update:
    reliable signal. An old-library skew therefore does not latch init. A
    library *newer* than a stale plugin copy still can, if a symbol or
    signature the deferred init uses has moved. Run `verify.py` before
-   restarting, but note its scanner-imports check probes `build_scanners`, not
-   the module-level floor: it FAILs a library too old for `build_scanners`,
-   and PASSes one that has `build_scanners` but still lacks
-   `format_result_notice`. Init otherwise latches on a config or pipeline
+   restarting. Its scanner-imports check still probes `build_scanners` only, so
+   that row FAILs a library too old for `build_scanners` and PASSes one that has
+   `build_scanners` but still lacks `format_result_notice`. Since PET-189 the
+   config validation, feature activation, and arming state rows import this
+   plugin file, so that module-level skew FAILs there with the import error
+   instead of passing unseen. Init otherwise latches on a config or pipeline
    construction error, and the session then runs on the syntactic fallback:
    dangerous tool calls are blocked under the default `degraded` fail-mode,
    read-only tools are still allowed, until the process is restarted. The

--- a/docs/deployment/hermes-desktop.md
+++ b/docs/deployment/hermes-desktop.md
@@ -418,12 +418,15 @@ Expected output: rows for scanner imports, plugin files, config validation,
 environment variables, license, feature activation, arming state, injection
 detection, and config split-brain. The header shows which config file was
 resolved, the winning tier, and which plugin copy the script imported. The
-config, feature activation, and arming state rows are all read from that config
-file, built by the plugin's own config builder, and each detail line names the
-file. A WARN on feature activation lists the session features that config turns
-off. A WARN on arming state means `petasos.enabled` is false (Unequipped in the
-console) and nothing is enforced, or that no boolean was there to read and the
-fail-secure default armed it. The script reads the config file and executes the
+config validation and feature activation rows are read from that config file
+and built by the plugin's own config builder; the arming state row reads the same
+file through the console's own arming reader. Each detail line names the file. A
+WARN on feature activation lists the session features that config turns off. A
+WARN on arming state means either that `petasos.enabled` is false (Unequipped in
+the console) and nothing is enforced, or that no boolean was there to read (no
+config file, an unreadable section, or a non-boolean value) and the fail-secure
+default armed it. An absent `petasos.enabled` is not a warning: it PASSes with a
+note saying the default armed it. The script reads the config file and executes the
 plugin file it sits beside; it reports what those two files say, so compare its
 resolved path with the `loading config from ...` INFO line in the gateway log
 rather than treating either file as tamper-evident, and restart after a config
@@ -472,9 +475,11 @@ minor update:
    restarting. Its scanner-imports check still probes `build_scanners` only, so
    that row FAILs a library too old for `build_scanners` and PASSes one that has
    `build_scanners` but still lacks `format_result_notice`. Since PET-189 the
-   config validation, feature activation, and arming state rows import this
-   plugin file, so that module-level skew FAILs there with the import error
-   instead of passing unseen. Init otherwise latches on a config or pipeline
+   config validation and feature activation rows import this plugin file, so that
+   module-level skew FAILs there with the import error instead of passing unseen.
+   The arming state row stays independent of that import, so the armed bit is
+   still readable when the plugin copy is skewed. Init otherwise latches on a
+   config or pipeline
    construction error, and the session then runs on the syntactic fallback:
    dangerous tool calls are blocked under the default `degraded` fail-mode,
    read-only tools are still allowed, until the process is restarted. The

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -16,9 +16,9 @@ Needs:  a ``petasos`` release exporting ``petasos.scanners.build_scanners`` AND 
         ``build_scanners`` shipped first, so a library too old for this file also
         misses ``format_result_notice``: it does not import at all and nothing is
         enforced. An old-library skew therefore does not latch init; a library newer
-        than a stale copy of this file still can. ``verify.py`` probes
-        ``build_scanners``, not the module-level floor. Init otherwise latches on a
-        config or pipeline error, and the session runs on the syntactic fallback.
+        than a stale copy of this file still can. ``verify.py`` probes ``build_scanners``
+        and (PET-189) imports this module, so the floor surfaces on its config and feature
+        rows. Init latches on a config or pipeline error; the session runs on the fallback.
 
 Capture window (PET-136): to record per-finding tuning data, open a short
 capture window by setting ``PETASOS_AUDIT_FINDING=1`` (or flipping the
@@ -437,9 +437,9 @@ def _load_config(res: HermesConfigResolution | None = None) -> dict[str, Any]:
     section = read_petasos_section(res)
     if not section:
         logger.warning(
-            "No 'petasos:' section in config.yaml — Petasos running with "
-            "defaults (all features disabled). Add a petasos: section to "
-            "enable enforcement."
+            "No 'petasos:' section in config.yaml. Petasos running with library "
+            "defaults (all five session features enabled, fail_mode=degraded). "
+            "Add a petasos: section to tune enforcement."
         )
     return section
 

--- a/docs/deployment/reference_plugin/verify.py
+++ b/docs/deployment/reference_plugin/verify.py
@@ -5,21 +5,26 @@ Run with Hermes's Python:
     %LOCALAPPDATA%\\hermes\\hermes-agent\\venv\\Scripts\\python.exe verify.py
 
 Checks: scanner imports, config validation, credentials, license activation,
-session features, a synthetic injection scan, plugin file presence, and
-config split-brain detection between root and profile homes.
+session-feature state read from the deployed config, arming state, a synthetic
+injection scan, plugin file presence, and config split-brain detection between
+root and profile homes.
 """
 
 from __future__ import annotations
 
 import asyncio
-import base64
+import importlib.util
 import os
 import sys
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
+
+    from petasos import PetasosConfig
+    from petasos.console._paths import HermesConfigResolution
 
 PASS = "PASS"
 FAIL = "FAIL"
@@ -28,6 +33,112 @@ WARN = "WARN"
 CheckResult = tuple[str, str]
 
 results: list[tuple[str, str, str]] = []
+
+# PET-189: the plugin copy this script sits beside. The config and feature rows
+# report what THIS directory's __init__.py would boot from, because verify.py and
+# __init__.py are deployed together as one directory copy.
+# resolve() guarded like _paths_are_same_file below: an unresolvable cwd or a
+# symlink loop must not stop this script importing, or the scanner-imports row
+# never gets to report the skew it exists to catch.
+try:
+    _PLUGIN_INIT_PATH = Path(__file__).resolve().with_name("__init__.py")
+except (OSError, RuntimeError):
+    _PLUGIN_INIT_PATH = Path(__file__).with_name("__init__.py")
+
+# Mirrors Pipeline._FEATURE_GATES, order included; pinned by
+# test_session_feature_table_matches_pipeline.
+_SESSION_FEATURES: tuple[tuple[str, str], ...] = (
+    ("frequency", "frequency_enabled"),
+    ("escalation", "escalation_enabled"),
+    ("tool_guard", "tool_guard_enabled"),
+    ("audit", "audit_enabled"),
+    ("alerting", "alert_enabled"),
+)
+
+
+def _where(res: HermesConfigResolution) -> str:
+    """The one label operators compare against the gateway's 'loading config from' line."""
+    return f"{res.path} [tier={res.tier}]"
+
+
+class PluginSkewError(RuntimeError):
+    """The sibling __init__.py cannot supply the plugin's config builder."""
+
+
+@dataclass(frozen=True)
+class ResolvedConfig:
+    res: HermesConfigResolution
+    origin: str  # "section" | "missing-file" | "missing-section" | "malformed" | "rejected"
+    config: PetasosConfig
+    error: str | None  # builder exception text when origin == "rejected"
+
+    @property
+    def where(self) -> str:
+        return _where(self.res)
+
+
+_resolved: ResolvedConfig | None = None
+
+
+def _plugin_builder() -> Callable[[dict[str, Any]], PetasosConfig]:
+    """Load the sibling plugin and return its config builder (PET-126 Decision 10).
+
+    No local re-implementation: the builder that runs here must be the one the
+    deployed plugin's boot and live-reload paths share, whatever version was copied.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_verify", _PLUGIN_INIT_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise PluginSkewError(f"Cannot load sibling plugin at {_PLUGIN_INIT_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except ImportError as exc:
+        raise PluginSkewError(
+            f"Sibling plugin {_PLUGIN_INIT_PATH} does not import against the installed"
+            f" petasos ({type(exc).__name__}: {exc}); the host would not load it either."
+            " Sync plugin files and library together."
+        ) from exc
+    except Exception as exc:
+        raise PluginSkewError(
+            f"Sibling plugin {_PLUGIN_INIT_PATH} failed at import"
+            f" ({type(exc).__name__}: {exc}); the copy may be truncated or mismatched."
+            " Re-sync the plugin directory."
+        ) from exc
+    builder = getattr(mod, "_build_config_from_section", None)
+    if builder is None:
+        raise PluginSkewError(
+            f"Sibling plugin {_PLUGIN_INIT_PATH} defines no _build_config_from_section;"
+            " sync plugin files and library together."
+        )
+    return cast("Callable[[dict[str, Any]], PetasosConfig]", builder)
+
+
+def resolve_deployed_config() -> ResolvedConfig:
+    """The config the plugin would boot from in this environment. Memoised per process."""
+    global _resolved
+    if _resolved is not None:
+        return _resolved
+    from petasos import PetasosConfig
+    from petasos.console._paths import read_petasos_section_checked, resolve_hermes_config_path
+
+    res = resolve_hermes_config_path()
+    builder = _plugin_builder()  # PluginSkewError propagates; nothing is memoised
+    section: dict[str, Any]
+    if not res.path.is_file():
+        section, origin = {}, "missing-file"
+    else:
+        section, ok = read_petasos_section_checked(res)
+        origin = "section" if (ok and section) else ("missing-section" if ok else "malformed")
+    error: str | None = None
+    try:
+        config = builder(section)
+    except (TypeError, ValueError) as exc:
+        # Mirrors _deferred_init's swallow: the plugin would boot on defaults.
+        config, origin, error = PetasosConfig(), "rejected", str(exc)
+    _resolved = ResolvedConfig(res=res, origin=origin, config=config, error=error)
+    return _resolved
 
 
 def check(name: str, fn: Callable[[], CheckResult]) -> None:
@@ -87,29 +198,28 @@ def check_scanner_imports() -> CheckResult:
 
 
 def check_config() -> CheckResult:
-    from petasos import PetasosConfig
-    from petasos.console._paths import read_petasos_section, resolve_hermes_config_path
-
-    res = resolve_hermes_config_path()
-    if not res.path.is_file():
-        return FAIL, f"Config not found at {res.path}"
-
-    section = read_petasos_section(res)
-    if not section:
-        return FAIL, "No 'petasos:' section in config.yaml"
-
-    clean = {k: v for k, v in section.items() if k not in ("host_id", "enabled")}
-    hash_key = os.environ.get("PETASOS_HASH_KEY")
-    if hash_key:
-        clean["hash_key"] = hash_key
-    session_secret_b64 = os.environ.get("PETASOS_SESSION_SECRET")
-    if session_secret_b64:
-        import contextlib
-
-        with contextlib.suppress(Exception):
-            clean["session_secret"] = base64.b64decode(session_secret_b64)
-    config = PetasosConfig.from_dict(clean)
-    return PASS, f"fail_mode={config.fail_mode}, anonymize={config.anonymize}"
+    try:
+        rc = resolve_deployed_config()
+    except PluginSkewError as exc:
+        return FAIL, str(exc)
+    if rc.origin == "missing-file":
+        return FAIL, f"Config not found at {rc.res.path}"
+    if rc.origin == "missing-section":
+        return FAIL, f"No usable 'petasos:' section (absent or empty) in {rc.where}"
+    if rc.origin == "malformed":
+        return FAIL, (
+            f"petasos: section at {rc.where} is unreadable (malformed YAML or not a"
+            " mapping); the plugin would boot on library defaults"
+        )
+    if rc.origin == "rejected":
+        return FAIL, (
+            f"petasos: section at {rc.where} rejected by the plugin config builder:"
+            f" {rc.error}; the plugin would boot on library defaults"
+        )
+    return PASS, (
+        f"fail_mode={rc.config.fail_mode}, anonymize={rc.config.anonymize}"
+        f" from {rc.where}, built by {_PLUGIN_INIT_PATH}"
+    )
 
 
 def check_env_vars() -> CheckResult:
@@ -147,30 +257,78 @@ def check_license() -> CheckResult:
 
 
 def check_features() -> CheckResult:
-    from petasos import PetasosConfig, Pipeline
-    from petasos.scanners import MinimalScanner
+    try:
+        rc = resolve_deployed_config()
+    except PluginSkewError as exc:
+        return FAIL, str(exc)
+    total = len(_SESSION_FEATURES)
+    off = [name for name, attr in _SESSION_FEATURES if not getattr(rc.config, attr)]
+    on = total - len(off)
+    off_note = f"; off: {', '.join(off)}" if off else ""
+    if rc.origin == "rejected":
+        return FAIL, (
+            f"Feature state not trustworthy: petasos: section at {rc.where} rejected"
+            f" ({rc.error}); the plugin would boot on library defaults"
+            f" ({on}/{total} on{off_note})"
+        )
+    if rc.origin != "section":
+        reason = {
+            "missing-file": "config file missing",
+            "missing-section": "no usable petasos: section",
+            "malformed": "petasos: section unreadable",
+        }[rc.origin]
+        return WARN, (
+            f"Reporting library defaults, not a validated section ({reason} at"
+            f" {rc.where}): {on}/{total} session features on{off_note}"
+        )
+    if off:
+        return WARN, (
+            f"Session features OFF in deployed config: {', '.join(off)}"
+            f" ({on}/{total} on) from {rc.where}"
+        )
+    return PASS, f"All {total} session features on in deployed config from {rc.where}"
 
-    config = PetasosConfig(
-        fail_mode="closed",
-        frequency_enabled=True,
-        escalation_enabled=True,
-        tool_guard_enabled=True,
-        audit_enabled=True,
-        alert_enabled=True,
-    )
-    pipeline = Pipeline(config=config, scanners=[MinimalScanner()], host_id="verify-test")
 
-    key = os.environ.get("PETASOS_LICENSE_KEY", "")
-    if key:
-        pipeline.activate(key)
+def check_armed() -> CheckResult:
+    """Report petasos.enabled via the reader the console and gateway share.
 
-    missing = []
-    for feat in ("frequency", "escalation", "tool_guard", "audit", "alerting"):
-        if not pipeline.is_feature_enabled(feat):
-            missing.append(feat)
-    if missing:
-        return WARN, f"Features not active: {', '.join(missing)}"
-    return PASS, "All 5 session features available"
+    Deliberately independent of the sibling plugin import: the armed bit must stay
+    readable on a deployment whose plugin copy is skewed (Decision 4). read_armed is
+    fail-secure True on a file it cannot read, so the three shapes where it never
+    saw a boolean WARN rather than PASS, and each names what was not read.
+    """
+    from petasos.console._armed import read_armed
+    from petasos.console._paths import read_petasos_section_checked, resolve_hermes_config_path
+
+    res = resolve_hermes_config_path()
+    where = _where(res)
+
+    if not res.path.is_file():
+        return WARN, (
+            f"Reporting the fail-secure default (armed): no config file at {res.path},"
+            " so petasos.enabled was never read"
+        )
+    section, ok = read_petasos_section_checked(res)
+    if not ok:
+        return WARN, (
+            f"Reporting the fail-secure default (armed): the petasos: section at {where}"
+            " is unreadable (malformed YAML or not a mapping), so petasos.enabled was"
+            " never read"
+        )
+    if not read_armed(res):
+        return WARN, (
+            f"DISARMED (Unequipped in the console): petasos.enabled is false at {where};"
+            " nothing is enforced until re-armed (console banner or config edit)"
+        )
+    if "enabled" not in section:
+        return PASS, f"Armed by fail-secure default (no boolean petasos.enabled at {where})"
+    raw = section["enabled"]
+    if not isinstance(raw, bool):
+        return WARN, (
+            f"Reporting the fail-secure default (armed): petasos.enabled at {where} is"
+            f" {raw!r}, not a boolean; the console writes true or false"
+        )
+    return PASS, f"petasos.enabled is true (armed) at {where}"
 
 
 def check_injection_scan() -> CheckResult:
@@ -319,7 +477,8 @@ def main() -> int:
     print("=" * 60)
     print("Petasos Deployment Verification")
     print("=" * 60)
-    print(f"  Config: {res.path} [tier={res.tier}]")
+    print(f"  Config: {_where(res)}")
+    print(f"  Plugin: {_PLUGIN_INIT_PATH}")
     if res.warning:
         print(f"  WARNING: {res.warning}")
     print()
@@ -330,22 +489,31 @@ def main() -> int:
     check("Environment variables", check_env_vars)
     check("License validation", check_license)
     check("Feature activation", check_features)
+    check("Arming state", check_armed)
     check("Injection detection", check_injection_scan)
     check("Config split-brain", check_config_split_brain)
 
     print()
     fail_count = 0
+    warn_count = 0
     for name, status, detail in results:
         marker = {"PASS": "+", "FAIL": "!", "WARN": "~"}[status]
         print(f"  [{marker}] {status:4s}  {name}")
         print(f"         {detail}")
         if status == FAIL:
             fail_count += 1
+        elif status == WARN:
+            warn_count += 1
     print()
 
     if fail_count:
         print(f"RESULT: {fail_count} check(s) FAILED")
         return 1
+    if warn_count:
+        # Exit status still counts only FAIL; the tally stops a run with WARNs
+        # from ending in an unqualified "All checks passed".
+        print(f"RESULT: All checks passed ({warn_count} warning(s), review above)")
+        return 0
     print("RESULT: All checks passed")
     return 0
 

--- a/tests/test_scanner_bootstrap_structure.py
+++ b/tests/test_scanner_bootstrap_structure.py
@@ -69,8 +69,8 @@ _DEFINITION_MODULES = frozenset(
 #       fallback; spec Decision 4 keeps it.
 #   reference_plugin/__init__.py :: _get_fallback_scanner - the cold-window
 #       fast-path fallback; spec Decision 7 keeps it bare.
-#   reference_plugin/verify.py :: check_features / check_injection_scan - a
-#       verification script, not a bootstrap.
+#   reference_plugin/verify.py :: check_injection_scan - a verification script,
+#       not a bootstrap.
 # The function is QUALIFIED (ClassName.method): a bare "__init__" key would exempt
 # every __init__ in pipeline.py, present and future. A module-scope construction
 # is never allowlisted.
@@ -78,7 +78,6 @@ _ALLOWLIST = frozenset(
     {
         ("petasos/pipeline.py", "Pipeline.__init__"),
         ("docs/deployment/reference_plugin/__init__.py", "_get_fallback_scanner"),
-        ("docs/deployment/reference_plugin/verify.py", "check_features"),
         ("docs/deployment/reference_plugin/verify.py", "check_injection_scan"),
     }
 )
@@ -298,7 +297,6 @@ def test_allowlist_is_exactly_the_documented_rows() -> None:
         {
             ("petasos/pipeline.py", "Pipeline.__init__"),
             ("docs/deployment/reference_plugin/__init__.py", "_get_fallback_scanner"),
-            ("docs/deployment/reference_plugin/verify.py", "check_features"),
             ("docs/deployment/reference_plugin/verify.py", "check_injection_scan"),
         }
     )

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,12 +3,18 @@
 PET-86 / D7: verify.py gains orphan and split-brain detection and is
 brought under test for the first time.  Loaded via importlib since it
 lives outside the package tree.
+
+PET-189: the config, feature, and arming rows are read from the deployed
+config, built by the plugin's own builder; a structural pin keeps them there.
 """
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import os
+import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,10 +31,19 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _load_verify_module() -> Any:
+    """A fresh verify module per call, so the PET-189 resolver memo starts empty.
+
+    Registered in sys.modules before exec: @dataclass resolves string annotations
+    (the module has `from __future__ import annotations`) through
+    sys.modules[cls.__module__], which is None for an unregistered spec-loaded
+    module. In deployment the script runs as __main__, which is always registered.
+    Each call rebinds the same key to a new module object, so nothing is shared.
+    """
     verify_path = _PROJECT_ROOT / "docs" / "deployment" / "reference_plugin" / "verify.py"
     spec = importlib.util.spec_from_file_location("verify", verify_path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod
 
@@ -375,3 +390,546 @@ def test_verify_clean_passes(
 
     status_sb, _ = verify.check_config_split_brain()
     assert status_sb == verify.PASS
+
+
+# ---------------------------------------------------------------------------
+# PET-189: the config, feature, and arming rows report the deployed config
+# ---------------------------------------------------------------------------
+
+
+def _reset_armed() -> None:
+    """read_armed keeps a process-global mtime/size/TTL cache that a freshly
+    loaded verify module does not reset."""
+    import petasos.console._armed as armed_mod
+
+    armed_mod._reset_armed_cache()
+
+
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every env var the plugin's config builder overlays, so a case's
+    section is the only thing shaping the resulting config."""
+    for var in (
+        "PETASOS_HASH_KEY",
+        "PETASOS_SESSION_SECRET",
+        "PETASOS_AUDIT_FINDING",
+        "PETASOS_LICENSE_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _plugin_stub(tmp_path: Path, name: str, source: str) -> Path:
+    """A stand-in sibling __init__.py, for the plugin-skew cases."""
+    stub = tmp_path / name
+    stub.write_text(source, encoding="utf-8")
+    return stub
+
+
+# --- Behavioural -----------------------------------------------------------
+
+
+def test_check_features_names_disabled_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for PET-189: the row named every feature 'available' over a
+    config that turned two of them off."""
+    _clean_env(monkeypatch)
+    root = _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"tool_guard_enabled": False, "alert_enabled": False},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_features()
+    assert status == verify.WARN
+    assert "tool_guard" in detail
+    assert "alerting" in detail
+    assert "frequency" not in detail
+    assert str(root / "profiles" / "gibson" / "config.yaml") in detail
+
+
+def test_check_features_all_on_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """All five on in the deployed section → PASS naming path and tier."""
+    _clean_env(monkeypatch)
+    root = _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "closed"},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_features()
+    assert status == verify.PASS
+    assert str(root / "profiles" / "gibson" / "config.yaml") in detail
+    assert "tier=profile" in detail
+
+
+def test_check_features_missing_section_reports_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No petasos: key at all → the row says it is reporting library defaults."""
+    _clean_env(monkeypatch)
+    root = _setup_root(tmp_path, monkeypatch, system="Windows")
+    _write_config(root / "config.yaml", {"fail_mode": "closed"})
+    profile_dir = root / "profiles" / "gibson"
+    _write_config(profile_dir / "config.yaml", None)
+    (root / "active_profile").write_text("gibson")
+
+    verify = _load_verify_module()
+    status, detail = verify.check_features()
+    assert status == verify.WARN
+    assert "library defaults" in detail
+    assert "no usable petasos:" in detail
+
+    status_cfg, detail_cfg = verify.check_config()
+    assert status_cfg == verify.FAIL
+    assert "No usable 'petasos:' section" in detail_cfg
+
+
+def test_check_features_malformed_section_reports_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """petasos: is a list, not a mapping → defaults, said out loud."""
+    _clean_env(monkeypatch)
+    root = _setup_root(tmp_path, monkeypatch, system="Windows")
+    _write_config(root / "config.yaml", {"fail_mode": "closed"})
+    profile_dir = root / "profiles" / "gibson"
+    _write_config_raw(
+        profile_dir / "config.yaml",
+        "model:\n  provider: test\npetasos: [1, 2]\n",
+    )
+    (root / "active_profile").write_text("gibson")
+
+    verify = _load_verify_module()
+    status, detail = verify.check_features()
+    assert status == verify.WARN
+    assert "unreadable" in detail
+
+    status_cfg, detail_cfg = verify.check_config()
+    assert status_cfg == verify.FAIL
+    assert "unreadable" in detail_cfg
+
+
+def test_check_features_rejected_section_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A section the plugin's builder rejects is not a feature state worth reading."""
+    _clean_env(monkeypatch)
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "bogus"},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_features()
+    assert status == verify.FAIL
+    assert "rejected" in detail
+    assert "bogus" in detail
+
+    status_cfg, detail_cfg = verify.check_config()
+    assert status_cfg == verify.FAIL
+    assert "rejected" in detail_cfg
+    assert "bogus" in detail_cfg
+
+
+def test_check_features_ignores_license_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All features are free; the license key must not move the row.
+
+    Two independent module loads, not two calls on one module: the resolver
+    memoises, so a second call would return the first answer and pass vacuously.
+    """
+    _clean_env(monkeypatch)
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"tool_guard_enabled": False, "alert_enabled": False},
+    )
+
+    monkeypatch.delenv("PETASOS_LICENSE_KEY", raising=False)
+    without_key = _load_verify_module().check_features()
+
+    monkeypatch.setenv("PETASOS_LICENSE_KEY", "not-a-real-jwt")
+    with_key = _load_verify_module().check_features()
+
+    assert without_key == with_key
+
+
+def test_check_features_sibling_skew_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sibling plugin without the builder FAILs both rows, no local fallback."""
+    _clean_env(monkeypatch)
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "closed"},
+    )
+
+    verify = _load_verify_module()
+    monkeypatch.setattr(
+        verify, "_PLUGIN_INIT_PATH", _plugin_stub(tmp_path, "skewed_plugin.py", "# plugin\n")
+    )
+
+    for status, detail in (verify.check_config(), verify.check_features()):
+        assert status == verify.FAIL
+        assert "_build_config_from_section" in detail
+
+
+def test_check_features_sibling_import_error_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin too new for the installed library FAILs with the import error."""
+    _clean_env(monkeypatch)
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "closed"},
+    )
+
+    verify = _load_verify_module()
+    monkeypatch.setattr(
+        verify,
+        "_PLUGIN_INIT_PATH",
+        _plugin_stub(
+            tmp_path,
+            "too_new_plugin.py",
+            "from petasos.session.formatting import definitely_missing_symbol\n",
+        ),
+    )
+
+    status, detail = verify.check_features()
+    assert status == verify.FAIL
+    assert "does not import" in detail
+
+
+def test_check_features_sibling_corrupt_copy_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A truncated hand-synced copy names the path and the exception class."""
+    _clean_env(monkeypatch)
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "closed"},
+    )
+
+    verify = _load_verify_module()
+    stub = _plugin_stub(tmp_path, "corrupt_plugin.py", "def f(:\n")
+    monkeypatch.setattr(verify, "_PLUGIN_INIT_PATH", stub)
+
+    status, detail = verify.check_features()
+    assert status == verify.FAIL
+    assert "SyntaxError" in detail
+    assert str(stub) in detail
+
+
+def test_check_armed_disarmed_warns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """petasos.enabled: false → the run says the deployment enforces nothing."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"enabled": False},
+        profile_section={"enabled": False},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.WARN
+    assert "DISARMED" in detail
+    assert "Unequipped" in detail
+
+
+def test_check_armed_explicit_true_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit enabled: true reads differently from the fail-secure default."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"enabled": True},
+        profile_section={"enabled": True},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.PASS
+    assert "enabled is true" in detail
+
+
+def test_check_armed_default_passes_with_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No enabled key → armed, and the row says it is the default that armed it."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "closed"},
+        profile_section={"fail_mode": "closed"},
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.PASS
+    assert "fail-secure default" in detail
+
+
+def test_check_armed_missing_file_warns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """read_armed is fail-secure True on a file it cannot stat, so a PASS here
+    would report a bit nothing ever read."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    _setup_root(tmp_path, monkeypatch, system="Windows")
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.WARN
+    assert "fail-secure default" in detail
+    assert "no config file" in detail
+
+
+def test_check_armed_malformed_section_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable petasos: section arms fail-secure; say so rather than PASS."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_root(tmp_path, monkeypatch, system="Windows")
+    _write_config_raw(root / "config.yaml", "model:\n  provider: test\npetasos: [1, 2]\n")
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.WARN
+    assert "unreadable" in detail
+
+
+def test_check_armed_non_bool_enabled_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """enabled: "yes" is not the boolean the console writes; name the raw value."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_root(tmp_path, monkeypatch, system="Windows")
+    _write_config_raw(
+        root / "config.yaml",
+        'model:\n  provider: test\npetasos:\n  enabled: "yes"\n',
+    )
+
+    verify = _load_verify_module()
+    status, detail = verify.check_armed()
+    assert status == verify.WARN
+    assert "not a boolean" in detail
+    assert "'yes'" in detail
+
+
+def test_verify_main_prints_new_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The report carries a Plugin header, an Arming state row, and a WARN tally."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"enabled": False},
+        profile_section={"enabled": False},
+    )
+    profile_config = str(root / "profiles" / "gibson" / "config.yaml")
+
+    verify = _load_verify_module()
+    rc = verify.main()
+    out = capsys.readouterr().out
+
+    assert "  Plugin: " in out
+    assert "Feature activation" in out
+    assert "Arming state" in out
+    assert profile_config in out
+    # Env vars are unset here, so the run FAILs and says so.
+    assert rc == 1
+    assert "FAILED" in out.strip().splitlines()[-1]
+
+    # Same deployment with the required env present: no FAIL, but the RESULT line
+    # must not read as an unqualified all-clear while the deployment is disarmed.
+    _reset_armed()
+    monkeypatch.setenv("PETASOS_SESSION_SECRET", "c2VjcmV0")
+    monkeypatch.setenv("PETASOS_HASH_KEY", "hash-key")
+    verify2 = _load_verify_module()
+    rc2 = verify2.main()
+    out2 = capsys.readouterr().out
+    assert rc2 == 0
+    last = out2.strip().splitlines()[-1]
+    match = re.fullmatch(r"RESULT: All checks passed \((\d+) warning\(s\), review above\)", last)
+    assert match is not None, last
+    assert int(match.group(1)) >= 1
+
+
+# --- Parity ----------------------------------------------------------------
+
+
+def test_resolved_config_matches_plugin_builder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One derivation: verify.py's config IS the plugin builder's output.
+
+    The section is one the pre-PET-189 check_config could not build at all (its
+    from_dict raises without a hash key), so this discriminates the builder from
+    both the old path and bare defaults.
+    """
+    _clean_env(monkeypatch)
+    section = {
+        "fail_mode": "closed",
+        "anonymize": True,
+        "redaction_mode": "hash",
+        "alert_enabled": False,
+    }
+    _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section=dict(section),
+        profile_section=dict(section),
+    )
+    monkeypatch.delenv("PETASOS_HASH_KEY", raising=False)
+    monkeypatch.setenv("PETASOS_AUDIT_FINDING", "1")
+
+    plugin_spec = importlib.util.spec_from_file_location(
+        "petasos_reference_plugin_pet189",
+        _PROJECT_ROOT / "docs" / "deployment" / "reference_plugin" / "__init__.py",
+    )
+    assert plugin_spec is not None and plugin_spec.loader is not None
+    plugin = importlib.util.module_from_spec(plugin_spec)
+    plugin_spec.loader.exec_module(plugin)
+
+    verify = _load_verify_module()
+    resolved = verify.resolve_deployed_config()
+
+    assert resolved.origin == "section"
+    assert resolved.config == plugin._build_config_from_section(dict(section))
+    # The two overlays the old check_config had drifted on.
+    assert resolved.config.anonymize is False
+    assert resolved.config.audit_emit_findings is True
+
+
+def test_session_feature_table_matches_pipeline() -> None:
+    """verify.py's display names must be the pipeline's gate names, order included."""
+    from petasos import Pipeline
+
+    verify = _load_verify_module()
+    assert tuple(Pipeline._FEATURE_GATES.items()) == verify._SESSION_FEATURES
+
+
+# --- Structural (D7) -------------------------------------------------------
+
+_CONFIG_ROWS = ("check_config", "check_features", "resolve_deployed_config")
+
+
+def _is_petasos_config_call(node: ast.AST) -> bool:
+    """True for ``PetasosConfig(...)`` and ``PetasosConfig.from_dict(...)``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "PetasosConfig"
+    if isinstance(func, ast.Attribute) and func.attr == "from_dict":
+        return isinstance(func.value, ast.Name) and func.value.id == "PetasosConfig"
+    return False
+
+
+def check_no_literal_config(source: str) -> list[str]:
+    """Violations of D7 in *source*; empty list means clean.
+
+    Pure over source text, so it can be exercised on a synthetic that does
+    violate, and never passes over an empty node set: a missing or duplicated
+    function is itself a violation.
+    """
+    tree = ast.parse(source)
+    violations: list[str] = []
+    for name in _CONFIG_ROWS:
+        defs = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == name]
+        if len(defs) != 1:
+            violations.append(
+                f"{name}: expected exactly one function definition, found {len(defs)}"
+            )
+            continue
+        calls: list[ast.Call] = [
+            n for n in ast.walk(defs[0]) if isinstance(n, ast.Call) and _is_petasos_config_call(n)
+        ]
+        if name == "resolve_deployed_config":
+            # One bare PetasosConfig() is allowed here: the rejected-section
+            # fallback mirroring the plugin's own swallow.
+            if len(calls) > 1:
+                violations.append(f"{name}: {len(calls)} PetasosConfig constructions, expected 1")
+            for call in calls:
+                if call.args or call.keywords:
+                    violations.append(
+                        f"{name}: PetasosConfig at line {call.lineno} takes arguments;"
+                        " only a defaults-only fallback is allowed"
+                    )
+        elif calls:
+            violations.append(
+                f"{name}: constructs PetasosConfig at line {calls[0].lineno};"
+                " this row must report the deployed config, not a literal"
+            )
+    return violations
+
+
+def test_config_rows_construct_no_literal_config() -> None:
+    """Regression for PET-189: the row reported a config it had built itself."""
+    verify_source = (
+        _PROJECT_ROOT / "docs" / "deployment" / "reference_plugin" / "verify.py"
+    ).read_text(encoding="utf-8")
+    assert check_no_literal_config(verify_source) == []
+
+
+def test_config_rows_checker_rejects_synthetic_literal() -> None:
+    """The checker has teeth, and cannot pass vacuously."""
+    violating = """
+def check_config():
+    return resolve_deployed_config()
+
+
+def check_features():
+    config = PetasosConfig(fail_mode="closed", tool_guard_enabled=True)
+    return config
+
+
+def resolve_deployed_config():
+    return PetasosConfig()
+"""
+    violations = check_no_literal_config(violating)
+    assert any("check_features" in v and "constructs PetasosConfig" in v for v in violations)
+
+    absent = """
+def check_config():
+    return resolve_deployed_config()
+
+
+def resolve_deployed_config():
+    return PetasosConfig()
+"""
+    violations_absent = check_no_literal_config(absent)
+    assert any("check_features" in v and "expected exactly one" in v for v in violations_absent)


### PR DESCRIPTION
## Summary

- `verify.py`'s `Feature activation` row built its own `PetasosConfig` with all five session flags forced true, so it printed `PASS: All 5 session features available` over any deployment, including one with `tool_guard_enabled: false`. It now reads the config the plugin would boot from and names the features that config turns off.
- A new `Arming state` row reports `petasos.enabled` through `read_armed`, the reader the console and gateway share.
- `Config validation` moves onto the same derivation and drops its drifted partial copy of the plugin's env overlay. The RESULT line now carries a warning count.

## One derivation, owned by the plugin

`resolve_deployed_config()` loads the sibling `__init__.py` by path and calls its `_build_config_from_section` over the section `resolve_hermes_config_path()` governs. That is the builder the plugin's boot and live-reload paths already share (PET-126 Decision 10), and `verify.py` ships in the same directory copy, so the two cannot drift. There is no local re-implementation and no fallback: a sibling that will not import, or that lacks the symbol, FAILs both rows with the path and the exception class.

Five origins are distinguished and named in the detail line, because the operator's fix differs for each:

| origin | row behaviour |
|---|---|
| `section` | PASS, or WARN naming the flags that are off |
| `missing-file` / `missing-section` / `malformed` | WARN saying it is reporting library defaults, and why |
| `rejected` (builder raised) | FAIL; the deployment must be repaired before any feature state is worth reading |

## Arming state stays independent

`check_armed` does not depend on the plugin import succeeding, so the armed bit stays readable on a deployment whose plugin copy is skewed. `read_armed` is fail-secure `True` on anything it cannot read, so the three shapes where no boolean was ever seen (missing file, unreadable section, non-bool value) WARN rather than PASS, each naming what was not read. A disarmed deployment WARNs and names the console's word for the state, Unequipped.

## Files changed

| File | Change |
|------|--------|
| `docs/deployment/reference_plugin/verify.py` | Adds `resolve_deployed_config` / `_plugin_builder` / `check_armed`; rewrites `check_config` and `check_features`; `main()` gains a `Plugin:` header line, the arming row, and a WARN tally |
| `docs/deployment/reference_plugin/__init__.py` | Two line-count-neutral string edits: the missing-section warning no longer claims defaults disable features, and the docstring no longer says the module-level floor is invisible to `verify.py` |
| `tests/test_verify.py` | 20 new cases: behavioural, parity against the plugin's builder, and an `ast` structural pin |
| `tests/test_scanner_bootstrap_structure.py` | Retires the `check_features` scanner-construction allowlist row in all three places |
| `CHANGELOG.md` | One `[Unreleased]` / `Fixed` entry |
| `docs/deployment/hermes-desktop.md` | Expected-output paragraph and the upgrade section's `verify.py` sentence |

## Notable side effect

Because the script now imports the sibling plugin module, a library too old for the plugin's module-level imports (`format_result_notice` and friends) FAILs the config and feature rows with the import error. That is the "module-level floor" blind spot CHANGELOG 0.3.0 and the runbook disclosed as invisible to `verify.py`. It was not this ticket's target, but the docs no longer claim the gap is open. `check_scanner_imports` itself is unchanged and its `build_scanners`-only probe is still described accurately.

## Test plan

- [x] `C:\python310\python.exe -m pytest -q --deselect tests/test_console_validation.py::test_default_ignorable_rejected` - 2768 passed, 48 skipped, 1 deselected, 1 xfailed (full output: `docs/specs/TODO/PET-189.test-output.txt`)
- [x] `ruff check` over `git ls-files '*.py'` - clean
- [x] `ruff format --check` over `git ls-files '*.py'` - clean
- [x] `mypy --strict .` - clean for this change; the 4 remaining errors are in `tests/test_console_sse_route.py` and reproduce unchanged on `master` in the same local 3.10 environment
- [x] Regression coverage: cases 1, 5, 7, 13 and 15 each fail against the pre-change `verify.py`

Note for reviewers: `tests/test_verify.py::_load_verify_module` now registers the module in `sys.modules` before `exec_module`. `@dataclass` resolves string annotations through `sys.modules[cls.__module__]`, which is `None` for an unregistered spec-loaded module; in deployment the script runs as `__main__`, which is always registered.

Spec: `docs/specs/TODO/PET-189.spec.md` (gitignored). Provenance: PET-184 finding PETRT-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCx5eBbyNbXtUguiqqVGWF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now reports deployed configuration, session-feature activation, arming state, and warnings.
  * Detects plugin import failures, configuration errors, version mismatches, and malformed settings.
  * Reports default session-feature behavior when configuration is missing or incomplete.
  * Arming-state checks remain independent and warn for missing, malformed, or non-boolean settings.
  * Clarifies that verification reflects deployment configuration and should be compared with gateway logs.

* **Documentation**
  * Updated deployment and plugin guidance with expanded verification output and troubleshooting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->