### PR TITLE
refactor(pet-182): share console test loader and audited DOM factory

### DIFF
--- a/tests/js/arm-scope-view.test.mjs
+++ b/tests/js/arm-scope-view.test.mjs
@@ -10,41 +10,20 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    attrs: {},
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute(k, v) { this.attrs[k] = v; },
-    removeAttribute(k) { delete this.attrs[k]; },
-    querySelector() { return null; },
-    querySelectorAll() { return []; },
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+const { makeDocument } = createDOM({
+  attributes: "raw", events: "noop", selectors: "empty", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = {
   window: {}, document, console,
   setTimeout, clearTimeout, setInterval, clearInterval,
   AbortController, TextDecoder,
   fetch: function () { return new Promise(function () {}); },
 };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 function view(rs) { return Pet.armScopeView(rs); }

--- a/tests/js/armed-sync.test.mjs
+++ b/tests/js/armed-sync.test.mjs
@@ -22,57 +22,23 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── Minimal DOM shim ────────────────────────────────────────────────────────
 // The armed arm needs no real DOM (its re-render is _container-guarded and
 // _container is null headlessly), but loading petasos.js under vm requires
 // `document` to exist. Mirror the scanner-health shim shape.
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true,
+  textContent: "readonly",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ────────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Tests ───────────────────────────────────────────────────────────────────

--- a/tests/js/cold-start-row.test.mjs
+++ b/tests/js/cold-start-row.test.mjs
@@ -17,59 +17,19 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim (same as selfmod-row.test.mjs) ─────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    dataset: {},
-    _text: "",
-    setAttribute() {},
-    addEventListener() {},
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
-    },
-    set textContent(v) {
-      this._text = String(v);
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true,
+  attributes: "noop", events: "noop",
+  textContent: "stored",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── helpers ─────────────────────────────────────────────────────────────────

--- a/tests/js/config-sections.test.mjs
+++ b/tests/js/config-sections.test.mjs
@@ -20,87 +20,27 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createDOM, loadConsole } from "./harness.mjs";
 // Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
 // returned from the node:vm sandbox carry the sandbox realm's Object/Array
 // prototypes, so assert/strict's prototype-checking deepStrictEqual rejects them
 // even when structurally identical. Structural comparisons use this; primitive
 // comparisons keep the strict `assert`.
 import assertLoose from "node:assert";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
 
 // ── Extended interactive DOM shim ──────────────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    tabIndex: undefined,
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      // Permissive (unlike scanner-health's throwing setter): replace children
-      // with a single text node so the getter stays consistent.
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      this.childNodes = [t];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(ns, tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    el.namespaceURI = ns;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ───────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/tests/js/console-token.test.mjs
+++ b/tests/js/console-token.test.mjs
@@ -25,99 +25,20 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim (mirrors trap-burst.test.mjs, + value/disabled/attrs for the panel) ──
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    value: "",
-    disabled: false,
-    attrs: {},
-    dataset: {},
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    insertBefore(node, ref) {
-      const i = ref ? this.childNodes.indexOf(ref) : -1;
-      if (i < 0) this.childNodes.push(node);
-      else this.childNodes.splice(i, 0, node);
-      return node;
-    },
-    get firstChild() {
-      return this.childNodes[0] || null;
-    },
-    addEventListener(_type, _fn) {},
-    setAttribute(k, v) {
-      this.attrs[k] = String(v);
-    },
-    removeAttribute(k) {
-      delete this.attrs[k];
-    },
-    getAttribute(k) {
-      return this.attrs[k];
-    },
-    querySelector() {
-      return null;
-    },
-    querySelectorAll() {
-      return [];
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      this.childNodes = [];
-      const s = v == null ? "" : String(v);
-      if (s !== "") {
-        const n = makeNode(3);
-        n.nodeValue = s;
-        this.childNodes.push(n);
-      }
-    },
-    set innerHTML(_v) {
-      this.childNodes = [];
-    },
-  };
-}
-
-function makeDocument() {
-  return {
-    createDocumentFragment() {
-      return makeNode(11);
-    },
-    createElement(tag) {
-      const el = makeNode(1);
-      el.tagName = tag.toUpperCase();
-      el.localName = tag;
-      return el;
-    },
-    createElementNS(_ns, tag) {
-      return this.createElement(tag);
-    },
-    createTextNode(t) {
-      const node = makeNode(3);
-      node.nodeValue = String(t);
-      return node;
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true,
+  attributes: "attrs", events: "noop", selectors: "empty",
+  textContent: "clear", innerHTML: "clear", svg: "alias",
+  tree: { insert: true, first: true },
+  extendNode(node) {
+    Object.assign(node, { value: "", disabled: false });
+  },
+});
 
 // ── Sandbox helpers ──────────────────────────────────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const src = readFileSync(
-  join(here, "..", "..", "petasos", "console", "static", "petasos.js"),
-  "utf8"
-);
 
 // Load the real petasos.js into a fresh vm context. Every option is overridable so a
 // test can inject its own fetch / timers / sessionStorage / window.
@@ -151,7 +72,7 @@ function loadPet(opts = {}) {
   // "sessionStorage" present as a key (even = undefined) means the test controls it;
   // otherwise hand the store a working in-memory sessionStorage.
   sandbox.sessionStorage = "sessionStorage" in opts ? opts.sessionStorage : makeSessionStorage();
-  vm.runInNewContext(src, sandbox);
+  loadConsole(sandbox);
   return { Pet: sandbox.window.__PETASOS_CONSOLE__, sandbox, document };
 }
 

