### PR TITLE
docs(pet-193): clarify clipped-result boundary limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
   finding PETRT-005).** Renamed the reference plugin's private `_SEAM_OVERLAP`
   constant to `_RESULT_SCAN_HEAD_BIAS` to describe its budget role. The hardening
   guide now states that injections crossing either head/gap or gap/tail cut can
-  lose findings, even when most of the trigger is retained. This is a naming and
-  documentation correction: detection coverage and the 8,000-character scan
-  budget are unchanged; clipping alone adds no banner when the scan is clean.
+  lose findings, even when most of the trigger is retained. These disjoint windows
+  and boundary blind spots already existed: only the constant name and explanatory
+  text changed. The head/tail slices, cut positions, and 8,000-character budget
+  remain identical; clipping alone adds no banner when the scan is clean.
 
 - **Re-authentication discards responses from a superseded host scope (PET-192,
   PET-184 finding PETRT-004).** Armed and health verification now check the scope

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Clipped tool-result boundary limits are now explicit (PET-193, PET-184
+  finding PETRT-005).** Renamed the reference plugin's private `_SEAM_OVERLAP`
+  constant to `_RESULT_SCAN_HEAD_BIAS` to describe its budget role. The hardening
+  guide now states that injections crossing either head/gap or gap/tail cut can
+  lose findings, even when most of the trigger is retained. This is a naming and
+  documentation correction: detection coverage and the 8,000-character scan
+  budget are unchanged; clipping alone adds no banner when the scan is clean.
+
 - **Re-authentication discards responses from a superseded host scope (PET-192,
   PET-184 finding PETRT-004).** Armed and health verification now check the scope
   generation captured when resume starts, alongside the token generation. Changing

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -35,6 +35,30 @@ than waving it through (`petasos/config.py:56`).
       (the console health panel and scanner init logs tell the truth —
       PET-87).
 
+### Tool-result scan coverage (PET-170, PET-193)
+
+The reference plugin scans ingestion-tool results through `_transform_tool_result`
+(`docs/deployment/reference_plugin/__init__.py`). `_clip_result` limits the scan
+input to **8,000 characters, including the inserted truncation marker**. Results
+within that cap are passed to the pipeline whole; larger results contribute two
+**disjoint** spans from the head and tail. `_RESULT_SCAN_HEAD_BIAS` allocates 512
+more characters to the head than the tail within that budget. It provides no
+overlap or boundary-spanning scan.
+
+The omitted middle is unscanned. An injection crossing either the **head/gap**
+or **gap/tail** cut can also lose its finding, even when most of the trigger is
+inside the retained span: the scanner no longer receives the complete trigger.
+A clean retained-window scan therefore does not establish that the whole result
+is clean. These are input-window limits; they do not guarantee that each scanner
+backend examines every character it receives.
+
+Clipping governs the scan input only: the model still receives the **whole result**.
+The hook adds a banner for a HIGH/CRITICAL non-PII finding or scan unavailability;
+clipping alone adds no banner or ingestion enforcement event when the retained
+scan is clean (it logs `PETASOS_RESULT_TRUNCATED` at INFO). PET-193 corrects the
+name and disclosure; detection coverage is unchanged. Full-result coverage with
+overlapping chunks is tracked separately in PET-178.
+
 ## 2. Console binding
 
 The standalone console binds to loopback by design: `serve()` hardcodes

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -55,9 +55,11 @@ backend examines every character it receives.
 Clipping governs the scan input only: the model still receives the **whole result**.
 The hook adds a banner for a HIGH/CRITICAL non-PII finding or scan unavailability;
 clipping alone adds no banner or ingestion enforcement event when the retained
-scan is clean (it logs `PETASOS_RESULT_TRUNCATED` at INFO). PET-193 corrects the
-name and disclosure; detection coverage is unchanged. Full-result coverage with
-overlapping chunks is tracked separately in PET-178.
+scan is clean (it logs `PETASOS_RESULT_TRUNCATED` at INFO). These disjoint windows
+and boundary blind spots predate PET-193: this correction only renames the constant
+and documents the existing behavior. The head/tail slices, cut positions, and
+8,000-character budget are identical to the prior implementation. Full-result
+coverage with overlapping chunks is tracked separately in PET-178.
 
 ## 2. Console binding
 

