### PR TITLE
docs(pet-194): correct live decode flag release note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,9 +289,11 @@ enforcement entirely).
   by the pipeline that enforces, including through all five console posture
   presets. Both bootstraps now route through `build_scanners`, and a structural
   test fails the build if a third bootstrap constructs scanners by hand. Log
-  wording, levels, and ordering on both paths are unchanged. These fields still
-  apply at construction time only: a live config edit or a Hermes-profile
-  re-bind takes effect at the next restart.
+  wording, levels, and ordering on both paths are unchanged. The three Presidio
+  fields still apply at construction time only: changes from a live config edit
+  or a Hermes-profile re-bind take effect at the next restart.
+  `decode_encoded_payloads` is propagated live to the existing `MinimalScanner`
+  by `Pipeline.reconfigure()`; no restart is required for that flag.
 - **A permanently failed scanner init no longer disables enforcement (PET-171).**
   The reference plugin's `init_failed` branch now runs the zero-dependency syntactic
   scanner and honors `fail_mode`, instead of allowing every tool call unscanned.


### PR DESCRIPTION
The v0.3.0 PET-174 release note incorrectly said `decode_encoded_payloads` required a restart. Scope the construction-time limitation to the three Presidio settings and document that `Pipeline.reconfigure()` updates the existing MinimalScanner's decode flag live.

Only the historical CHANGELOG paragraph changes; runtime behavior is unchanged.

Validation: source inspection of reconfiguration and scanner construction; 15 existing reconfiguration tests passed (`py -3.13 -m pytest tests/test_pipeline_reconfigure.py -q`); `git diff --check` passed. Independent correctness, edge-case, and convention reviews cover the spec and final edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 0.3.0 changelog to clarify that encoded-payload decoding settings apply immediately when pipelines are reconfigured.
  * Clarified that Presidio configuration changes require restarting the pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->