--- a/tests/js/disarm-bypass-counter.test.mjs
+++ b/tests/js/disarm-bypass-counter.test.mjs
@@ -13,34 +13,17 @@
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-// Minimal DOM shim — these tests exercise pure data seams (accrueBypass /
+// ?? Audited DOM options (see harness-audit.md) ??
 // bypassTotal), so document is only needed for petasos.js to evaluate.
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute() {},
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+const { makeDocument } = createDOM({
+  attributes: "noop", events: "noop", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 const bypass = (session_id, bypassed_count) => ({

--- a/tests/js/enforcement-history.test.mjs
+++ b/tests/js/enforcement-history.test.mjs
@@ -15,62 +15,22 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim ────────────────────────────────────────────────────────────────
 // scanHistoryRows uses `el.textContent = ...` on freshly-created spans, so the
 // shim ALLOWS textContent assignment (unlike the PET-103 scanner-health shim). The
 // textContent getter aggregates child text plus any directly-set text.
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    dataset: {},
-    _text: "",
-    setAttribute() {},
-    addEventListener() {},
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
-    },
-    set textContent(v) {
-      this._text = String(v);
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true,
+  attributes: "noop", events: "noop",
+  textContent: "stored",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── helpers ───────────────────────────────────────────────────────────────

--- a/tests/js/enforcement-provenance.test.mjs
+++ b/tests/js/enforcement-provenance.test.mjs
@@ -11,33 +11,16 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-// Minimal DOM shim — scanDetailPanel only builds elements + text nodes via Pet.h.
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute() {},
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+// ?? Audited DOM options (see harness-audit.md) ??
+const { makeDocument } = createDOM({
+  attributes: "noop", events: "noop", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // Recursively concatenate all text-node content under a rendered node.

--- a/tests/js/harness-audit.md
+++ b/tests/js/harness-audit.md
@@ -1,0 +1,70 @@
+# PET-182 harness audit
+
+Baseline: `ad8d33a`. There are 24 suites, 313 tests and 7,858 JavaScript lines.
+The ticket's 22 suites / 6,925 lines describe an older tree. The audit examined
+node factories, document factories, source reads, VM globals and throwing fixtures
+before extraction. No console behavior or existing assertion is changed.
+
+A = duplicate within the named family (ignoring comments/formatting).
+B = deliberately stricter surface. C = distinct surface or lifecycle fixture.
+Categories can overlap; a shared DOM does not imply interchangeable runtimes.
+
+| Suite (`.test.mjs`) | Class | DOM and retained differences | Runtime fixtures retained in suite |
+| --- | --- | --- | --- |
+| arm-scope-view | A/C | Scope family: raw `attrs`, empty selectors, no text accessor/localName | Real timers and stream APIs; parked fetch |
+| armed-sync | B | Styled nodes; getter-only textContent | Bare sandbox |
+| cold-start-row | A | Row family: dataset, stored text, no-op attributes/events | Bare sandbox |
+| config-sections | A | Form family: recorded attributes/events, replacement text, SVG namespace | Bare sandbox |
+| console-token | C | Clearing text/HTML, insertion, form values, `attrs`, empty selectors | Fresh realm/document, storage failure fixtures, fetch, recording timers, abort/decoder overrides |
+| disarm-bypass-counter | A | Minimal family: no text accessor/localName, no-op attributes/events | Bare sandbox |
+| enforcement-history | A | Row family | Bare sandbox |
+| enforcement-provenance | A | Minimal family | Bare sandbox |
+| hermes-diegetic-profile | C | Form family plus parent links, insertion/removal, selectors, head, HTML getter/clear | Fresh realm/document, host history/events, SDK, fetch, inert timers, throwing subscriber |
+| hermes-profile-selector | C | Form family plus parent links, removal and class-only selector | Suite-local API/host fixtures |
+| integrity-health | A | Minimal family | Bare sandbox |
+| playground | C | Clearing text/HTML; SVG aliases createElement; no-op attributes/events | Suite-local scan fixtures |
+| preset-dial | A | Form family | Bare sandbox |
+| profile-picker | C | Form family plus removal without parent links | Bare sandbox |
+| profile-scoped-reads | A/C | Scope family | Real timers and stream APIs; parked fetch, per-case state reset |
+| richtext | B | Getter-only text; deliberately no style, className or extra DOM APIs | Bare sandbox |
+| scan-history-count | A | Minimal family | Bare sandbox |
+| scan-history-paging | A/C | Minimal family | Per-case fetch overrides and deferred requests |
+| scanner-health | B | Styled nodes; PET-103 D10 throwing setter **and** aggregating getter | Existing guard-of-the-guard test |
+| selfmod-row | A | Row family | Bare sandbox |
+| selfmod-tile-filter | A/C | Row family | Source-copy assertion now uses the shared source read |
+| skeleton | A | Form family | Bare sandbox |
+| sse-reconnect | B/C | Getter-only text, no-op attributes, null querySelector, currentScript:null | Fresh realm/document, controlled streams/timers/randomness, capturing console, invalid-outcome guard |
+| trap-burst | C | Playground family plus insertion/firstChild | Immediate short timers; long timers suppressed |
+
+## Strictness and failure fixtures
+
+The four-file `throw` count in the original brief is not a count of strict DOMs.
+Only scanner-health has the explicit PET-103 D10 setter; its existing test checks
+that the setter throws, and its renderer tests check that the getter still works.
+Getter-only textContent in armed-sync, richtext and sse-reconnect also rejects
+assignment by the strict-mode console. Those accessors remain getter-only.
+
+Console-token's three throws simulate denied storage and failed set/remove writes.
+Hermes-diegetic-profile's throw tests subscriber exception isolation.
+SSE-reconnect's `bad /events outcome` throw rejects an invalid test fixture; it is
+not a production DOM regression guard. These fixtures stay local, unchanged.
+
+## Shared seam and fidelity boundary
+
+`harness.mjs` is the only place that reads/evaluates the shipped console source.
+`loadConsole(sandbox)` evaluates in the supplied sandbox and injects no additional
+globals; suites retain their fresh-sandbox boundaries. `consoleSource` exposes that same read for the existing copy
+assertion. PET-183 can change the source-loading implementation here.
+
+`createDOM(options)` returns node/document factories. Each suite names its existing
+capabilities explicitly; it does not receive a union of all suites' APIs. Text modes
+preserve the old distinction between getter-only, throwing, stored text, replacing
+with one text node, and clearing empty/null text. Attribute modes preserve raw vs
+string values and missing-value null vs undefined. Optional tree operations,
+selectors, SVG namespaces, event recording and innerHTML clearing are enabled only
+where previously present. Specialized selector matching remains suite-local.
+
+This remains a test DOM: appends do not flatten fragments or reparent children,
+and HTML setters model clearing, not parsing. Cross-realm assertions still compare
+keys and values rather than host-realm prototypes. No dependency or build step is
+introduced; no additional frontend coverage is added.

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -1,0 +1,150 @@
+// Shared console test harness (PET-182). Node built-ins only.
+// Owns source loading and the base DOM; suites opt into their audited surfaces.
+// Fetch, timers, storage, SDKs and lifecycle fixtures remain caller-owned.
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+export const consoleSource = readFileSync(new URL("../../petasos/console/static/petasos.js", import.meta.url), "utf8");
+
+// Suites supply fresh sandboxes when they need fresh realms; no globals are added.
+// Compare realm objects by keys/values, not host-realm prototype identity.
+export function loadConsole(sandbox) {
+  vm.runInNewContext(consoleSource, sandbox);
+  return sandbox.window.__PETASOS_CONSOLE__;
+}
+
+// This is deliberately a small test DOM, not a browser implementation. Appends
+// do not reparent or flatten fragments. Options preserve existing shim behavior,
+// including absent APIs and the different empty/null text assignment semantics.
+export function createDOM(options = {}) {
+  const tree = options.tree || {};
+  function makeNode(nodeType) {
+    const node = {
+      nodeType,
+      childNodes: [],
+      appendChild(child) {
+        if (tree.parents) child.parentNode = this;
+        this.childNodes.push(child);
+        return child;
+      },
+    };
+    if (options.styled !== false) Object.assign(node, { style: {}, className: "" });
+    if (options.title) node.title = "";
+    if (options.dataset) node.dataset = {};
+    if (options.tabIndex) node.tabIndex = undefined;
+    if (tree.parents) node.parentNode = null;
+    if (tree.remove) node.removeChild = function (child) {
+      const i = this.childNodes.indexOf(child);
+      if (i !== -1) this.childNodes.splice(i, 1);
+      if (tree.parents) child.parentNode = null;
+      return child;
+    };
+    if (tree.detach) node.remove = function () {
+      if (this.parentNode) this.parentNode.removeChild(this);
+    };
+    if (tree.insert) node.insertBefore = function (child, ref) {
+      if (tree.parents) child.parentNode = this;
+      const i = ref ? this.childNodes.indexOf(ref) : -1;
+      if (i < 0) this.childNodes.push(child);
+      else this.childNodes.splice(i, 0, child);
+      return child;
+    };
+    if (tree.first) Object.defineProperty(node, "firstChild", {
+      enumerable: true, configurable: true,
+      get() { return this.childNodes[0] || null; },
+    });
+
+    const attrs = options.attributes;
+    if (attrs === "noop") node.setAttribute = function () {};
+    else if (attrs) {
+      const key = attrs === "record" ? "attributes" : "attrs";
+      node[key] = {};
+      node.setAttribute = function (k, v) { this[key][k] = attrs === "raw" ? v : String(v); };
+      if (attrs !== "raw") node.getAttribute = function (k) {
+        return attrs === "record" && !Object.prototype.hasOwnProperty.call(this[key], k)
+          ? null : this[key][k];
+      };
+      if (attrs !== "record") node.removeAttribute = function (k) { delete this[key][k]; };
+    }
+    if (options.events === "noop") node.addEventListener = function () {};
+    if (options.events === "record") {
+      node.handlers = {};
+      node.addEventListener = function (type, fn) {
+        (this.handlers[type] = this.handlers[type] || []).push(fn);
+      };
+    }
+    if (options.selectors) node.querySelector = function () { return null; };
+    if (options.selectors === "empty") node.querySelectorAll = function () { return []; };
+
+    const text = options.textContent;
+    if (text === "stored") node._text = "";
+    if (text) {
+      const descriptor = {
+        enumerable: true, configurable: true,
+        get() {
+          if (this.nodeType === 3) return this.nodeValue;
+          return this.childNodes.map((c) => c.textContent).join("") +
+            (text === "stored" ? (this._text || "") : "");
+        },
+      };
+      if (text !== "readonly") descriptor.set = function (v) {
+        if (text === "strict") throw new Error(
+          "PET-103 D10: textContent assignment is banned in this shim — pass the " +
+          "message as a Pet.h text child, not `errEl.textContent = ...`."
+        );
+        if (text === "stored") {
+          this._text = String(v);
+          this.childNodes = [];
+          return;
+        }
+        this.childNodes = [];
+        const s = text === "clear" && v == null ? "" : String(v);
+        if (text === "clear" && s === "") return;
+        const child = makeNode(3);
+        child.nodeValue = s;
+        if (tree.parents) child.parentNode = this;
+        this.childNodes.push(child);
+      };
+      Object.defineProperty(node, "textContent", descriptor);
+    }
+    if (options.innerHTML) {
+      const descriptor = {
+        enumerable: true, configurable: true,
+        set(_v) { this.childNodes = []; },
+      };
+      if (options.innerHTML === "readWrite") descriptor.get = function () { return ""; };
+      Object.defineProperty(node, "innerHTML", descriptor);
+    }
+    if (options.extendNode) options.extendNode(node);
+    return node;
+  }
+
+  function makeDocument() {
+    const document = {
+      createDocumentFragment() { return makeNode(11); },
+      createElement(tag) {
+        const el = makeNode(1);
+        el.tagName = tag.toUpperCase();
+        if (options.localName !== false) el.localName = tag;
+        return el;
+      },
+      createTextNode(t) {
+        const node = makeNode(3);
+        node.nodeValue = String(t);
+        return node;
+      },
+    };
+    if (options.svg) document.createElementNS = function (ns, tag) {
+      if (options.svg === "alias") return this.createElement(tag);
+      const el = makeNode(1);
+      el.tagName = tag.toUpperCase();
+      el.localName = tag;
+      el.namespaceURI = ns;
+      return el;
+    };
+    if (options.head) document.head = makeNode(1);
+    if (options.currentScript === null) document.currentScript = null;
+    return document;
+  }
+  return { makeNode, makeDocument };
+}

--- a/tests/js/hermes-diegetic-profile.test.mjs
+++ b/tests/js/hermes-diegetic-profile.test.mjs
@@ -23,85 +23,23 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createDOM, loadConsole } from "./harness.mjs";
 import assertLoose from "node:assert";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
 
 // ── Interactive DOM shim (superset of hermes-profile-selector's) ────────────
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    value: undefined,
-    parentNode: null,
-    tabIndex: undefined,
-    appendChild(child) {
-      child.parentNode = this;
-      this.childNodes.push(child);
-      return child;
-    },
-    removeChild(child) {
-      const i = this.childNodes.indexOf(child);
-      if (i !== -1) this.childNodes.splice(i, 1);
-      child.parentNode = null;
-      return child;
-    },
-    insertBefore(node, ref) {
-      node.parentNode = this;
-      if (ref == null) { this.childNodes.push(node); return node; }
-      const i = this.childNodes.indexOf(ref);
-      if (i === -1) this.childNodes.push(node);
-      else this.childNodes.splice(i, 0, node);
-      return node;
-    },
-    remove() {
-      if (this.parentNode) this.parentNode.removeChild(this);
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    querySelector(sel) {
-      return matchAll(this, sel)[0] || null;
-    },
-    querySelectorAll(sel) {
-      return matchAll(this, sel);
-    },
-    get firstChild() {
-      return this.childNodes[0] || null;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      t.parentNode = this;
-      this.childNodes = [t];
-    },
-    set innerHTML(v) {
-      // The console only ever assigns "" (a wipe). Treat any value as a clear.
-      this.childNodes = [];
-    },
-    get innerHTML() {
-      return "";
-    },
-  };
-}
+const { makeNode, makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+  tree: { parents: true, remove: true, detach: true, insert: true, first: true }, head: true, innerHTML: "readWrite",
+  extendNode(node) {
+    Object.assign(node, {
+      value: undefined,
+      querySelector(sel) { return matchAll(this, sel)[0] || null; },
+      querySelectorAll(sel) { return matchAll(this, sel); },
+    });
+  },
+});
 
 // Single-token selector matcher: ".class" | "tag" | "[data-x]" | "[data-x=\"v\"]".
 // (Compound selectors like '.tab[data-key="x"]' are only used on keydown, untested.)
@@ -134,31 +72,6 @@ function matchAll(root, sel) {
   };
   walk(root);
   return out;
-}
-
-function makeDocument() {
-  return {
-    head: makeNode(1),
-    createDocumentFragment() { return makeNode(11); },
-    createElement(tag) {
-      const el = makeNode(1);
-      el.tagName = tag.toUpperCase();
-      el.localName = tag;
-      return el;
-    },
-    createElementNS(ns, tag) {
-      const el = makeNode(1);
-      el.tagName = tag.toUpperCase();
-      el.localName = tag;
-      el.namespaceURI = ns;
-      return el;
-    },
-    createTextNode(t) {
-      const node = makeNode(3);
-      node.nodeValue = String(t);
-      return node;
-    },
-  };
 }
 
 // Distinguishable original-history return values, so the patch's "return the captured
@@ -202,9 +115,6 @@ function makeWindow(opts) {
 }
 
 // ── Load a fresh petasos.js per test (state + history patch must not leak) ──
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 function load(opts) {
   opts = opts || {};
@@ -219,7 +129,7 @@ function load(opts) {
     clearInterval: () => {},
     fetch: () => Promise.resolve({ ok: true, status: 200, statusText: "OK", json: () => Promise.resolve({}) }),
   };
-  vm.runInNewContext(src, sandbox);
+  loadConsole(sandbox);
   const Pet = win.__PETASOS_CONSOLE__;
   return { Pet, win };
 }

--- a/tests/js/hermes-profile-selector.test.mjs
+++ b/tests/js/hermes-profile-selector.test.mjs
@@ -22,112 +22,46 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createDOM, loadConsole } from "./harness.mjs";
 // Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
 // returned from the node:vm sandbox carry the sandbox realm's Object/Array
 // prototypes, so assert/strict's deepStrictEqual rejects them even when
 // structurally identical (profile-picker.test.mjs:24-29). Structural comparisons
 // of sandbox-origin values use this; primitive comparisons keep strict `assert`.
 import assertLoose from "node:assert";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
 
 // ── Extended interactive DOM shim ──────────────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    value: undefined,
-    parentNode: null,
-    tabIndex: undefined,
-    appendChild(child) {
-      child.parentNode = this;
-      this.childNodes.push(child);
-      return child;
-    },
-    removeChild(child) {
-      const i = this.childNodes.indexOf(child);
-      if (i !== -1) this.childNodes.splice(i, 1);
-      child.parentNode = null;
-      return child;
-    },
-    remove() {
-      if (this.parentNode) this.parentNode.removeChild(this);
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    // Minimal descendant ".class" matcher (the only selector the seam uses).
-    querySelector(sel) {
-      const cls = sel.startsWith(".") ? sel.slice(1) : sel;
-      const hit = (node) => {
-        for (const c of node.childNodes) {
-          if (c.nodeType === 1) {
-            if ((c.className || "").split(/\s+/).includes(cls)) return c;
-            const deep = hit(c);
-            if (deep) return deep;
+const { makeNode, makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+  tree: { parents: true, remove: true, detach: true },
+  extendNode(node) {
+    Object.assign(node, {
+      value: undefined,
+      querySelector(sel) {
+        const cls = sel.startsWith(".") ? sel.slice(1) : sel;
+        const hit = (node) => {
+          for (const c of node.childNodes) {
+            if (c.nodeType === 1) {
+              if ((c.className || "").split(/\s+/).includes(cls)) return c;
+              const deep = hit(c);
+              if (deep) return deep;
+            }
           }
-        }
-        return null;
-      };
-      return hit(this);
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      t.parentNode = this;
-      this.childNodes = [t];
-    },
-  };
-}
+          return null;
+        };
+        return hit(this);
+      },
+    });
+  },
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(ns, tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    el.namespaceURI = ns;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ───────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/tests/js/integrity-health.test.mjs
+++ b/tests/js/integrity-health.test.mjs
@@ -10,33 +10,16 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-// Minimal DOM shim — Pet.integrityRows only builds elements + text nodes via Pet.h.
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute() {},
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+// ?? Audited DOM options (see harness-audit.md) ??
+const { makeDocument } = createDOM({
+  attributes: "noop", events: "noop", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 function textOf(node) {

--- a/tests/js/playground.test.mjs
+++ b/tests/js/playground.test.mjs
@@ -21,10 +21,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── Extended DOM shim (PET-99) ──────────────────────────────────────────────
 // Superset of the scanner-health shim. Differences (see spec Test plan):
@@ -36,68 +33,18 @@ import vm from "node:vm";
 //   * innerHTML setter clears childNodes (the `resultArea.innerHTML = ""` clear
 //     idiom — real-DOM semantics, so children don't accumulate across calls).
 //   * no-op addEventListener / setAttribute (Pet.HelpTip / Pet.svg touch them).
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    addEventListener(_type, _fn) {},
-    setAttribute(_k, _v) {},
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      // Real-DOM semantics: clear children; for a non-empty value, append one
-      // text node. (Empty string clears to no children.)
-      this.childNodes = [];
-      const s = v == null ? "" : String(v);
-      if (s !== "") {
-        const n = makeNode(3);
-        n.nodeValue = s;
-        this.childNodes.push(n);
-      }
-    },
-    set innerHTML(_v) {
-      // Only `... = ""` is used in production; model the clear, ignore the value.
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true,
+  attributes: "noop", events: "noop",
+  textContent: "clear", innerHTML: "clear", svg: "alias",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase(); // mirrors real DOM (uppercase for HTML)
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(_ns, tag) {
-    return this.createElement(tag); // Pet.svg path
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ──────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/js/preset-dial.test.mjs
+++ b/tests/js/preset-dial.test.mjs
@@ -18,80 +18,22 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createDOM, loadConsole } from "./harness.mjs";
 import assertLoose from "node:assert";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
 
 // ── Interactive DOM shim ────────────────────────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    tabIndex: undefined,
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      this.childNodes = [t];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(ns, tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    el.namespaceURI = ns;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ───────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/js/profile-picker.test.mjs
+++ b/tests/js/profile-picker.test.mjs
@@ -21,90 +21,28 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createDOM, loadConsole } from "./harness.mjs";
 // Legacy (non-strict) assert: its deepEqual ignores object prototypes. Values
 // returned from the node:vm sandbox carry the sandbox realm's Object/Array
 // prototypes, so assert/strict's deepStrictEqual rejects them even when
 // structurally identical (config-sections.test.mjs:22-28). Structural comparisons
 // use this; primitive comparisons keep the strict `assert`.
 import assertLoose from "node:assert";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
 
 // ── Extended interactive DOM shim ──────────────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    tabIndex: undefined,
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    removeChild(child) {
-      const i = this.childNodes.indexOf(child);
-      if (i !== -1) this.childNodes.splice(i, 1);
-      return child;
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      this.childNodes = [t];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+  tree: { remove: true },
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(ns, tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    el.namespaceURI = ns;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ───────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 const FALLBACK_TIP = "Custom profile: no description provided.";

--- a/tests/js/profile-scoped-reads.test.mjs
+++ b/tests/js/profile-scoped-reads.test.mjs
@@ -14,34 +14,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    attrs: {},
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute(k, v) { this.attrs[k] = v; },
-    removeAttribute(k) { delete this.attrs[k]; },
-    querySelector() { return null; },
-    querySelectorAll() { return []; },
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+const { makeDocument } = createDOM({
+  attributes: "raw", events: "noop", selectors: "empty", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 // AbortController / TextDecoder / fetch are runtime APIs petasos.js already relies
 // on (the SSE pump); the shim provides them so _openStream can be driven headlessly.
 const sandbox = {
@@ -50,7 +29,7 @@ const sandbox = {
   AbortController, TextDecoder,
   fetch: function () { return new Promise(function () {}); },
 };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));

--- a/tests/js/richtext.test.mjs
+++ b/tests/js/richtext.test.mjs
@@ -11,55 +11,24 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── Minimal DOM shim ──────────────────────────────────────────────────────
 // Models exactly the surface richText touches. richText only ever appends
 // freshly-created nodes (never re-parents, never appends a fragment into a
 // node), so the shim does not model real-DOM appendChild re-parenting or
 // DocumentFragment flattening — see spec D3 "Fidelity boundary".
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  styled: false,
+  textContent: "readonly",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase(); // mirrors real DOM (uppercase for HTML)
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ──────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // Guards spec D5: the export ran and richText is present.

--- a/tests/js/scan-history-count.test.mjs
+++ b/tests/js/scan-history-count.test.mjs
@@ -13,34 +13,17 @@
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-// Minimal DOM shim -- these tests exercise a pure data seam, so document is only needed
+// ?? Audited DOM options (see harness-audit.md) ??
 // for petasos.js to evaluate.
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute() {},
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+const { makeDocument } = createDOM({
+  attributes: "noop", events: "noop", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 beforeEach(() => {

--- a/tests/js/scan-history-paging.test.mjs
+++ b/tests/js/scan-history-paging.test.mjs
@@ -12,32 +12,15 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    appendChild(child) { this.childNodes.push(child); return child; },
-    setAttribute() {},
-    addEventListener() {},
-  };
-}
-const document = {
-  createDocumentFragment() { return makeNode(11); },
-  createElement(tag) { const el = makeNode(1); el.tagName = tag.toUpperCase(); return el; },
-  createTextNode(t) { const n = makeNode(3); n.nodeValue = String(t); return n; },
-};
+const { makeDocument } = createDOM({
+  attributes: "noop", events: "noop", localName: false,
+});
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── PET-152 handler-integration helpers ──────────────────────────────────────

--- a/tests/js/scanner-health.test.mjs
+++ b/tests/js/scanner-health.test.mjs
@@ -17,10 +17,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── Extended DOM shim (PET-103 D10) ────────────────────────────────────────
 // Models the surface Pet.h touches that the richtext shim does not: `style`
@@ -28,57 +25,19 @@ import vm from "node:vm";
 // `undefined`), plus plain `className`/`title` slots. `textContent` keeps the
 // aggregating GETTER (so `errEl.textContent === message` reads work) AND gains a
 // throwing SETTER — so a regression to the old `errEl.textContent = ...` pattern
-// fails loudly here instead of being a silent no-op. Both accessors are defined
-// together (a `get`/`set` literal pair) so adding the setter does not drop the
-// getter.
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(_v) {
-      throw new Error(
-        "PET-103 D10: textContent assignment is banned in this shim — pass the " +
-          "message as a Pet.h text child, not `errEl.textContent = ...`."
-      );
-    },
-  };
-}
+// fails loudly here instead of being a silent no-op. The shared factory defines
+// both accessors in one descriptor so the setter does not drop the getter.
+const { makeDocument } = createDOM({
+  title: true,
+  textContent: "strict",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase(); // mirrors real DOM (uppercase for HTML)
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ──────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/js/selfmod-row.test.mjs
+++ b/tests/js/selfmod-row.test.mjs
@@ -17,59 +17,19 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim (same as enforcement-history.test.mjs) ─────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    dataset: {},
-    _text: "",
-    setAttribute() {},
-    addEventListener() {},
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
-    },
-    set textContent(v) {
-      this._text = String(v);
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true,
+  attributes: "noop", events: "noop",
+  textContent: "stored",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── helpers ─────────────────────────────────────────────────────────────────

--- a/tests/js/selfmod-tile-filter.test.mjs
+++ b/tests/js/selfmod-tile-filter.test.mjs
@@ -23,59 +23,19 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole, consoleSource } from "./harness.mjs";
 
 // ── DOM shim (same as selfmod-row.test.mjs) ─────────────────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    dataset: {},
-    _text: "",
-    setAttribute() {},
-    addEventListener() {},
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("") + (this._text || "");
-    },
-    set textContent(v) {
-      this._text = String(v);
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true,
+  attributes: "noop", events: "noop",
+  textContent: "stored",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
 const sandbox = { window: {}, document };
-vm.runInNewContext(readFileSync(petasosJsPath, "utf8"), sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── fixtures ────────────────────────────────────────────────────────────────
@@ -289,7 +249,7 @@ test("setHistoryFilter: selecting 'all' from a paged view leaves the page alone"
 // ── house style ─────────────────────────────────────────────────────────────
 
 test("PET-165 copy carries no em dash", () => {
-  const src = readFileSync(petasosJsPath, "utf8");
+  const src = consoleSource;
   const selfmodCopy = src.match(/"[^"\n]*self-tamper[^"\n]*"/g) || [];
   assert.ok(selfmodCopy.length > 0, "expected self-tamper copy in the shipped console");
   for (const s of selfmodCopy) assert.ok(!s.includes("—"), `em dash in shipped copy: ${s}`);

--- a/tests/js/skeleton.test.mjs
+++ b/tests/js/skeleton.test.mjs
@@ -17,79 +17,21 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim (style / className / dataset / attributes) ─────────────────────
-function makeNode(nodeType) {
-  return {
-    nodeType, // 1 = element, 3 = text, 11 = fragment
-    childNodes: [],
-    style: {},
-    dataset: {},
-    attributes: {},
-    handlers: {},
-    className: "",
-    title: "",
-    tabIndex: undefined,
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    setAttribute(k, v) {
-      this.attributes[k] = String(v);
-    },
-    getAttribute(k) {
-      return Object.prototype.hasOwnProperty.call(this.attributes, k) ? this.attributes[k] : null;
-    },
-    addEventListener(type, fn) {
-      (this.handlers[type] = this.handlers[type] || []).push(fn);
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      const t = makeNode(3);
-      t.nodeValue = String(v);
-      this.childNodes = [t];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true, dataset: true, tabIndex: true,
+  attributes: "record", events: "record",
+  textContent: "replace", svg: "namespace",
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(ns, tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    el.namespaceURI = ns;
-    return el;
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ────────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const src = readFileSync(petasosJsPath, "utf8");
 
 const sandbox = { window: {}, document };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // element children of a node (skip text nodes)

--- a/tests/js/sse-reconnect.test.mjs
+++ b/tests/js/sse-reconnect.test.mjs
@@ -24,59 +24,17 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
-
-const here = dirname(fileURLToPath(import.meta.url));
-const petasosJsPath = join(here, "..", "..", "petasos", "console", "static", "petasos.js");
-const SRC = readFileSync(petasosJsPath, "utf8");
+import { createDOM, loadConsole } from "./harness.mjs";
 
 const enc = new TextEncoder();
 const POLL_MS = 10000; // startFallbackPolling delay (petasos.js:545) — fixed, not a Pet.sse constant
 
 // ── Minimal DOM shim (same shape as armed-sync / scanner-health) ────────────
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    appendChild(c) {
-      this.childNodes.push(c);
-      return c;
-    },
-    setAttribute() {},
-    querySelector() {
-      return null;
-    },
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-  };
-}
-function makeDocument() {
-  return {
-    currentScript: null, // _assetBase falls back to "/static/"
-    createDocumentFragment() {
-      return makeNode(11);
-    },
-    createElement(tag) {
-      const el = makeNode(1);
-      el.tagName = tag.toUpperCase();
-      el.localName = tag;
-      return el;
-    },
-    createTextNode(t) {
-      const n = makeNode(3);
-      n.nodeValue = String(t);
-      return n;
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true,
+  attributes: "noop", selectors: "null",
+  textContent: "readonly", currentScript: null,
+});
 
 // ── Promise/microtask helpers ───────────────────────────────────────────────
 function makeDeferred() {
@@ -256,7 +214,7 @@ function setup(opts = {}) {
       debug: () => {},
     },
   };
-  vm.runInNewContext(SRC, sandbox);
+  loadConsole(sandbox);
   const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
   return {

--- a/tests/js/trap-burst.test.mjs
+++ b/tests/js/trap-burst.test.mjs
@@ -16,79 +16,19 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import vm from "node:vm";
+import { createDOM, loadConsole } from "./harness.mjs";
 
 // ── DOM shim (extends playground.test.mjs's with insertBefore + firstChild) ──
-function makeNode(nodeType) {
-  return {
-    nodeType,
-    childNodes: [],
-    style: {},
-    className: "",
-    title: "",
-    appendChild(child) {
-      this.childNodes.push(child);
-      return child;
-    },
-    insertBefore(node, ref) {
-      const i = ref ? this.childNodes.indexOf(ref) : -1;
-      if (i < 0) this.childNodes.push(node);
-      else this.childNodes.splice(i, 0, node);
-      return node;
-    },
-    get firstChild() {
-      return this.childNodes[0] || null;
-    },
-    addEventListener(_type, _fn) {},
-    setAttribute(_k, _v) {},
-    get textContent() {
-      if (this.nodeType === 3) return this.nodeValue;
-      return this.childNodes.map((c) => c.textContent).join("");
-    },
-    set textContent(v) {
-      this.childNodes = [];
-      const s = v == null ? "" : String(v);
-      if (s !== "") {
-        const n = makeNode(3);
-        n.nodeValue = s;
-        this.childNodes.push(n);
-      }
-    },
-    set innerHTML(_v) {
-      this.childNodes = [];
-    },
-  };
-}
+const { makeDocument } = createDOM({
+  title: true,
+  attributes: "noop", events: "noop",
+  textContent: "clear", innerHTML: "clear", svg: "alias",
+  tree: { insert: true, first: true },
+});
 
-const document = {
-  createDocumentFragment() {
-    return makeNode(11);
-  },
-  createElement(tag) {
-    const el = makeNode(1);
-    el.tagName = tag.toUpperCase();
-    el.localName = tag;
-    return el;
-  },
-  createElementNS(_ns, tag) {
-    return this.createElement(tag);
-  },
-  createTextNode(t) {
-    const node = makeNode(3);
-    node.nodeValue = String(t);
-    return node;
-  },
-};
+const document = makeDocument();
 
 // ── Load the real petasos.js under a sandbox ──────────────────────────────
-const here = dirname(fileURLToPath(import.meta.url));
-const src = readFileSync(
-  join(here, "..", "..", "petasos", "console", "static", "petasos.js"),
-  "utf8"
-);
 // setTimeout fires SHORT timers (the inter-shot delay) immediately and ignores
 // LONG ones (the 8s per-shot hang guard) so a resolved postScan wins the race;
 // the timeout test injects a short shotTimeoutMs to exercise the guard directly.
@@ -98,7 +38,7 @@ const sandbox = {
   setTimeout: (fn, ms) => { if ((ms || 0) <= 1000) fn(); },
   clearTimeout: () => {},
 };
-vm.runInNewContext(src, sandbox);
+loadConsole(sandbox);
 const Pet = sandbox.window.__PETASOS_CONSOLE__;
 
 // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
PET-182 consolidates the 24 console test loaders behind `tests/js/harness.mjs`, so PET-183 can change the shipped script layout through one loader. The shared DOM factory preserves each suite's opt-in capabilities, including PET-103 D10's throwing setter and aggregating getter, getter-only accessors, attribute semantics, and caller-owned lifecycle fixtures. Shipped console code and dependencies are unchanged.

JavaScript lines in `tests/js/`: **7,858 to 6,987**, a net reduction of **871** including the shared helper. Including the new Markdown audit, total directory lines are **7,858 to 7,057**.

Validation:
- All 313 existing tests pass across 24 suites. Existing test bodies and later fixtures compare unchanged, apart from routing the existing source-copy assertion through the shared source read.
- Before/after DOM probes match all 24 factories: property/API presence, text assignment, attributes, events, insertion/removal, HTML clearing and SVG metadata. This is a bounded probe, not browser conformance testing.
- Four source mutations fail the same existing tests before and after: direct scanner-error text assignment, escaping storage set errors, escaping storage remove errors, and escaping host subscriber errors. Scanner mutation specifically reports the PET-103 D10 guard.
- One source read and one VM evaluation site; whitespace check passes.

The original brief's four-file throwing-DOM count included fixture exceptions. Scanner-health owns the explicit throwing setter; token storage errors, subscriber failure and the SSE invalid-outcome guard remain in their original suites. Getter-only text in armed-sync, richtext and sse-reconnect also stays strict.

Audit (A = duplicate within a family; B = deliberately stricter; C = distinct surface/lifecycle):

| Suite (`.test.mjs`) | Class | DOM and retained differences | Runtime fixtures retained in suite |
| --- | --- | --- | --- |
| arm-scope-view | A/C | Scope family: raw `attrs`, empty selectors, no text accessor/localName | Real timers and stream APIs; parked fetch |
| armed-sync | B | Styled nodes; getter-only textContent | Bare sandbox |
| cold-start-row | A | Row family: dataset, stored text, no-op attributes/events | Bare sandbox |
| config-sections | A | Form family: recorded attributes/events, replacement text, SVG namespace | Bare sandbox |
| console-token | C | Clearing text/HTML, insertion, form values, `attrs`, empty selectors | Fresh realm/document, storage failure fixtures, fetch, recording timers, abort/decoder overrides |
| disarm-bypass-counter | A | Minimal family: no text accessor/localName, no-op attributes/events | Bare sandbox |
| enforcement-history | A | Row family | Bare sandbox |
| enforcement-provenance | A | Minimal family | Bare sandbox |
| hermes-diegetic-profile | C | Form family plus parent links, insertion/removal, selectors, head, HTML getter/clear | Fresh realm/document, host history/events, SDK, fetch, inert timers, throwing subscriber |
| hermes-profile-selector | C | Form family plus parent links, removal and class-only selector | Suite-local API/host fixtures |
| integrity-health | A | Minimal family | Bare sandbox |
| playground | C | Clearing text/HTML; SVG aliases createElement; no-op attributes/events | Suite-local scan fixtures |
| preset-dial | A | Form family | Bare sandbox |
| profile-picker | C | Form family plus removal without parent links | Bare sandbox |
| profile-scoped-reads | A/C | Scope family | Real timers and stream APIs; parked fetch, per-case state reset |
| richtext | B | Getter-only text; deliberately no style, className or extra DOM APIs | Bare sandbox |
| scan-history-count | A | Minimal family | Bare sandbox |
| scan-history-paging | A/C | Minimal family | Per-case fetch overrides and deferred requests |
| scanner-health | B | Styled nodes; PET-103 D10 throwing setter **and** aggregating getter | Existing guard-of-the-guard test |
| selfmod-row | A | Row family | Bare sandbox |
| selfmod-tile-filter | A/C | Row family | Source-copy assertion now uses the shared source read |
| skeleton | A | Form family | Bare sandbox |
| sse-reconnect | B/C | Getter-only text, no-op attributes, null querySelector, currentScript:null | Fresh realm/document, controlled streams/timers/randomness, capturing console, invalid-outcome guard |
| trap-burst | C | Playground family plus insertion/firstChild | Immediate short timers; long timers suppressed |

Full fidelity notes: [harness audit](tests/js/harness-audit.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Standardized 24 JavaScript test suites on a shared, configurable browser-like test harness.
  - Preserved existing test behavior and assertions while simplifying test setup.
  - Continued supporting required DOM interactions, sandbox loading, and runtime fixtures.

- **Documentation**
  - Added an audit document describing harness coverage, supported DOM behavior, fixtures, and fidelity boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->