### PR TITLE
fix(pet-195): make scoped cursors surrogate-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ All notable changes to Petasos are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Profile-scoped history cursors tolerate surrogate-bearing stored IDs
+  (PET-195, PET-184 finding PETRT-007).** The supported Hermes and playground
+  writers mint their own UUID-backed IDs, but direct internal-writer use and
+  hand-authored, legacy, or foreign-profile JSONL can contain an unpaired
+  Unicode surrogate. Such a row no longer raises while the console mints its
+  `next_before` cursor. A fallback ASCII encoding preserves the exact ID and
+  contiguous pagination; ordinary cursor tokens remain byte-identical, and
+  malformed fallback tokens retain the existing fail-safe empty-page behavior.
+
 - **Clipped tool-result boundary limits are now explicit (PET-193, PET-184
   finding PETRT-005).** Renamed the reference plugin's private `_SEAM_OVERLAP`
   constant to `_RESULT_SCAN_HEAD_BIAS` to describe its budget role. The hardening

--- a/petasos/console/server.py
+++ b/petasos/console/server.py
@@ -10,6 +10,8 @@ TYPE_CHECKING-only names in module-level signatures are quoted instead.
 """
 
 import asyncio
+import base64
+import binascii
 import contextlib
 import hashlib
 import hmac
@@ -398,17 +400,42 @@ def read_spool_tail(path: str) -> tuple[list[dict[str, Any]], bool]:
     return events, truncated
 
 
+_CURSOR_SURROGATE_PREFIX = "!u!"
+
+
 def _cursor_esc(s: str) -> str:
-    """Escape one cursor segment (PET-166 D18). ``quote`` alone does not do it: ``~`` is in
-    ``_ALWAYS_SAFE`` (RFC 3986 unreserved) and ``safe=`` only adds to that set, so the
-    structural separator would survive unescaped. The ``.replace`` is unambiguous because
-    ``quote(safe="")`` has already turned every literal ``%`` into ``%25``."""
-    return quote(s, safe="").replace("~", "%7E")
+    """Escape one cursor segment (PET-166 D18; PET-195).
+
+    ``quote`` alone does not escape ``~`` because RFC 3986 declares it unreserved, so the
+    structural separator needs the explicit replacement. It also rejects unpaired Unicode
+    surrogates. Those are valid in parsed JSON strings, so encode that narrow case as
+    URL-safe base64 over surrogate-preserving UTF-8. The literal ``!`` sentinel cannot
+    collide with the ordinary path: ``quote(safe="")`` emits it as ``%21``.
+    """
+    try:
+        return quote(s, safe="").replace("~", "%7E")
+    except UnicodeEncodeError:
+        raw = s.encode("utf-8", errors="surrogatepass")
+        payload = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+        return _CURSOR_SURROGATE_PREFIX + payload
 
 
-def _cursor_unesc(s: str) -> str:
-    """Reverse ``_cursor_esc`` in a single pass."""
-    return unquote(s)
+def _cursor_unesc(s: str) -> str | None:
+    """Reverse ``_cursor_esc`` in a single pass; return ``None`` when malformed."""
+    if not s.startswith(_CURSOR_SURROGATE_PREFIX):
+        return unquote(s)
+    payload = s[len(_CURSOR_SURROGATE_PREFIX) :]
+    if not payload:
+        return None
+    try:
+        padded = payload + "=" * (-len(payload) % 4)
+        raw = base64.b64decode(padded, altchars=b"-_", validate=True)
+        decoded = raw.decode("utf-8", errors="surrogatepass")
+    except (binascii.Error, UnicodeError, ValueError):
+        return None
+    # Accept only the one spelling the mint produces. This rejects padding, alternate
+    # encodings, and sentinel-prefixed scalar-only text that belongs on the ordinary path.
+    return decoded if _cursor_esc(decoded) == s else None
 
 
 def _history_cursor_token(row: dict[str, Any], scope_name: str | None = None) -> str | None:
@@ -451,8 +478,8 @@ def _parse_history_cursor(
       ``before`` by the routes — never a plausible, non-contiguous page under a scope the
       token was not minted for.
 
-    The three ways a token is rejected: the scope check above, the arity check (exactly one
-    ``~`` split into two parts), and the ``float()`` try.
+    A token is rejected by the scope check above, the arity check (exactly one ``~`` split
+    into two parts), the ``float()`` conversion, or malformed PET-195 fallback encoding.
     """
     if before is None:
         return None, "ok"