--- a/docs/deployment/reference_plugin/__init__.py
+++ b/docs/deployment/reference_plugin/__init__.py
@@ -2003,9 +2003,9 @@ def _post_tool_call(
 # bounds tool *arguments*; this bounds a tool *result* at the ingestion seam.
 _MAX_RESULT_SCAN_CHARS = 8_000
 _TRUNCATION_MARKER = "\n...[petasos: scan window truncated]...\n"
-# Extends head coverage past the head/tail boundary. NOT seam-safety in general: for a
-# large result, head and tail are separated by an unscanned gap that nothing covers.
-_SEAM_OVERLAP = 512
+# Head-minus-tail length within the fixed scan budget; not an overlap. The retained
+# spans are disjoint, with no scan spanning either cut into the omitted middle.
+_RESULT_SCAN_HEAD_BIAS = 512
 # The outer bound sits ABOVE the per-scanner timeout, with the INPUT clamped rather than
 # the sum, so the margin survives at the top of the validated (0, 60] range (60 -> 65).
 # Below the per-scanner timeout, an abandoned outer future would never let `_scan_one`
@@ -2026,17 +2026,18 @@ _result_scan_status = "unprobed"
 def _clip_result(result: str) -> tuple[str, bool]:
     """Return ``(text_to_scan, truncated)`` for an ingestion-tool result.
 
-    Head + tail with a marker between them. The overlap comes out of the TAIL so the
-    budget invariant holds exactly: ``len(scanned) <= _MAX_RESULT_SCAN_CHARS`` always. The
-    whole-result short-circuit means head and tail never overlap in the original, so
-    nothing is scanned twice.
+    Head + tail with a marker between them, biased toward the head within the fixed
+    budget: ``len(scanned) <= _MAX_RESULT_SCAN_CHARS`` always. When clipping, the retained
+    spans are disjoint in the original, so nothing is scanned twice. The omitted middle
+    is unscanned, and no pass spans either head/gap or gap/tail cut: an injection split
+    across either cut can lose its finding even when most of its text is retained.
 
     Clipping governs only what is SCANNED. The handler always returns the whole result.
     """
     if len(result) <= _MAX_RESULT_SCAN_CHARS:
         return result, False
-    half = (_MAX_RESULT_SCAN_CHARS - len(_TRUNCATION_MARKER) - _SEAM_OVERLAP) // 2
-    head = result[: half + _SEAM_OVERLAP]
+    half = (_MAX_RESULT_SCAN_CHARS - len(_TRUNCATION_MARKER) - _RESULT_SCAN_HEAD_BIAS) // 2
+    head = result[: half + _RESULT_SCAN_HEAD_BIAS]
     tail = result[-half:]
     return head + _TRUNCATION_MARKER + tail, True
 

--- a/tests/test_reference_plugin_tool_result.py
+++ b/tests/test_reference_plugin_tool_result.py
@@ -962,13 +962,15 @@ def test_clip_boundaries_take_the_right_branch_and_never_double_scan(
 
 
 def test_the_clip_constants_leave_room_for_a_positive_half() -> None:
-    # `half` is `(cap - marker - overlap) // 2`. At zero or below, `result[-half:]` becomes
+    # `half` is `(cap - marker - head_bias) // 2`. At zero or below, `result[-half:]` becomes
     # `result[-0:]` — the WHOLE result — and the budget invariant asserted above would stop
     # holding silently. Pinned on the constants rather than guarded at runtime: the branch
-    # is unreachable at today's values, and a cap below the marker plus the overlap would
+    # is unreachable at today's values, and a cap below the marker plus the head bias would
     # make the head/tail window meaningless anyway.
     ref = _import_reference_plugin()
-    assert ref._MAX_RESULT_SCAN_CHARS - len(ref._TRUNCATION_MARKER) - ref._SEAM_OVERLAP >= 2
+    assert (
+        ref._MAX_RESULT_SCAN_CHARS - len(ref._TRUNCATION_MARKER) - ref._RESULT_SCAN_HEAD_BIAS >= 2
+    )
 
 
 def test_a_payload_in_the_last_thousand_chars_is_caught(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -989,10 +991,10 @@ def test_a_payload_at_the_exact_midpoint_is_missed_pinned_gap(
 ) -> None:
     """The mid-window gap, pinned rather than left to be rediscovered.
 
-    ``_SEAM_OVERLAP`` extends head coverage 512 chars past the boundary; it is not
-    seam-safety in general. For a large result, head and tail are separated by an unscanned
-    gap, and content landing there is invisible to this seam. The banner says what was
-    scanned, never that the content is clean.
+    ``_RESULT_SCAN_HEAD_BIAS`` makes the head 512 chars longer than the tail within the
+    fixed budget. The retained spans are disjoint, with no boundary-spanning pass.
+    Content in the gap is invisible to this scan; a trigger split across either cut can
+    also lose its finding. Clipping alone adds no banner when the retained scan is clean.
     """
     ref = _import_reference_plugin()
     filler = "filler line\n" * 40_000


### PR DESCRIPTION
## Summary

Clipping an ingestion-tool result can sever an injection at either retained-window/gap cut, even when most of its trigger remains in the scan. `_SEAM_OVERLAP` only biased the fixed budget toward the head; its name suggested coverage it did not provide.

This implements PET-193's naming-and-disclosure remedy: rename the private constant to `_RESULT_SCAN_HEAD_BIAS`, update its existing test reference and comments, and explain the omitted middle, both boundary misses, and clean-clipped no-banner behavior in the hardening guide and changelog. Detection coverage, slicing, and the 8,000-character budget are unchanged. Full coverage through overlapping chunks remains PET-178.

## Files changed

| File | Change |
| --- | --- |
| `docs/deployment/reference_plugin/__init__.py` | Private constant rename and accurate clipping documentation. |
| `tests/test_reference_plugin_tool_result.py` | Update the existing constant pin and gap explanation. |
| `docs/deployment/hardening.md` | Disclose window coverage and both boundary blind spots. |
| `CHANGELOG.md` | Record the correction under Unreleased. |

## Test plan

- [x] Python 3.13: tool-result, ingestion-backstop, cold-start, and egress suites — 290 passed.
- [x] Ruff lint and format checks on the two touched Python files; `git diff --check`.
- [x] Temporary real-MinimalScanner probe: inside-head/tail positive controls, both cuts, and omitted-middle cases at 8,001, 10,000, and 1,000,000 characters. Both cuts reproduce the documented missed rule.
- [x] Old/new clipping-output parity at nine representative sizes plus all 15 scanner-probe cases.
- [x] No remaining old-name references in tracked Python files.

The probe and full local gate output are retained as ignored lifecycle artifacts. Existing runtime tests were updated; no test was added that requires future scanners to retain these misses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how tool-result content is scanned when results exceed the scan budget.
  * Documented separate beginning and ending scan sections, with an unscanned middle portion and boundary blind spots.
  * Clarified that clipping affects scanning only; models continue to receive the full result.
  * Documented truncation logging and clean-scan banner behavior.

* **Security**
  * Adjusted the fixed scan window to retain more leading content while keeping the 8,000-character budget unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->