### PR TITLE
fix(pet-192): guard re-auth resume against scope changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Re-authentication discards responses from a superseded host scope (PET-192,
+  PET-184 finding PETRT-004).** Armed and health verification now check the scope
+  generation captured when resume starts, alongside the token generation. Changing
+  the selected or equipped host profile during either read can no longer let that
+  old response seed console state or finish resume by restarting polling/SSE.
+
 - **The failed-init fallback scans the same parameter text as the healthy guard
   (PET-190, PET-184 finding PETRT-002).** The reference plugin's cold-start and
   `init_failed` branches scanned the first 100,000 characters of the JSON-encoded,

--- a/petasos/console/static/petasos.js
+++ b/petasos/console/static/petasos.js
@@ -505,13 +505,15 @@
     // double-submit cannot let the wrong token's stale 401 tear down the correct
     // token's session (edge F-6). authRequired is cleared ONLY after the verification
     // read returns a non-401, well-shaped body (not optimistically on submit).
+    // PET-192: both continuations also drop a superseded host scope (PET-166 D17).
     _resume: function () {
       var gen = Pet.auth._gen;
+      var scopeGen = _scopeGen; // PET-192 / D17: one send-time scope for the whole resume
       _armedSeeded = false;   // re-derive from server truth, regardless of any stray frame (edge F-3)
       _historySeeded = false;
       _historyPaging = false; _historyPagingGen++; // PET-152: supersede any in-flight paging re-mint across the re-auth resume
       return Pet.api.getArmed().then(function (d) {
-        if (gen !== Pet.auth._gen) return { ok: false, stale: true }; // superseded; drop (incl. a stale 401)
+        if (gen !== Pet.auth._gen || scopeGen !== _scopeGen) return { ok: false, stale: true }; // superseded; drop (incl. a stale 401)
         if (d && d._status === 401) return { ok: false, message: "Authentication failed. Check the token and retry." };
         // round-2 edge F-3: a transient non-401 error (no boolean armed) keeps the
         // authenticate state and re-enables the control with a distinct message.
@@ -520,12 +522,12 @@
         Pet.state.armed = d.armed; // seed from the authenticated read, not the stale default
         _armedSeeded = true;       // armed is verified; skip the dashboard's mount re-fetch
         return Pet.api.getHealth().then(function (h) {
-          // A token set/clear during the /health round-trip supersedes this resume (a
-          // newer submit, or a clearToken, now owns the outcome). Drop the whole stale
+          // A token set/clear or host scope change during the /health round-trip
+          // supersedes this resume. Drop the whole stale
           // continuation — not just the health seed — so it cannot restart transports
           // or re-render the dashboard under a superseded generation (e.g. re-arming
           // polling/SSE that a concurrent clearToken just tore down).
-          if (gen !== Pet.auth._gen) return { ok: false, stale: true };
+          if (gen !== Pet.auth._gen || scopeGen !== _scopeGen) return { ok: false, stale: true };
           if (h && !h.error && h._status !== 401) {
             _healthLoaded = true;
             Pet.state.scannerHealth = h.scanners || [];

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -41,6 +41,7 @@ function makeNode(nodeType) {
     value: "",
     disabled: false,
     attrs: {},
+    dataset: {},
     appendChild(child) {
       this.childNodes.push(child);
       return child;
@@ -679,4 +680,157 @@ test("test_config_tab_in_authenticate_state_renders_panel_no_reads", () => {
   assert.ok(/AUTHENTICATE/.test(container.textContent), "config tab shows the authenticate panel");
   assert.ok(!/EQUIPPED/.test(container.textContent), "never EQUIPPED");
   assert.equal(calls.length, 0, "no /config or /profiles reads issued while authRequired");
+});
+
+// PET-192: hold real API requests across the real SDK host-rebind lifecycle.
+function resumeScopeHarness() {
+  const timers = makeTimers();
+  const pending = [];
+  const scope = {
+    profile: "alpha", currentProfile: "alpha", profiles: ["alpha", "beta"],
+    subscribe() { return () => {}; },
+  };
+  const { Pet, document } = loadPet({
+    ...timers,
+    window: { __HERMES_PLUGIN_SDK__: {
+      profileScope: scope,
+      fetchJSON(url) {
+        return new Promise((resolve) => pending.push({ url, resolve }));
+      },
+    } },
+  });
+  const effects = { connects: 0, renders: 0, connectivity: 0 };
+  Pet.sse.connect = () => { effects.connects++; };
+  Pet.renderDashboard = () => { effects.renders++; };
+  Pet.updateConnStatus = () => { effects.connectivity++; };
+  // Mount creates the real private container, so render assertions are non-vacuous.
+  Pet.mount(document.createElement("div"));
+  Pet.auth.on401({ _status: 401 });
+  assert.equal(Pet._poll.state().health, false);
+  assert.equal(pending.length, 0);
+  return {
+    Pet, pending, scope,
+    effects: () => ({ ...effects, intervals: timers.totalIntervals }),
+    rebind(axis) {
+      const authGen = Pet.auth._gen;
+      if (axis === "management") scope.profile = "beta";
+      if (axis === "equipped") scope.currentProfile = "beta";
+      Pet.hostProfile._rebind();
+      assert.equal(Pet.auth._gen, authGen, "scope rebind does not supersede the token");
+      assert.equal(Pet.state.selectedHermesProfile, scope.profile);
+      assert.equal(Pet.hostProfile.current, scope.currentProfile);
+    },
+  };
+}
+
+for (const axis of ["management", "equipped"]) {
+  // Regression for PET-192: an old armed answer must not authorize a new scope.
+  test(`PET-192: ${axis} rebind during armed drops the old response`, async () => {
+    const h = resumeScopeHarness();
+    const result = h.Pet.auth.submitToken("valid");
+    assert.equal(h.pending[0].url, "/api/armed?profile=alpha");
+    h.rebind(axis);
+    const before = h.effects();
+    h.pending[0].resolve({ armed: true });
+    await flush();
+    assert.equal(h.pending.length, 1, "superseded armed never issues health");
+    const res = await result;
+    assert.equal(res.ok, false);
+    assert.equal(res.stale, true);
+    assert.equal(h.Pet.state.authRequired, true);
+    assert.equal(h.Pet.state.armed, null);
+    assert.equal(h.Pet._armedTestState().seeded, false);
+    assert.equal(h.pending.length, 1, "superseded armed never issues health");
+    assert.equal(h.Pet._poll.state().health, false);
+    assert.deepEqual(h.effects(), before, "stale resume has no transport/UI effects");
+  });
+
+  // Regression for PET-192: the whole health continuation belongs to its send scope.
+  test(`PET-192: ${axis} rebind during health drops state and restart effects`, async () => {
+    const h = resumeScopeHarness();
+    const result = h.Pet.auth.submitToken("valid");
+    h.pending[0].resolve({ armed: true });
+    await flush();
+    assert.equal(h.pending[1].url, "/api/health?profile=alpha");
+    assert.equal(h.Pet.state.authRequired, false, "armed verification already completed");
+    h.rebind(axis);
+    const before = h.effects();
+    const { scannerHealth, pipelineHealth, integrityHealth, selfmodTotal } = h.Pet.state;
+    h.pending[1].resolve({
+      scanners: [{ name: "old-scope", status: "healthy" }],
+      pipeline: { selfmod_total: 192 }, integrity: { status: "old-scope" },
+    });
+    const res = await result;
+    assert.equal(res.ok, false);
+    assert.equal(res.stale, true);
+    assert.equal(h.Pet.state.scannerHealth, scannerHealth);
+    assert.equal(h.Pet.state.pipelineHealth, pipelineHealth);
+    assert.equal(h.Pet.state.integrityHealth, integrityHealth);
+    assert.equal(h.Pet.state.selfmodTotal, selfmodTotal);
+    assert.equal(h.Pet._poll.state().health, false);
+    assert.deepEqual(h.effects(), before, "no extra effects after the legitimate rebind");
+  });
+}
+
+for (const [label, body] of [
+  ["401", { _status: 401, detail: "Unauthorized" }],
+  ["malformed", {}],
+  ["error", { error: "unavailable", _status: 503 }],
+]) {
+  // Regression for PET-192: scope supersession wins over armed status/shape handling.
+  test(`PET-192: stale armed ${label} returns stale`, async () => {
+    const h = resumeScopeHarness();
+    const result = h.Pet.auth.submitToken("valid");
+    h.rebind("management");
+    h.pending[0].resolve(body);
+    const res = await result;
+    assert.equal(res.stale, true);
+    assert.equal(res.ok, false);
+    assert.equal(h.pending.length, 1);
+  });
+}
+
+// Regression for PET-192: even a stale health 401 must not complete resume.
+test("PET-192: stale health 401 cannot restart transports", async () => {
+  const h = resumeScopeHarness();
+  const result = h.Pet.auth.submitToken("valid");
+  h.pending[0].resolve({ armed: false });
+  await flush();
+  h.rebind("management");
+  const before = h.effects();
+  h.pending[1].resolve({ _status: 401, detail: "Unauthorized" });
+  const res = await result;
+  assert.equal(res.stale, true);
+  assert.equal(res.ok, false);
+  assert.equal(h.Pet._poll.state().health, false);
+  assert.deepEqual(h.effects(), before);
+});
+
+// Regression for PET-192: an unchanged host scope must still complete re-auth.
+test("PET-192: no-op rebind preserves same-scope resume", async () => {
+  const h = resumeScopeHarness();
+  const result = h.Pet.auth.submitToken("valid");
+  h.rebind("unchanged");
+  h.pending[0].resolve({ armed: false });
+  await flush();
+  h.rebind("unchanged");
+  const before = h.effects();
+  h.pending[1].resolve({
+    scanners: [{ name: "current", status: "healthy" }],
+    pipeline: { selfmod_total: 7 }, integrity: { status: "clean" },
+  });
+  const res = await result;
+  assert.equal(res.ok, true);
+  assert.equal(h.Pet.state.authRequired, false);
+  assert.equal(h.Pet.state.armed, false);
+  assert.equal(h.Pet._armedTestState().seeded, true);
+  assert.equal(h.Pet.state.scannerHealth[0].name, "current");
+  assert.equal(h.Pet.state.pipelineHealth.selfmod_total, 7);
+  assert.equal(h.Pet.state.integrityHealth.status, "clean");
+  assert.equal(h.Pet.state.selfmodTotal, 7);
+  assert.equal(h.Pet._poll.state().health, true);
+  assert.deepEqual(h.effects(), {
+    connects: before.connects + 1, renders: before.renders + 1,
+    connectivity: before.connectivity + 1, intervals: before.intervals + 1,
+  });
 });


### PR DESCRIPTION
When the host's selected or equipped profile changes during re-authentication, the old armed or health response can still finish the resume under the new scope. Both continuations now check the scope generation captured at resume entry alongside the existing token generation, before changing state or restarting transports.

Adds nine regressions over the shipped JavaScript using deferred SDK responses and real host rebinds. They cover both scope-change axes and both request boundaries, stale errors, transport/render effects, and unchanged-scope success. Includes an Unreleased changelog entry.

Validation: all 313 JavaScript tests pass locally; JavaScript syntax and diff whitespace checks pass. Against the original code, eight new regression cases fail and the unchanged-scope control passes. GPT-5.6 Sol reviewed the spec and implementation through correctness, edge-case, and convention lenses; the sole minor finding (duplicate test helper) was fixed. Local tests ran on Windows with Node 26.7.0; normal CI runs Node 22 and the Python matrix.

Refs PET-192 (PETRT-004).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication recovery when the active host profile changes.
  - Prevented outdated authentication responses from updating console state or restarting connection activity.
  - Preserved re-authentication behavior when the host profile remains unchanged.
  - Added safeguards for stale, malformed, unauthorized, and failed authentication responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->