@@ -461,6 +488,8 @@ def _parse_history_cursor(
     if "|" in before:
         head, body = before.split("|", 1)
         prefix = _cursor_unesc(head)
+        if prefix is None:
+            return None, "malformed"
     if (prefix is None) != (scope_name is None) or (prefix is not None and prefix != scope_name):
         return None, "scope_mismatch"
     parts = body.rsplit("~", 1)
@@ -471,6 +500,8 @@ def _parse_history_cursor(
     except (ValueError, TypeError):
         return None, "malformed"
     sid = _cursor_unesc(parts[1]) if prefix is not None else parts[1]
+    if sid is None:
+        return None, "malformed"
     return (ts, sid), "ok"
 
 

--- a/tests/test_console_profile_scoped_reads.py
+++ b/tests/test_console_profile_scoped_reads.py
@@ -546,7 +546,7 @@ async def test_equipped_named_cursor_round_trips(env: _Env) -> None:
     assert cursor is not None and cursor[0] == 6.0
 
 
-@pytest.mark.parametrize("sid", ["e-a|b", "e-a~b", "e-a~b|c", "e-a%b"])
+@pytest.mark.parametrize("sid", ["e-a|b", "e-a~b", "e-a~b|c", "e-a%b", "!u!literal"])
 def test_delimiter_bearing_scan_id_round_trips(sid: str) -> None:
     tok = server_mod._history_cursor_token({"timestamp": 1.5, "scan_id": sid}, "beta")
     assert tok is not None
@@ -562,6 +562,56 @@ def test_cursor_scope_name_is_escaped() -> None:
     tok = server_mod._history_cursor_token({"timestamp": 1.0, "scan_id": "s-a"}, "we|ird~name")
     assert tok is not None and tok.count("|") == 1 and tok.count("~") == 1
     assert server_mod._parse_history_cursor(tok, "we|ird~name")[1] == "ok"
+
+
+@pytest.mark.parametrize("sid", ["\ud800", "\udfff", "a\ud800b", "\ud83d\ude00"])
+def test_surrogate_bearing_scan_id_round_trips_as_ascii(sid: str) -> None:
+    tok = server_mod._history_cursor_token({"timestamp": 1.5, "scan_id": sid}, "beta")
+    assert tok is not None and tok.isascii()
+    assert tok.count("|") == 1
+    assert tok.count("~") == 1
+    assert server_mod._parse_history_cursor(tok, "beta") == ((1.5, sid), "ok")
+
+
+def test_surrogate_bearing_scope_name_round_trips_as_ascii() -> None:
+    scope = "be\udfffta"
+    tok = server_mod._history_cursor_token({"timestamp": 1.0, "scan_id": "s-a"}, scope)
+    assert tok is not None and tok.isascii()
+    assert tok.count("|") == 1
+    assert tok.count("~") == 1
+    assert server_mod._parse_history_cursor(tok, scope) == ((1.0, "s-a"), "ok")
+
+
+@pytest.mark.parametrize(
+    "tok",
+    [
+        "beta|1.0~!u!not*base64",
+        "!u!not*base64|1.0~s-a",
+        "beta|1.0~!u!_w",
+    ],
+)
+def test_malformed_surrogate_fallback_is_fail_safe(tok: str) -> None:
+    assert server_mod._parse_history_cursor(tok, "beta") == (None, "malformed")
+
+
+async def test_surrogate_bearing_stored_row_keeps_foreign_pagination_contiguous(
+    env: _Env,
+) -> None:
+    surrogate_id = "s-newest-\ud800"
+    env.beta.seed(
+        sink=[
+            _sink_row("s-older", 1.0),
+            _sink_row(surrogate_id, 2.0),
+        ]
+    )
+    h = _make_handlers()
+
+    first = await h.get_scan_history(limit=1, profile="beta")
+    assert [r["scan_id"] for r in first["entries"]] == [surrogate_id]
+    assert first["next_before"] is not None and first["next_before"].isascii()
+
+    second = await h.get_scan_history(limit=1, before=first["next_before"], profile="beta")
+    assert [r["scan_id"] for r in second["entries"]] == ["s-older"]
 
 
 # ── Armed ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- keep existing percent-encoded scoped cursor segments byte-identical for ordinary text
- encode surrogate-bearing segments as canonical ASCII URL-safe base64 over surrogate-preserving UTF-8
- reject malformed fallback segments through the existing fail-safe malformed-cursor path
- prove a stored surrogate ID can page contiguously to older history

## Reachability

Supported Hermes and playground paths mint UUID-backed scan IDs and do not expose caller-selected IDs. Direct internal-writer use and hand-authored, legacy, or foreign-profile JSONL can still carry the stored value, so this closes a robustness/defense-in-depth denial rather than claiming a demonstrated remote primitive.

## Verification

- `2794 passed, 69 skipped, 1 xfailed` — full Python suite
- `333 passed, 0 failed` — JavaScript suite
- `197 passed` — adjacent history/scope/spool/integrity suites
- Ruff lint and format clean
- strict mypy clean on both changed Python files
- exhaustive U+D800..U+DFFF sweep: 2,048 exact ASCII round-trips
- `git diff --check` clean

Full-tree mypy on the host retains four unchanged `tests/test_console_sse_route.py` errors from newer Starlette types; hosted CI's Python 3.11 dev lane is the authoritative full-tree check.

Plane: PET-195 · PET-184 finding PETRT-007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Profile-scoped history pagination now supports stored IDs and scope names containing unusual Unicode characters, including unpaired surrogates.
  - Cursor tokens remain ASCII-safe while preserving exact IDs and pagination order.
  - Malformed or invalid cursor tokens are rejected consistently.
  - Existing behavior for standard tokens remains unchanged.

- **Tests**
  - Expanded coverage for special characters, delimiter-containing IDs, malformed tokens, and cross-profile pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->