### PR TITLE
fix(pet-189): read the root .env for a profile run that has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **verify.py reads the root `.env` for a profile run that has none (PET-189 follow-up).**
+  The root-home fallback recomputed the profile path, so it never fired. A
+  `PETASOS_HASH_KEY` or `PETASOS_SESSION_SECRET` kept only in the root `.env` was invisible
+  to a profile-tier run: the environment-variables row failed on a key the deployment had,
+  and the feature row could under-report anonymization as off. A profile `.env` still wins
+  when both exist.
 - **The verify.py feature row now reports the deployed config (PET-189, PET-184 finding
   PETRT-001).** The `Feature activation` row built its own `PetasosConfig` with every
   session flag forced on and reported `PASS: All 5 session features available` over any

--- a/docs/deployment/reference_plugin/verify.py
+++ b/docs/deployment/reference_plugin/verify.py
@@ -463,8 +463,11 @@ def main() -> int:
 
     # Profile-tier `.env` wins; a profile without one falls back to the root
     # `.env`, mirroring how the plugin's env overlay reaches a profile run.
+    # Only the profile tier falls back: a HERMES_HOME override is a different
+    # installation, and reading the canonical root's secrets for it would
+    # report the wrong deployment.
     env_path = res.path.parent / ".env"
-    if not env_path.exists():
+    if not env_path.exists() and res.tier == "profile":
         root_env = hermes_root() / ".env"
         if root_env.exists():
             env_path = root_env

--- a/docs/deployment/reference_plugin/verify.py
+++ b/docs/deployment/reference_plugin/verify.py
@@ -457,13 +457,15 @@ def _file_has_petasos_key(path: Path) -> bool:
 
 
 def main() -> int:
-    from petasos.console._paths import resolve_hermes_config_path
+    from petasos.console._paths import hermes_root, resolve_hermes_config_path
 
     res = resolve_hermes_config_path()
 
+    # Profile-tier `.env` wins; a profile without one falls back to the root
+    # `.env`, mirroring how the plugin's env overlay reaches a profile run.
     env_path = res.path.parent / ".env"
     if not env_path.exists():
-        root_env = res.path.parent / ".env"
+        root_env = hermes_root() / ".env"
         if root_env.exists():
             env_path = root_env
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -787,6 +787,62 @@ def test_verify_main_prints_new_rows(
     assert int(match.group(1)) >= 1
 
 
+def test_verify_main_preloads_root_env_for_profile_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A profile run with no profile `.env` falls back to the root `.env`.
+
+    The fallback used to recompute the profile path, so a PETASOS_HASH_KEY living
+    only in the root `.env` was invisible to a profile-tier run and the env-vars
+    row FAILed on a key the deployment actually had.
+    """
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_clean_install(
+        tmp_path,
+        monkeypatch,
+        profile="gibson",
+        root_section={"fail_mode": "degraded"},
+        profile_section={"fail_mode": "degraded"},
+    )
+    (root / ".env").write_text(
+        "PETASOS_SESSION_SECRET=c2VjcmV0\nPETASOS_HASH_KEY=root-hash-key\n",
+        encoding="utf-8",
+    )
+    assert not (root / "profiles" / "gibson" / ".env").exists()
+
+    verify = _load_verify_module()
+    rc = verify.main()
+    out = capsys.readouterr().out
+
+    assert os.environ.get("PETASOS_HASH_KEY") == "root-hash-key"
+    assert "Missing required" not in out, out
+    assert rc == 0, out
+
+
+def test_verify_main_prefers_profile_env_over_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When both tiers carry a `.env`, the profile's wins and the root's is not read."""
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_clean_install(tmp_path, monkeypatch, profile="gibson")
+    (root / ".env").write_text(
+        "PETASOS_SESSION_SECRET=root-secret\nPETASOS_HASH_KEY=root-hash-key\n",
+        encoding="utf-8",
+    )
+    (root / "profiles" / "gibson" / ".env").write_text(
+        "PETASOS_SESSION_SECRET=profile-secret\n", encoding="utf-8"
+    )
+
+    verify = _load_verify_module()
+    verify.main()
+    capsys.readouterr()
+
+    assert os.environ.get("PETASOS_SESSION_SECRET") == "profile-secret"
+    assert os.environ.get("PETASOS_HASH_KEY") is None
+
+
 # --- Parity ----------------------------------------------------------------
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -843,6 +843,31 @@ def test_verify_main_prefers_profile_env_over_root(
     assert os.environ.get("PETASOS_HASH_KEY") is None
 
 
+def test_verify_main_hermes_home_does_not_read_root_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A HERMES_HOME override without a `.env` never borrows the canonical root's.
+
+    The override names a different installation; its verification report must not
+    be built from another install's secrets.
+    """
+    _clean_env(monkeypatch)
+    _reset_armed()
+    root = _setup_root(tmp_path, monkeypatch, system="Windows")
+    _write_config(root / "config.yaml", {"fail_mode": "degraded"})
+    (root / ".env").write_text("PETASOS_HASH_KEY=root-hash-key\n", encoding="utf-8")
+    custom = tmp_path / "custom"
+    _write_config(custom / "config.yaml", {"fail_mode": "degraded"})
+    monkeypatch.setenv("HERMES_HOME", str(custom))
+    assert not (custom / ".env").exists()
+
+    verify = _load_verify_module()
+    verify.main()
+    capsys.readouterr()
+
+    assert os.environ.get("PETASOS_HASH_KEY") is None
+
+
 # --- Parity ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Follow-up to PET-189 (edge-cases review finding F-7). `verify.py`'s `.env` preload had a dead root-home fallback: it recomputed `res.path.parent / ".env"` twice, so the root branch never fired. A `PETASOS_HASH_KEY` or `PETASOS_SESSION_SECRET` kept only in the root `.env` was invisible to a profile-tier run. The `Environment variables` row then FAILed on a key the deployment actually had, and the builder's defang could under-report `anonymize=False`.

Fix is `hermes_root() / ".env"`. A profile `.env` still wins when both exist.

## Changes

- `docs/deployment/reference_plugin/verify.py`: the fallback resolves against `hermes_root()`.
- `tests/test_verify.py`: `test_verify_main_preloads_root_env_for_profile_run` (fails on the old code: `1 failed` under a negative-control stash) and `test_verify_main_prefers_profile_env_over_root` (profile wins, root not read).
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry.

## Gate

- `pytest tests/test_verify.py`: 35 passed (C:\python310, Python 3.10).
- `ruff check` / `ruff format --check`: clean on both files.
- `mypy --strict`: clean on both files.

Tracked in Plane as a PET-189 follow-up (workspace is private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCx5eBbyNbXtUguiqqVGWF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile-tier verification now loads environment settings from the root `.env` file when no profile-specific file exists.
  * Profile-specific `.env` values continue to take precedence when both files are present.
  * Verification using a configured `HERMES_HOME` no longer reads secrets from the root `.env` file.

* **Documentation**
  * Added an unreleased changelog entry describing the updated environment-file behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->